### PR TITLE
chore: update CLAUDE.md with recent features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,152 @@
+# forza — agent context
+
+forza is a GitHub automation runner that processes issues and PRs through configurable
+multi-stage workflows executed by Claude. This file documents the configuration model
+and key features for agents processing forza's own issues.
+
+## Architecture
+
+```
+RunnerConfig (forza.toml / runner.toml)
+  └─ repos."owner/name"
+       └─ routes.name  ──→  WorkflowTemplate  ──→  Stage[]
+                                                     ├─ kind (StageKind)
+                                                     ├─ agentless / command
+                                                     ├─ condition
+                                                     ├─ skills / model / mcp_config
+                                                     └─ optional / max_retries
+```
+
+Key modules: `src/config.rs` (config structs), `src/workflow.rs` (`Stage`, `StageKind`,
+`WorkflowTemplate`), `src/planner.rs` (build stage prompts, breadcrumb instructions),
+`src/orchestrator.rs` (execute stages, load breadcrumbs, fire hooks).
+
+## Config structure
+
+```toml
+[global]
+model = "claude-sonnet-4-6"
+gate_label = "forza:ready"
+branch_pattern = "automation/{issue}-{slug}"
+
+[security]
+authorization_level = "contributor"   # sandbox | local | contributor | trusted
+
+[validation]
+commands = ["cargo fmt --all -- --check", "cargo clippy --all-targets -- -D warnings"]
+
+[repos."owner/name"]
+[repos."owner/name".routes.route-name]
+type = "issue"          # or "pr"
+label = "bug"           # label trigger (mutually exclusive with condition)
+workflow = "bug"        # workflow template name
+
+[agent_config]
+skills = ["./skills/rust.md"]
+mcp_config = ".mcp.json"
+
+[stage_hooks.implement]
+pre    = ["..."]
+post   = ["..."]
+finally = ["..."]
+```
+
+## Breadcrumbs
+
+Each stage that has a successor is instructed to write a context summary to
+`.forza/breadcrumbs/{run_id}/{stage_name}.md` (e.g.,
+`.forza/breadcrumbs/run-20260321-170349-1ff7fe81/plan.md`). The orchestrator reads
+this file after the stage completes and prepends it as `## Context from previous stage`
+to the next stage's prompt.
+
+The plan stage is special: it writes to `.plan_breadcrumb.md` in the repo root (not
+`.forza/breadcrumbs/`). The implement stage reads it for the file list and exact commit
+message. Similarly `.review_breadcrumb.md` is written by review and read by open_pr.
+
+## Agentless stages
+
+Set `agentless = true` and `command = "..."` on a stage to run a shell command directly
+instead of invoking Claude. Useful for formatting, linting, or scaffolding steps.
+
+```toml
+[[workflow_templates]]
+name = "lint-first"
+stages = [
+  { kind = "implement", agentless = true, command = "cargo fmt --all" },
+  { kind = "review" },
+  { kind = "open_pr" },
+]
+```
+
+The orchestrator runs the command via `sh -c` and records the output. No agent
+invocation happens for agentless stages.
+
+## Conditional stages
+
+Set `condition = "..."` (a shell command) on a stage to gate its execution. Exit 0
+means **skip** the stage; non-zero (or absent) means **run** it. Use together with
+`optional = true` so a skipped stage does not fail the run. No hooks fire for skipped
+stages.
+
+```toml
+{ kind = "test", optional = true, condition = "git diff --quiet HEAD~1 -- src/tests/" }
+```
+
+The condition is evaluated by the orchestrator before the stage starts.
+
+## Per-stage hooks
+
+Define hooks keyed by the snake_case `StageKind` name (`plan`, `implement`, `test`,
+`review`, `open_pr`, `revise_pr`, `fix_ci`, `merge`, `research`, `comment`).
+
+```toml
+[stage_hooks.implement]
+pre     = ["cargo check"]          # runs before the stage
+post    = ["cargo fmt --all"]      # runs on success
+finally = ["echo done"]            # runs regardless of outcome
+```
+
+`pre` failure aborts the stage. `post` failure marks the stage failed. `finally` always
+runs (clean-up, notifications, etc.).
+
+## Route-based config
+
+Multi-repo config uses `[repos."owner/name".routes.name]`. Each route needs a `type`
+(`issue` or `pr`) and at least one trigger (`label` or `condition`).
+
+```toml
+[repos."owner/name".routes.auto-fix]
+type       = "pr"
+condition  = "ci_failing_or_conflicts"   # RouteCondition: ci_failing | has_conflicts |
+                                         #   ci_failing_or_conflicts | approved_and_green
+workflow   = "pr-fix"
+scope      = "forza_owned"               # forza_owned (default) | all
+max_retries = 3                          # applies forza:needs-human after N failures
+concurrency = 2
+model      = "claude-opus-4-6"           # per-route model override
+skills     = ["./skills/pr-fix.md"]      # per-route skills override
+mcp_config = ".mcp.json"
+validation_commands = ["cargo test"]
+```
+
+Condition routes fire automatically based on PR state; no label is needed. Label routes
+fire when the GitHub label is applied.
+
+## Skill injection
+
+Skills are markdown files injected into the agent's context. Three levels of override
+(stage > route > global):
+
+```toml
+[agent_config]
+skills = ["./skills/rust.md"]          # global baseline
+
+[repos."owner/name".routes.bugfix]
+skills = ["./skills/bugfix.md"]        # overrides global for this route
+
+# In a workflow template stage:
+{ kind = "implement", skills = ["./skills/impl.md"] }   # overrides route for this stage
+```
+
+`RunnerConfig::effective_skills(route, stage_skills)` resolves the final list: stage
+skills win if present, otherwise route skills, otherwise global.


### PR DESCRIPTION
## Summary

Automated implementation for [#84](https://github.com/joshrotenberg/forza/issues/84) — chore: update CLAUDE.md with recent features.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 107.5s | - |
| implement | succeeded | 110.3s | - |
| test | succeeded | 33.9s | - |
| review | succeeded | 111.1s | - |

## Files changed

```
 CLAUDE.md | 152 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 152 insertions(+)
```

## Plan

# Plan stage breadcrumb — issue #84

## Key findings

**No CLAUDE.md exists.** The file must be created from scratch. The issue description says "outdated" but there is simply no file yet.

**Six features to document** (verified from source):

1. **Breadcrumbs** — `src/planner.rs` appends a `## Breadcrumb` section to every stage prompt that has a successor, instructing the agent to write `.forza/breadcrumbs/{run_id}/{stage_name}.md`. `src/orchestrator.rs` reads the file after each stage completes and prepends it as `## Context from previous stage` to the next stage's prompt. Format: `run-{timestamp}-{short_hash}/{stage}.md`.

2. **Agentless stages** — `Stage.agentless = true` + `Stage.command = "..."` in a workflow template stage. The orchestrator runs the command directly via `sh -c` and records output, skipping Claude invocation entirely. Useful for lint/format steps.

3. **Conditional stages** — `Stage.condition = "..."` (shell command). Used together with `Stage.optional = true`; if the condition exits 0 the stage is **skipped**; if non-zero (or absent) it runs. No hooks fire for skipped stages.

4. **Per-stage hooks** — `[stage_hooks.{stage_kind_name}]` in `runner.toml`/`forza.toml` with `pre`, `post`, `finally` string arrays. `pre` runs before the stage, `post` runs on success, `finally` runs regardless. Stage kind names are snake_case (`plan`, `implement`, `test`, `review`, `open_pr`, etc.).

5. **Route-based config** — Multi-repo table `[repos."owner/name".routes.name]`. Each route has `type`, `label` or `condition`, `workflow`, `concurrency`, `poll_interval`, optional `model`/`skills`/`mcp_config`/`validation_commands`/`schedule`/`scope`/`max_retries`. Condition routes (`ci_failing_or_conflicts`, `approved_and_green`, etc.) trigger automatically without manual labeling. `scope` can be `forza_owned` (default) or `all`.

6. **Skill injection** — Three levels: global `[agent_config] skills = [...]`, per-route `skills = [...]`, per-stage `skills = [...]` in a workflow template stage. `effective_skills()` in `config.rs` merges them with stage overriding route overriding global.

## Decisions

- CLAUDE.md should be scoped to agent context: architecture overview, config reference for the six features, and forza's self-hosting pattern. Do not duplicate README prose or global CLAUDE.md standards.
- Use concrete TOML snippets matching `forza.toml` style for every feature.
- Keep it concise — agents read this every run, so shorter is better.

## For the implement stage

- Create `CLAUDE.md` in the repo root.
- Sections: Overview, Architecture (brief), Config structure, then one section per feature (Breadcrumbs, Agentless Stages, Conditional Stages, Per-Stage Hooks, Route-Based Config, Skill Injection).
- Reference actual struct names where helpful (`Stage`, `StageHooks`, `RouteCondition`, `ConditionScope`).
- The commit message is: `chore: add CLAUDE.md with breadcrumbs, agentless stages, conditions, hooks, routes, and skill injection closes #84`


## Review

## Review stage breadcrumb

### What was done

Reviewed the CLAUDE.md added in issue #84 against the actual source code.

### Findings

- All documented features (breadcrumbs, agentless stages, conditional stages, hooks,
  routes, skill injection) verified accurate against `src/config.rs`, `src/workflow.rs`,
  `src/planner.rs`, and `src/orchestrator.rs`.
- One low-severity documentation note: the condition semantics ("Exit 0 means skip")
  match the optional-stage code path but are inverted relative to `eval_stage_condition`
  (line 2148), which is a pre-existing code inconsistency, not introduced by this PR.

### Verdict: PASS

No high-severity issues found.

### For the next stage (open_pr)

- Branch: `automation/84-chore-update-claude-md-with-recent-featu`
- Only `CLAUDE.md` was created (152 insertions). No source code changes.
- Commit: `chore: add CLAUDE.md with breadcrumbs, agentless stages, conditions, hooks, routes, and skill injection closes #84`
- Closes issue #84.
- Note for PR description: `CLAUDE.md` is listed in `.gitignore`; it was force-added.
  The PR description should mention this as a follow-up item (either remove CLAUDE.md
  from .gitignore or document the rationale for keeping it there).


Closes #84