### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/joshrotenberg/forza/compare/v0.1.0...v0.2.0) - 2026-03-21
+
+### Added
+
+- *(mcp)* embed MCP server with runner, status, and config tool groups closes #52 ([#101](https://github.com/joshrotenberg/forza/pull/101))
+- REST API ([#100](https://github.com/joshrotenberg/forza/pull/100))
+- security hardening — prompt injection, authz, rate limiting ([#72](https://github.com/joshrotenberg/forza/pull/72))
+- pr-fix workflow and route config updates ([#97](https://github.com/joshrotenberg/forza/pull/97))
+- reactive workflow mode for PR maintenance ([#92](https://github.com/joshrotenberg/forza/pull/92))
+- configurable stage prompt templates ([#61](https://github.com/joshrotenberg/forza/pull/61))
+- *(isolation)* auto-detect repo dir and clone if needed closes #69 ([#90](https://github.com/joshrotenberg/forza/pull/90))
+- *(deps)* validate gh, git, and agent CLI on startup closes #70 ([#89](https://github.com/joshrotenberg/forza/pull/89))
+- PR workflows — label-driven PR processing ([#88](https://github.com/joshrotenberg/forza/pull/88))
+- skill injection and MCP server access for stages ([#87](https://github.com/joshrotenberg/forza/pull/87))
+- *(notifications)* desktop, slack, and webhook alerts on run completion closes #17 ([#73](https://github.com/joshrotenberg/forza/pull/73))
+- *(config)* add multi-repo support with per-repo routes closes #19 ([#71](https://github.com/joshrotenberg/forza/pull/71))
+- *(orchestrator)* rich PR descriptions from run data and breadcrumbs closes #64 ([#67](https://github.com/joshrotenberg/forza/pull/67))
+- schedule windows for routes ([#66](https://github.com/joshrotenberg/forza/pull/66))
+- *(orchestrator)* initialize active counts from in-progress labels and add concurrency tracing closes #21 ([#65](https://github.com/joshrotenberg/forza/pull/65))
+- *(github)* add automation-optimized issue templates closes #22 ([#63](https://github.com/joshrotenberg/forza/pull/63))
+- *(config)* add tests for custom workflow template resolution closes #23 ([#62](https://github.com/joshrotenberg/forza/pull/62))
+- *(workflow)* add auto-merge stage gated by global.auto_merge closes #55 ([#58](https://github.com/joshrotenberg/forza/pull/58))
+- *(orchestrator)* concurrent batch processing via JoinSet closes #56 ([#57](https://github.com/joshrotenberg/forza/pull/57))
+- tool call tracing in executor via streaming ([#54](https://github.com/joshrotenberg/forza/pull/54))
+- per-route agent config (model, skills, MCP) ([#51](https://github.com/joshrotenberg/forza/pull/51))
+- per-stage hooks (pre/post/finally) ([#48](https://github.com/joshrotenberg/forza/pull/48))
+- *(dry-run)* show estimated cost from run history closes #16 ([#47](https://github.com/joshrotenberg/forza/pull/47))
+- *(init)* add forza init command — create labels and starter config closes #35 ([#46](https://github.com/joshrotenberg/forza/pull/46))
+- fix command — re-run failed stages ([#13](https://github.com/joshrotenberg/forza/pull/13)) ([#45](https://github.com/joshrotenberg/forza/pull/45))
+- agentless stages and issue comments in prompts (#26, #28) ([#44](https://github.com/joshrotenberg/forza/pull/44))
+
+### Other
+
+- add badges to README ([#99](https://github.com/joshrotenberg/forza/pull/99))
+- forza tag line ([#98](https://github.com/joshrotenberg/forza/pull/98))
+- *(config)* add research and chore routes to forza.toml closes #68 ([#91](https://github.com/joshrotenberg/forza/pull/91))
+- cargo dist config with homebrew, shell, powershell installers ([#43](https://github.com/joshrotenberg/forza/pull/43))
+- cargo dist setup for releases ([#41](https://github.com/joshrotenberg/forza/pull/41))
+- release v0.1.0 ([#40](https://github.com/joshrotenberg/forza/pull/40))
+
 ### Added
 
 - *(dry-run)* show estimated cost range from historical run data in `--dry-run` output closes #16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "forza"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forza"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `forza`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `forza` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GlobalConfig.auto_merge in /tmp/.tmpD6YNcM/forza/src/config.rs:122
  field GlobalConfig.notifications in /tmp/.tmpD6YNcM/forza/src/config.rs:125
  field IssueCandidate.author in /tmp/.tmpD6YNcM/forza/src/github.rs:27
  field IssueCandidate.comments in /tmp/.tmpD6YNcM/forza/src/github.rs:30
  field SecurityConfig.require_label in /tmp/.tmpD6YNcM/forza/src/config.rs:157
  field RunnerConfig.repos in /tmp/.tmpD6YNcM/forza/src/config.rs:36
  field RunnerConfig.repos in /tmp/.tmpD6YNcM/forza/src/config.rs:36
  field Route.schedule in /tmp/.tmpD6YNcM/forza/src/config.rs:255
  field PlannedStage.agentless in /tmp/.tmpD6YNcM/forza/src/planner.rs:46
  field PlannedStage.command in /tmp/.tmpD6YNcM/forza/src/planner.rs:48
  field PlannedStage.model in /tmp/.tmpD6YNcM/forza/src/planner.rs:50
  field PlannedStage.skills in /tmp/.tmpD6YNcM/forza/src/planner.rs:52
  field PlannedStage.mcp_config in /tmp/.tmpD6YNcM/forza/src/planner.rs:54
  field StageHooks.finally in /tmp/.tmpD6YNcM/forza/src/config.rs:281
  field RepoPolicy.skills in /tmp/.tmpD6YNcM/forza/src/policy.rs:73
  field RepoPolicy.mcp_config in /tmp/.tmpD6YNcM/forza/src/policy.rs:76
  field Stage.agentless in /tmp/.tmpD6YNcM/forza/src/workflow.rs:78
  field Stage.command in /tmp/.tmpD6YNcM/forza/src/workflow.rs:81
  field Stage.model in /tmp/.tmpD6YNcM/forza/src/workflow.rs:84
  field Stage.skills in /tmp/.tmpD6YNcM/forza/src/workflow.rs:87
  field Stage.mcp_config in /tmp/.tmpD6YNcM/forza/src/workflow.rs:90
  field RunRecord.subject_kind in /tmp/.tmpD6YNcM/forza/src/state.rs:86
  field WorkflowTemplate.mode in /tmp/.tmpD6YNcM/forza/src/workflow.rs:23

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:Dependency in /tmp/.tmpD6YNcM/forza/src/error.rs:29
  variant Error:Authorization in /tmp/.tmpD6YNcM/forza/src/error.rs:35

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  forza::orchestrator::process_issue_with_config now takes 6 parameters instead of 4, in /tmp/.tmpD6YNcM/forza/src/orchestrator.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/joshrotenberg/forza/compare/v0.1.0...v0.2.0) - 2026-03-21

### Added

- *(mcp)* embed MCP server with runner, status, and config tool groups closes #52 ([#101](https://github.com/joshrotenberg/forza/pull/101))
- REST API ([#100](https://github.com/joshrotenberg/forza/pull/100))
- security hardening — prompt injection, authz, rate limiting ([#72](https://github.com/joshrotenberg/forza/pull/72))
- pr-fix workflow and route config updates ([#97](https://github.com/joshrotenberg/forza/pull/97))
- reactive workflow mode for PR maintenance ([#92](https://github.com/joshrotenberg/forza/pull/92))
- configurable stage prompt templates ([#61](https://github.com/joshrotenberg/forza/pull/61))
- *(isolation)* auto-detect repo dir and clone if needed closes #69 ([#90](https://github.com/joshrotenberg/forza/pull/90))
- *(deps)* validate gh, git, and agent CLI on startup closes #70 ([#89](https://github.com/joshrotenberg/forza/pull/89))
- PR workflows — label-driven PR processing ([#88](https://github.com/joshrotenberg/forza/pull/88))
- skill injection and MCP server access for stages ([#87](https://github.com/joshrotenberg/forza/pull/87))
- *(notifications)* desktop, slack, and webhook alerts on run completion closes #17 ([#73](https://github.com/joshrotenberg/forza/pull/73))
- *(config)* add multi-repo support with per-repo routes closes #19 ([#71](https://github.com/joshrotenberg/forza/pull/71))
- *(orchestrator)* rich PR descriptions from run data and breadcrumbs closes #64 ([#67](https://github.com/joshrotenberg/forza/pull/67))
- schedule windows for routes ([#66](https://github.com/joshrotenberg/forza/pull/66))
- *(orchestrator)* initialize active counts from in-progress labels and add concurrency tracing closes #21 ([#65](https://github.com/joshrotenberg/forza/pull/65))
- *(github)* add automation-optimized issue templates closes #22 ([#63](https://github.com/joshrotenberg/forza/pull/63))
- *(config)* add tests for custom workflow template resolution closes #23 ([#62](https://github.com/joshrotenberg/forza/pull/62))
- *(workflow)* add auto-merge stage gated by global.auto_merge closes #55 ([#58](https://github.com/joshrotenberg/forza/pull/58))
- *(orchestrator)* concurrent batch processing via JoinSet closes #56 ([#57](https://github.com/joshrotenberg/forza/pull/57))
- tool call tracing in executor via streaming ([#54](https://github.com/joshrotenberg/forza/pull/54))
- per-route agent config (model, skills, MCP) ([#51](https://github.com/joshrotenberg/forza/pull/51))
- per-stage hooks (pre/post/finally) ([#48](https://github.com/joshrotenberg/forza/pull/48))
- *(dry-run)* show estimated cost from run history closes #16 ([#47](https://github.com/joshrotenberg/forza/pull/47))
- *(init)* add forza init command — create labels and starter config closes #35 ([#46](https://github.com/joshrotenberg/forza/pull/46))
- fix command — re-run failed stages ([#13](https://github.com/joshrotenberg/forza/pull/13)) ([#45](https://github.com/joshrotenberg/forza/pull/45))
- agentless stages and issue comments in prompts (#26, #28) ([#44](https://github.com/joshrotenberg/forza/pull/44))

### Other

- add badges to README ([#99](https://github.com/joshrotenberg/forza/pull/99))
- forza tag line ([#98](https://github.com/joshrotenberg/forza/pull/98))
- *(config)* add research and chore routes to forza.toml closes #68 ([#91](https://github.com/joshrotenberg/forza/pull/91))
- cargo dist config with homebrew, shell, powershell installers ([#43](https://github.com/joshrotenberg/forza/pull/43))
- cargo dist setup for releases ([#41](https://github.com/joshrotenberg/forza/pull/41))
- release v0.1.0 ([#40](https://github.com/joshrotenberg/forza/pull/40))

### Added

- *(dry-run)* show estimated cost range from historical run data in `--dry-run` output closes #16
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).