### PR TITLE
chore: cargo dist with homebrew and installers

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,6 +8,17 @@ cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = []
+installers = ["shell", "powershell", "homebrew"]
+# Target platforms to build apps for (Rust target-triple syntax)
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+# Path that installers should place binaries in
+install-path = "CARGO_HOME"
+# Whether to install an updater program
+install-updater = true
+
+# Homebrew tap
+[dist.homebrew]
+tap = "joshrotenberg/homebrew-brew"
+publish = true
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]


### PR DESCRIPTION
Release workflow with  binary builds, shell/powershell installers, homebrew formula, and auto-updater.