### PR TITLE
chore: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0](https://github.com/joshrotenberg/forza/compare/v0.1.0...v0.2.0) - 2026-03-21
 
+Major expansion of the forza platform: REST API and embedded MCP server for programmatic control, reactive PR workflows with label-driven processing and retry budgets, security hardening (prompt injection protection, authorization, rate limiting), desktop/Slack/webhook notifications, multi-repo support with per-repo routes, configurable stage prompt templates, rich PR descriptions generated from run data, schedule windows, per-route agent configuration, and the `forza init` command for bootstrapping new repos.
+
 ### Added
 
 - *(mcp)* embed MCP server with runner, status, and config tool groups closes #52 ([#101](https://github.com/joshrotenberg/forza/pull/101))
@@ -52,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(dry-run)* show estimated cost range from historical run data in `--dry-run` output closes #16
 
 ## [0.1.0](https://github.com/joshrotenberg/forza/releases/tag/v0.1.0) - 2026-03-21
+
+Initial release of forza: an autonomous GitHub issue runner. Core features include breadcrumb-based context flow between pipeline stages, clean and status commands for managing run state, concurrent batch processing, signal handling with stale lease recovery, and a full CI suite covering formatting, linting, tests, MSRV, docs, and release automation.
 
 ### Added
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,59 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}]\
+    {% if previous.version %}\
+        (https://github.com/joshrotenberg/forza/compare/{{ previous.version }}...{{ version }})\
+    {% else %}\
+        (https://github.com/joshrotenberg/forza/releases/tag/{{ version }})\
+    {% endif %} \
+    - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+
+    {% for commit in commits %}\
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+        {{ commit.message | upper_first }}\
+        {% if commit.remote.pr_number %} ([#{{ commit.remote.pr_number }}](https://github.com/joshrotenberg/forza/pull/{{ commit.remote.pr_number }})){% endif %}
+    {% endfor %}\
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_preprocessors = [
+  { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/joshrotenberg/forza/pull/${2}))" },
+]
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^doc", group = "Documentation" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^style", group = "Styling" },
+  { message = "^test", group = "Testing" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore", group = "Other" },
+  { body = ".*security", group = "Security" },
+]
+filter_commits = false
+tag_pattern = "v[0-9]*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,3 @@
+[workspace]
+changelog_update = true
+git_cliff_config = "cliff.toml"


### PR DESCRIPTION
## Summary

Automated implementation for [#77](https://github.com/joshrotenberg/forza/issues/77) — chore: add CHANGELOG.md.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 74.1s | - |
| implement | succeeded | 65.3s | - |
| test | succeeded | 30.3s | - |
| review | succeeded | 521.9s | - |

## Files changed

```
 CHANGELOG.md     |  4 ++++
 cliff.toml       | 59 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 release-plz.toml |  3 +++
 3 files changed, 66 insertions(+)
```

## Plan

# Plan Breadcrumb — Issue #77: Add CHANGELOG.md

## Current State

- `CHANGELOG.md` already exists at repo root, following Keep a Changelog format
- It is auto-generated by release-plz from conventional commits
- Contains entries for v0.1.0 and v0.2.0 with individual PR-level bullet points
- No human-readable summaries explaining major themes per version
- No `cliff.toml` or `release-plz.toml` present
- release-plz is configured via `.github/workflows/release-plz.yml` only

## Key Decisions

1. **Add `cliff.toml`** — configure git-cliff as the changelog generator. This addresses the issue discussion suggestion. The config should group commits by conventional commit type and produce readable output.

2. **Add `release-plz.toml`** — wire release-plz to use git-cliff as its changelog backend via `changelog_update = true` and `git_cliff_config = "cliff.toml"` so future releases auto-generate via git-cliff.

3. **Update `CHANGELOG.md`** — add a short human-readable summary paragraph at the top of each version section (v0.1.0 and v0.2.0) describing the major features and themes in plain language. The auto-generated bullet points stay; the summary adds context.

## Files to Create/Modify

| File | Action | Reason |
|------|--------|--------|
| `cliff.toml` | Create | Configure git-cliff for changelog generation |
| `release-plz.toml` | Create | Wire release-plz to use git-cliff |
| `CHANGELOG.md` | Modify | Add human-readable summaries for v0.1.0 and v0.2.0 |

## Version Summaries (for CHANGELOG.md)

**v0.2.0** — Major expansion: REST API, embedded MCP server, reactive PR workflows, security hardening (prompt injection/authz/rate limiting), desktop/Slack/webhook notifications, multi-repo support, configurable stage prompt templates, rich PR descriptions, schedule windows, and per-route agent config.

**v0.1.0** — Initial release: autonomous GitHub issue runner with breadcrumb-based context flow between stages, clean/status commands, concurrent batch processing, signal handling, and full CI suite.

## Commit Message

`chore: add git-cliff config and human-readable changelog summaries closes #77`


## Review

## Review Stage: issue #77 — Add CHANGELOG.md

### Verdict: PASS

### Changes reviewed (vs origin/main)
- `CHANGELOG.md` — added human-readable summary paragraphs for v0.2.0 and v0.1.0 releases
- `cliff.toml` — new git-cliff configuration (standard template + conventional commit parsers)
- `release-plz.toml` — new file wiring release-plz to use cliff.toml

### Key findings
- No Rust source code changed; no new tests required or applicable
- The duplicate `### Added` section in the v0.2.0 block of CHANGELOG.md is pre-existing on main — predates this PR
- The branch has two commits ahead of local main (`7083c96` closes #86, `568c79d` closes #77), but `7083c96` is already merged in origin/main — the effective PR diff is only the three config/doc files above
- `cliff.toml` uses `commit.remote.pr_number` in the body template; this requires git-cliff to be run with a configured GitHub remote. The `commit_preprocessors` regex handles existing commit message link rewriting, but future changelog generation may not auto-link PRs unless invoked with `--github-repo`. Low severity — operational concern, not a bug.
- The summary paragraphs are accurate and well-written

### State for next stage
- Branch: `automation/77-chore-add-changelog-md`
- Ready for PR creation targeting main
- PR should reference `closes #77`
- No source files were modified during review stage


Closes #77