### PR TITLE
feat: route conditions and PR health monitoring

### DIFF
--- a/forza.toml
+++ b/forza.toml
@@ -93,3 +93,18 @@ type = "pr"
 label = "forza:rebase"
 workflow = "pr-rebase"
 concurrency = 2
+
+# ── Condition routes (monitors) ──────────────────────────────────────
+# These routes watch forza-owned PRs and automatically trigger fixes
+# when problems are detected. No manual labeling needed.
+
+# Auto-fix PRs with CI failures or merge conflicts.
+# Watches only forza-owned PRs (branches starting with "automation/").
+# After 3 failed attempts, applies forza:needs-human instead.
+[repos."joshrotenberg/forza".routes.auto-fix]
+type = "pr"
+condition = "ci_failing_or_conflicts"
+workflow = "pr-fix"
+scope = "forza_owned"
+max_retries = 3
+concurrency = 2

--- a/src/api.rs
+++ b/src/api.rs
@@ -232,10 +232,11 @@ async fn trigger_issue(
                 ))
             })?;
 
+        let wf_name = route.workflow.as_deref().unwrap_or("");
         let template = state
             .config
-            .resolve_workflow(&route.workflow)
-            .ok_or_else(|| ApiError::Internal(format!("unknown workflow: {}", route.workflow)))?;
+            .resolve_workflow(wf_name)
+            .ok_or_else(|| ApiError::Internal(format!("unknown workflow: {wf_name}")))?;
 
         let branch = state.config.branch_for_issue(&issue);
         let run_id = crate::state::generate_run_id();
@@ -302,10 +303,11 @@ async fn trigger_pr(
                 ))
             })?;
 
+        let wf_name = route.workflow.as_deref().unwrap_or("");
         let template = state
             .config
-            .resolve_workflow(&route.workflow)
-            .ok_or_else(|| ApiError::Internal(format!("unknown workflow: {}", route.workflow)))?;
+            .resolve_workflow(wf_name)
+            .ok_or_else(|| ApiError::Internal(format!("unknown workflow: {wf_name}")))?;
 
         let branch = RunnerConfig::branch_for_pr(&pr);
         let run_id = crate::state::generate_run_id();

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,7 +217,54 @@ impl ScheduleWindow {
     }
 }
 
-/// A named route — maps type+label to a workflow.
+/// A condition that triggers a route based on PR state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RouteCondition {
+    /// CI checks are failing on the PR.
+    CiFailing,
+    /// The PR has merge conflicts.
+    HasConflicts,
+    /// CI is failing or the PR has conflicts (or both).
+    CiFailingOrConflicts,
+    /// The PR is approved and CI is green.
+    ApprovedAndGreen,
+}
+
+impl RouteCondition {
+    /// Evaluate whether this condition holds for the given PR.
+    pub fn matches(&self, pr: &crate::github::PrCandidate) -> bool {
+        let ci_failing = pr.checks_passing == Some(false);
+        let has_conflicts = pr.mergeable.as_deref() == Some("CONFLICTING");
+        let approved = pr.review_decision.as_deref() == Some("APPROVED");
+        let ci_green = pr.checks_passing == Some(true);
+
+        match self {
+            RouteCondition::CiFailing => ci_failing,
+            RouteCondition::HasConflicts => has_conflicts,
+            RouteCondition::CiFailingOrConflicts => ci_failing || has_conflicts,
+            RouteCondition::ApprovedAndGreen => approved && ci_green && !has_conflicts,
+        }
+    }
+}
+
+/// Which PRs are in scope for condition evaluation.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConditionScope {
+    /// Only PRs on branches created by forza (matching the branch pattern prefix).
+    #[default]
+    ForzaOwned,
+    /// All open PRs in the repo.
+    All,
+}
+
+/// A named route — maps type+trigger to an action.
+///
+/// A route must have at least one trigger (`label` or `condition`) and
+/// at least one action (`workflow`). Label-triggered routes fire when a
+/// subject has the specified label. Condition-triggered routes fire when
+/// PR state matches (e.g., CI failing, has conflicts).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Route {
     /// "issue" or "pr".
@@ -225,10 +272,16 @@ pub struct Route {
     pub route_type: String,
 
     /// GitHub label that triggers this route.
-    pub label: String,
+    #[serde(default)]
+    pub label: Option<String>,
+
+    /// Condition that triggers this route when evaluated against a PR.
+    #[serde(default)]
+    pub condition: Option<RouteCondition>,
 
     /// Workflow template name to use.
-    pub workflow: String,
+    #[serde(default)]
+    pub workflow: Option<String>,
 
     /// Maximum concurrent runs for this route.
     #[serde(default = "default_route_concurrency")]
@@ -253,6 +306,31 @@ pub struct Route {
     /// Optional schedule window. When set, issues for this route are only
     /// processed during the active window. `None` means always active.
     pub schedule: Option<ScheduleWindow>,
+
+    /// Scope of PRs to evaluate conditions against.
+    #[serde(default)]
+    pub scope: ConditionScope,
+
+    /// Maximum retry attempts for condition-triggered routes.
+    /// When exceeded, `forza:needs-human` label is applied instead.
+    pub max_retries: Option<usize>,
+}
+
+impl Route {
+    /// Validate that a route has at least one trigger and one action.
+    pub fn validate(&self, name: &str) -> Result<()> {
+        if self.label.is_none() && self.condition.is_none() {
+            return Err(Error::Policy(format!(
+                "route '{name}' must have a label or a condition"
+            )));
+        }
+        if self.workflow.is_none() {
+            return Err(Error::Policy(format!(
+                "route '{name}' must have a workflow"
+            )));
+        }
+        Ok(())
+    }
 }
 
 /// Agent-specific configuration.
@@ -329,7 +407,17 @@ impl RunnerConfig {
     /// Load config from a TOML file.
     pub fn from_file(path: &Path) -> Result<Self> {
         let content = std::fs::read_to_string(path)?;
-        toml::from_str(&content).map_err(|e| Error::Policy(e.to_string()))
+        let config: Self = toml::from_str(&content).map_err(|e| Error::Policy(e.to_string()))?;
+        // Validate routes.
+        for (name, route) in &config.routes {
+            route.validate(name)?;
+        }
+        for entry in config.repos.values() {
+            for (name, route) in &entry.routes {
+                route.validate(name)?;
+            }
+        }
+        Ok(config)
     }
 
     /// Iterate all repos yielding `(repo_slug, repo_dir, routes)` for each.
@@ -356,7 +444,12 @@ impl RunnerConfig {
         issue: &IssueCandidate,
     ) -> Option<(&'a str, &'a Route)> {
         for (name, route) in routes {
-            if route.route_type == "issue" && issue.labels.iter().any(|l| l == &route.label) {
+            if route.route_type == "issue"
+                && route
+                    .label
+                    .as_ref()
+                    .is_some_and(|rl| issue.labels.iter().any(|l| l == rl))
+            {
                 return Some((name.as_str(), route));
             }
         }
@@ -369,7 +462,12 @@ impl RunnerConfig {
         pr: &PrCandidate,
     ) -> Option<(&'a str, &'a Route)> {
         for (name, route) in routes {
-            if route.route_type == "pr" && pr.labels.iter().any(|l| l == &route.label) {
+            if route.route_type == "pr"
+                && route
+                    .label
+                    .as_ref()
+                    .is_some_and(|rl| pr.labels.iter().any(|l| l == rl))
+            {
                 return Some((name.as_str(), route));
             }
         }
@@ -547,7 +645,7 @@ poll_interval = 300
         let config: RunnerConfig = toml::from_str(content).unwrap();
         assert_eq!(config.global.repo.as_deref(), Some("owner/repo"));
         assert_eq!(config.routes.len(), 2);
-        assert_eq!(config.routes["bugfix"].workflow, "bug");
+        assert_eq!(config.routes["bugfix"].workflow.as_deref(), Some("bug"));
         assert_eq!(config.routes["features"].concurrency, 2);
     }
 
@@ -583,7 +681,7 @@ workflow = "bug"
 
         let (name, route) = config.match_route(&issue).unwrap();
         assert_eq!(name, "bugfix");
-        assert_eq!(route.workflow, "bug");
+        assert_eq!(route.workflow.as_deref(), Some("bug"));
     }
 
     #[test]
@@ -1048,8 +1146,9 @@ workflow = "bug"
             "bugfix".to_string(),
             Route {
                 route_type: "issue".to_string(),
-                label: "bug".to_string(),
-                workflow: "bug".to_string(),
+                label: Some("bug".to_string()),
+                workflow: Some("bug".to_string()),
+                condition: None,
                 concurrency: 1,
                 poll_interval: 60,
                 model: None,
@@ -1057,6 +1156,8 @@ workflow = "bug"
                 validation_commands: None,
                 mcp_config: None,
                 schedule: None,
+                scope: ConditionScope::default(),
+                max_retries: None,
             },
         );
 
@@ -1077,7 +1178,7 @@ workflow = "bug"
 
         let (name, route) = RunnerConfig::match_route_in(&routes, &issue).unwrap();
         assert_eq!(name, "bugfix");
-        assert_eq!(route.workflow, "bug");
+        assert_eq!(route.workflow.as_deref(), Some("bug"));
     }
 
     fn make_config_with_agent(
@@ -1193,5 +1294,103 @@ repo = "owner/repo"
         )
         .unwrap();
         assert!(config.resolve_workflow("nonexistent").is_none());
+    }
+
+    #[test]
+    fn route_validate_requires_trigger_and_action() {
+        let route = Route {
+            route_type: "pr".to_string(),
+            label: None,
+            condition: None,
+            workflow: Some("pr-fix".to_string()),
+            concurrency: 1,
+            poll_interval: 60,
+            model: None,
+            skills: None,
+            validation_commands: None,
+            mcp_config: None,
+            schedule: None,
+            scope: ConditionScope::default(),
+            max_retries: None,
+        };
+        assert!(route.validate("test").is_err()); // no trigger
+
+        let route2 = Route {
+            label: Some("bug".to_string()),
+            workflow: None,
+            ..route.clone()
+        };
+        assert!(route2.validate("test").is_err()); // no action
+
+        let route3 = Route {
+            label: Some("bug".to_string()),
+            workflow: Some("bug".to_string()),
+            ..route.clone()
+        };
+        assert!(route3.validate("test").is_ok()); // label + workflow
+
+        let route4 = Route {
+            condition: Some(RouteCondition::CiFailing),
+            workflow: Some("pr-fix".to_string()),
+            ..route
+        };
+        assert!(route4.validate("test").is_ok()); // condition + workflow
+    }
+
+    #[test]
+    fn condition_route_parses_from_toml() {
+        let config: RunnerConfig = toml::from_str(
+            r#"
+[global]
+repo = "owner/repo"
+
+[routes.auto-fix]
+type = "pr"
+condition = "ci_failing_or_conflicts"
+workflow = "pr-fix"
+scope = "forza_owned"
+max_retries = 3
+"#,
+        )
+        .unwrap();
+
+        let route = &config.routes["auto-fix"];
+        assert_eq!(route.condition, Some(RouteCondition::CiFailingOrConflicts));
+        assert_eq!(route.workflow.as_deref(), Some("pr-fix"));
+        assert_eq!(route.scope, ConditionScope::ForzaOwned);
+        assert_eq!(route.max_retries, Some(3));
+        assert!(route.label.is_none());
+    }
+
+    #[test]
+    fn condition_matches_ci_failing() {
+        let mut pr = crate::github::PrCandidate {
+            number: 1,
+            repo: "owner/repo".into(),
+            title: "test".into(),
+            body: String::new(),
+            labels: vec![],
+            state: "open".into(),
+            html_url: String::new(),
+            head_branch: "automation/1-test".into(),
+            base_branch: "main".into(),
+            is_draft: false,
+            mergeable: Some("MERGEABLE".into()),
+            review_decision: None,
+            checks_passing: Some(false),
+        };
+        assert!(RouteCondition::CiFailing.matches(&pr));
+        assert!(!RouteCondition::HasConflicts.matches(&pr));
+        assert!(RouteCondition::CiFailingOrConflicts.matches(&pr));
+
+        pr.checks_passing = Some(true);
+        pr.mergeable = Some("CONFLICTING".into());
+        assert!(!RouteCondition::CiFailing.matches(&pr));
+        assert!(RouteCondition::HasConflicts.matches(&pr));
+        assert!(RouteCondition::CiFailingOrConflicts.matches(&pr));
+
+        pr.mergeable = Some("MERGEABLE".into());
+        pr.review_decision = Some("APPROVED".into());
+        assert!(RouteCondition::ApprovedAndGreen.matches(&pr));
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -54,6 +54,9 @@ pub struct PrCandidate {
     pub is_draft: bool,
     pub mergeable: Option<String>,
     pub review_decision: Option<String>,
+    /// Whether all required CI checks are passing. `None` if unknown.
+    #[serde(default)]
+    pub checks_passing: Option<bool>,
 }
 
 // ── Raw gh CLI JSON shapes (private) ─────────────────────────────────
@@ -92,6 +95,11 @@ struct GhComment {
 }
 
 #[derive(Debug, Deserialize)]
+struct GhStatusCheck {
+    conclusion: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct GhPrFull {
     number: u64,
     title: String,
@@ -109,6 +117,8 @@ struct GhPrFull {
     base_ref_name: String,
     #[serde(rename = "isDraft")]
     is_draft: bool,
+    #[serde(rename = "statusCheckRollup", default)]
+    status_check_rollup: Vec<GhStatusCheck>,
 }
 
 // Raw shape for `gh pr list` in reactive workflows (minimal fields).
@@ -125,6 +135,29 @@ struct GhPrRaw {
     #[serde(rename = "reviewDecision", default)]
     review_decision: Option<String>,
     url: String,
+    #[serde(rename = "statusCheckRollup", default)]
+    status_check_rollup: Vec<GhStatusCheck>,
+}
+
+/// Compute whether all checks are passing from a status check rollup.
+fn checks_passing(rollup: &[GhStatusCheck]) -> Option<bool> {
+    if rollup.is_empty() {
+        return None;
+    }
+    // If any check has conclusion FAILURE, checks are failing.
+    // If all concluded checks are SUCCESS/SKIPPED/NEUTRAL, checks are passing.
+    // If some checks have no conclusion yet (in progress), result is None.
+    let mut all_concluded = true;
+    for check in rollup {
+        match check.conclusion.as_deref() {
+            Some("FAILURE") | Some("TIMED_OUT") | Some("CANCELLED") | Some("ACTION_REQUIRED") => {
+                return Some(false);
+            }
+            Some("SUCCESS") | Some("SKIPPED") | Some("NEUTRAL") => {}
+            _ => all_concluded = false,
+        }
+    }
+    if all_concluded { Some(true) } else { None }
 }
 
 // ── Public API ───────────────────────────────────────────────────────
@@ -483,19 +516,23 @@ pub async fn fetch_eligible_prs(
 
     Ok(raw
         .into_iter()
-        .map(|r| PrCandidate {
-            number: r.number,
-            repo: repo.to_string(),
-            title: r.title,
-            body: String::new(),
-            labels: r.labels.into_iter().map(|l| l.name).collect(),
-            state: r.state,
-            html_url: r.url,
-            head_branch: r.head_ref_name,
-            base_branch: String::new(),
-            is_draft: false,
-            mergeable: r.mergeable,
-            review_decision: r.review_decision,
+        .map(|r| {
+            let cp = checks_passing(&r.status_check_rollup);
+            PrCandidate {
+                number: r.number,
+                repo: repo.to_string(),
+                title: r.title,
+                body: String::new(),
+                labels: r.labels.into_iter().map(|l| l.name).collect(),
+                state: r.state,
+                html_url: r.url,
+                head_branch: r.head_ref_name,
+                base_branch: String::new(),
+                is_draft: false,
+                mergeable: r.mergeable,
+                review_decision: r.review_decision,
+                checks_passing: cp,
+            }
         })
         .collect())
 }
@@ -510,7 +547,7 @@ pub async fn fetch_pr(repo: &str, number: u64) -> Result<PrCandidate> {
             repo,
             &number.to_string(),
             "--json",
-            "number,title,body,labels,state,url,headRefName,baseRefName,isDraft,mergeable,reviewDecision",
+            "number,title,body,labels,state,url,headRefName,baseRefName,isDraft,mergeable,reviewDecision,statusCheckRollup",
         ])
         .output()
         .await
@@ -524,6 +561,7 @@ pub async fn fetch_pr(repo: &str, number: u64) -> Result<PrCandidate> {
     let raw: GhPrFull = serde_json::from_slice(&output.stdout)
         .map_err(|e| Error::GitHub(format!("failed to parse gh output: {e}")))?;
 
+    let cp = checks_passing(&raw.status_check_rollup);
     Ok(PrCandidate {
         number: raw.number,
         repo: repo.to_string(),
@@ -537,6 +575,7 @@ pub async fn fetch_pr(repo: &str, number: u64) -> Result<PrCandidate> {
         is_draft: raw.is_draft,
         mergeable: raw.mergeable,
         review_decision: raw.review_decision,
+        checks_passing: cp,
     })
 }
 
@@ -553,7 +592,7 @@ pub async fn fetch_prs_with_label(repo: &str, label: &str) -> Result<Vec<PrCandi
             "--label",
             label,
             "--json",
-            "number,title,body,labels,state,url,headRefName,baseRefName,isDraft,mergeable,reviewDecision",
+            "number,title,body,labels,state,url,headRefName,baseRefName,isDraft,mergeable,reviewDecision,statusCheckRollup",
             "--limit",
             "100",
         ])
@@ -573,21 +612,99 @@ pub async fn fetch_prs_with_label(repo: &str, label: &str) -> Result<Vec<PrCandi
 
     Ok(raw
         .into_iter()
-        .map(|r| PrCandidate {
-            number: r.number,
-            repo: repo.to_string(),
-            title: r.title,
-            body: r.body.unwrap_or_default(),
-            labels: r.labels.into_iter().map(|l| l.name).collect(),
-            state: r.state,
-            html_url: r.url,
-            head_branch: r.head_ref_name,
-            base_branch: r.base_ref_name,
-            is_draft: r.is_draft,
-            mergeable: r.mergeable,
-            review_decision: r.review_decision,
+        .map(|r| {
+            let cp = checks_passing(&r.status_check_rollup);
+            PrCandidate {
+                number: r.number,
+                repo: repo.to_string(),
+                title: r.title,
+                body: r.body.unwrap_or_default(),
+                labels: r.labels.into_iter().map(|l| l.name).collect(),
+                state: r.state,
+                html_url: r.url,
+                head_branch: r.head_ref_name,
+                base_branch: r.base_ref_name,
+                is_draft: r.is_draft,
+                mergeable: r.mergeable,
+                review_decision: r.review_decision,
+                checks_passing: cp,
+            }
         })
         .collect())
+}
+
+/// Fetch all open PRs in a repo (no label filter).
+pub async fn fetch_all_open_prs(repo: &str, limit: usize) -> Result<Vec<PrCandidate>> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "number,title,body,labels,state,url,headRefName,baseRefName,isDraft,mergeable,reviewDecision,statusCheckRollup",
+            "--limit",
+            &limit.to_string(),
+        ])
+        .output()
+        .await
+        .map_err(|e| Error::GitHub(format!("failed to run gh: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::GitHub(format!("gh pr list failed: {stderr}")));
+    }
+
+    let raw: Vec<GhPrFull> = serde_json::from_slice(&output.stdout)
+        .map_err(|e| Error::GitHub(format!("failed to parse gh output: {e}")))?;
+
+    Ok(raw
+        .into_iter()
+        .map(|r| {
+            let cp = checks_passing(&r.status_check_rollup);
+            PrCandidate {
+                number: r.number,
+                repo: repo.to_string(),
+                title: r.title,
+                body: r.body.unwrap_or_default(),
+                labels: r.labels.into_iter().map(|l| l.name).collect(),
+                state: r.state,
+                html_url: r.url,
+                head_branch: r.head_ref_name,
+                base_branch: r.base_ref_name,
+                is_draft: r.is_draft,
+                mergeable: r.mergeable,
+                review_decision: r.review_decision,
+                checks_passing: cp,
+            }
+        })
+        .collect())
+}
+
+/// Post a comment on a PR.
+pub async fn comment_on_pr(repo: &str, number: u64, body: &str) -> Result<()> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "pr",
+            "comment",
+            "--repo",
+            repo,
+            &number.to_string(),
+            "--body",
+            body,
+        ])
+        .output()
+        .await
+        .map_err(|e| Error::GitHub(format!("gh pr comment failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::GitHub(format!("gh pr comment failed: {stderr}")));
+    }
+
+    Ok(())
 }
 
 /// Add a label to a PR.

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,11 @@ async fn cmd_init(args: InitArgs) -> ExitCode {
             "d73a4a",
             "Forza encountered an error processing this issue",
         ),
+        (
+            "forza:needs-human",
+            "c2e0c6",
+            "Retry budget exhausted, needs human review",
+        ),
     ];
 
     println!("Creating forza labels in {}...", args.repo);
@@ -380,10 +385,11 @@ async fn cmd_issue(args: IssueArgs, config: &forza::RunnerConfig) -> ExitCode {
             }
         };
 
-        let template = match config.resolve_workflow(&route.workflow) {
+        let wf_name = route.workflow.as_deref().unwrap_or("");
+        let template = match config.resolve_workflow(wf_name) {
             Some(t) => t,
             None => {
-                eprintln!("unknown workflow: {}", route.workflow);
+                eprintln!("unknown workflow: {wf_name}");
                 return ExitCode::FAILURE;
             }
         };
@@ -460,10 +466,11 @@ async fn cmd_pr(args: PrArgs, config: &forza::RunnerConfig) -> ExitCode {
             }
         };
 
-        let template = match config.resolve_workflow(&route.workflow) {
+        let wf_name = route.workflow.as_deref().unwrap_or("");
+        let template = match config.resolve_workflow(wf_name) {
             Some(t) => t,
             None => {
-                eprintln!("unknown workflow: {}", route.workflow);
+                eprintln!("unknown workflow: {wf_name}");
                 return ExitCode::FAILURE;
             }
         };

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -258,12 +258,12 @@ pub fn build_router(state: AppState) -> McpRouter {
                             )))
                         }
                     };
-                let template = match config.resolve_workflow(&route.workflow) {
+                let wf_name = route.workflow.as_deref().unwrap_or("");
+                let template = match config.resolve_workflow(wf_name) {
                     Some(t) => t,
                     None => {
                         return Ok(CallToolResult::text(format!(
-                            "unknown workflow: {}",
-                            route.workflow
+                            "unknown workflow: {wf_name}"
                         )))
                     }
                 };

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -95,8 +95,13 @@ pub async fn process_issue_with_config(
 
     // 4. Resolve workflow template.
     let template = config
-        .resolve_workflow(&route.workflow)
-        .ok_or_else(|| Error::Policy(format!("unknown workflow: {}", route.workflow)))?;
+        .resolve_workflow(route.workflow.as_deref().unwrap_or(""))
+        .ok_or_else(|| {
+            Error::Policy(format!(
+                "unknown workflow: {}",
+                route.workflow.as_deref().unwrap_or("<none>")
+            ))
+        })?;
     let branch = config.branch_for_issue(&issue);
     info!(
         issue = number,
@@ -510,8 +515,13 @@ pub async fn process_pr_with_config(
 
     // 4. Resolve workflow template.
     let template = config
-        .resolve_workflow(&route.workflow)
-        .ok_or_else(|| Error::Policy(format!("unknown workflow: {}", route.workflow)))?;
+        .resolve_workflow(route.workflow.as_deref().unwrap_or(""))
+        .ok_or_else(|| {
+            Error::Policy(format!(
+                "unknown workflow: {}",
+                route.workflow.as_deref().unwrap_or("<none>")
+            ))
+        })?;
     let branch = RunnerConfig::branch_for_pr(&pr);
     info!(
         pr = number,
@@ -918,8 +928,13 @@ pub async fn process_reactive_pr(
         .get(route_name)
         .ok_or_else(|| Error::Policy(format!("route not found: {route_name}")))?;
     let template = config
-        .resolve_workflow(&route.workflow)
-        .ok_or_else(|| Error::Policy(format!("unknown workflow: {}", route.workflow)))?;
+        .resolve_workflow(route.workflow.as_deref().unwrap_or(""))
+        .ok_or_else(|| {
+            Error::Policy(format!(
+                "unknown workflow: {}",
+                route.workflow.as_deref().unwrap_or("<none>")
+            ))
+        })?;
 
     if template.mode != WorkflowMode::Reactive {
         return Err(Error::Policy(format!(
@@ -1211,14 +1226,14 @@ pub async fn process_batch_for_repo(
         })
         .collect();
 
-    // Discover PRs for all "pr"-type routes.
-    let pr_routes: Vec<(&str, &Route)> = routes
+    // Discover PRs for label-based "pr"-type routes.
+    let label_pr_routes: Vec<(&str, &Route)> = routes
         .iter()
-        .filter(|(_, r)| r.route_type == "pr")
+        .filter(|(_, r)| r.route_type == "pr" && r.label.is_some() && r.condition.is_none())
         .map(|(name, route)| (name.as_str(), route))
         .collect();
 
-    for (pr_route_name, pr_route) in &pr_routes {
+    for (pr_route_name, pr_route) in &label_pr_routes {
         if let Some(schedule) = &pr_route.schedule
             && !schedule.is_active(now)
         {
@@ -1228,7 +1243,8 @@ pub async fn process_batch_for_repo(
             );
             continue;
         }
-        match github::fetch_prs_with_label(repo, &pr_route.label).await {
+        let label = pr_route.label.as_deref().unwrap();
+        match github::fetch_prs_with_label(repo, label).await {
             Ok(prs) => {
                 info!(
                     repo = repo,
@@ -1242,6 +1258,91 @@ pub async fn process_batch_for_repo(
             }
             Err(e) => {
                 warn!(route = pr_route_name, error = %e, "failed to fetch PRs for route");
+            }
+        }
+    }
+
+    // Discover PRs for condition-based routes.
+    let condition_routes: Vec<(&str, &Route)> = routes
+        .iter()
+        .filter(|(_, r)| r.route_type == "pr" && r.condition.is_some())
+        .map(|(name, route)| (name.as_str(), route))
+        .collect();
+
+    if !condition_routes.is_empty() {
+        let all_prs = match github::fetch_all_open_prs(repo, 100).await {
+            Ok(prs) => prs,
+            Err(e) => {
+                warn!(error = %e, "failed to fetch open PRs for condition routes");
+                vec![]
+            }
+        };
+
+        let branch_prefix = config
+            .global
+            .branch_pattern
+            .split('{')
+            .next()
+            .unwrap_or("automation/");
+
+        for (route_name, route) in &condition_routes {
+            let condition = route.condition.as_ref().unwrap();
+            for pr in &all_prs {
+                // Skip PRs already in progress or marked needs-human.
+                if pr
+                    .labels
+                    .iter()
+                    .any(|l| l == &config.global.in_progress_label || l == "forza:needs-human")
+                {
+                    continue;
+                }
+
+                // Apply scope filter.
+                if route.scope == crate::config::ConditionScope::ForzaOwned
+                    && !pr.head_branch.starts_with(branch_prefix)
+                {
+                    continue;
+                }
+
+                if !condition.matches(pr) {
+                    continue;
+                }
+
+                // Check retry budget.
+                if let Some(max) = route.max_retries {
+                    let workflow_name = route.workflow.as_deref().unwrap_or("");
+                    let prior_runs =
+                        state::count_runs_for_subject(pr.number, workflow_name, state_dir);
+                    if prior_runs >= max {
+                        warn!(
+                            pr = pr.number,
+                            route = route_name,
+                            prior_runs = prior_runs,
+                            max_retries = max,
+                            "retry budget exhausted, applying needs-human label"
+                        );
+                        let _ = github::add_pr_label(repo, pr.number, "forza:needs-human").await;
+                        let _ = github::comment_on_pr(
+                            repo,
+                            pr.number,
+                            &format!(
+                                "Retry budget exhausted for route `{route_name}` \
+                                 ({prior_runs}/{max} attempts). Applying `forza:needs-human` \
+                                 for manual review."
+                            ),
+                        )
+                        .await;
+                        continue;
+                    }
+                }
+
+                info!(
+                    pr = pr.number,
+                    route = route_name,
+                    condition = ?condition,
+                    "condition matched, queuing PR"
+                );
+                pending.push_back((route_name.to_string(), PendingSubject::Pr(pr.clone())));
             }
         }
     }
@@ -1379,11 +1480,11 @@ pub async fn process_batch_for_repo(
         }
     }
 
-    // Process PR-type routes with reactive dispatch.
+    // Process PR-type routes with reactive dispatch (label-based only in legacy path).
     let pr_routes: Vec<(String, String)> = routes
         .iter()
-        .filter(|(_, r)| r.route_type == "pr")
-        .map(|(name, r)| (name.clone(), r.label.clone()))
+        .filter(|(_, r)| r.route_type == "pr" && r.label.is_some())
+        .map(|(name, r)| (name.clone(), r.label.clone().unwrap()))
         .collect();
 
     if !pr_routes.is_empty() && !*cancel.borrow() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -282,6 +282,18 @@ pub fn find_latest_run_for_issue(
         .find(|r| r.issue_number == issue_number)
 }
 
+/// Count completed runs for a given issue/PR number with a specific workflow.
+pub fn count_runs_for_subject(
+    issue_number: u64,
+    workflow: &str,
+    state_dir: &std::path::Path,
+) -> usize {
+    load_all_runs(state_dir)
+        .iter()
+        .filter(|r| r.issue_number == issue_number && r.workflow == workflow)
+        .count()
+}
+
 /// Per-workflow aggregate stats.
 #[derive(Debug, Clone)]
 pub struct WorkflowSummary {


### PR DESCRIPTION
## Summary

- Route conditions: routes can trigger on PR state (ci_failing, has_conflicts, approved_and_green) instead of labels
- Optional Route fields: label and workflow are now `Option<String>` with validation
- Retry budget: `max_retries` per route with `forza:needs-human` escalation
- PR health monitoring: condition route in forza.toml auto-detects and fixes broken forza-owned PRs

This enables fully automated PR maintenance. The watch loop now:
1. Processes labeled issues (existing behavior)
2. Scans forza-owned PRs for CI failures or conflicts (new)
3. Automatically queues them for the pr-fix workflow (new)
4. Stops after max_retries and escalates to human (new)

## Test plan

- [x] 95 unit tests pass (3 new: validation, config parsing, condition matching)
- [x] cargo clippy clean
- [x] cargo fmt clean
- [x] Verified existing label routes still work via dry-run
- [x] Config with condition route parses correctly

Closes #93, closes #94, closes #95, closes #96