### PR TITLE
chore: add Cargo.toml keywords and categories for crates.io discoverability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Configurable workflow orchestrator for agent driven software development"
 repository = "https://github.com/joshrotenberg/forza"
+keywords = ["github", "automation", "issues", "pull-requests", "ci"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 tower-mcp = "0.9"


### PR DESCRIPTION
## Summary

Automated implementation for [#86](https://github.com/joshrotenberg/forza/issues/86) — chore: add Cargo.toml keywords and categories for crates.io discoverability.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 26.5s | - |
| implement | succeeded | 28.3s | - |
| test | succeeded | 26.6s | - |
| review | succeeded | 55.1s | - |

## Files changed

```
 Cargo.toml | 2 ++
 1 file changed, 2 insertions(+)
```

## Plan

# Plan Stage: Issue #86 — Add Cargo.toml keywords and categories

## Findings

- Single `Cargo.toml` at the repo root (no workspace, no sub-crates).
- `[package]` section (lines 1–9) has name, version, edition, rust-version, authors, license, description, and repository — but no `keywords` or `categories`.
- The issue specifies exact values to add.

## Decision

Add two fields after the existing package metadata:
```toml
keywords = ["github", "automation", "issues", "pull-requests", "ci"]
categories = ["command-line-utilities", "development-tools"]
```

`keywords` must have ≤ 5 entries (crates.io limit) — the proposed list has exactly 5. Both category slugs (`command-line-utilities`, `development-tools`) are valid crates.io categories.

## Next Stage Needs

- Edit `Cargo.toml` lines 9–10: insert the two fields after the `repository` line.
- Commit message: `chore: add Cargo.toml keywords and categories for crates.io discoverability closes #86`
- No other files require changes.


## Review

## Review Stage — Issue #86

### Verdict: PASS

### Findings

The diff consists of exactly two lines added to `Cargo.toml`:

```toml
keywords = ["github", "automation", "issues", "pull-requests", "ci"]
categories = ["command-line-utilities", "development-tools"]
```

**Validation:**
- Keywords: 5 of 5 allowed; all within 20-char limit; valid format (alphanumeric + hyphens)
- Categories: 2 of 5 allowed; both (`command-line-utilities`, `development-tools`) are valid crates.io category slugs
- No code changes; no tests needed
- No issues of any severity found

### Next Stage Notes

- Ready for PR creation targeting `main`
- PR body should include `closes #86`
- No follow-up work required


Closes #86