### PR TITLE
refactor: extract orchestrator helpers into separate module

### DIFF
--- a/src/orchestrator/helpers.rs
+++ b/src/orchestrator/helpers.rs
@@ -248,7 +248,6 @@ pub(super) fn build_pr_body(
     body
 }
 
-
 pub(super) async fn run_stage_hooks(hooks: &[String], work_dir: &Path, label: &str) {
     for cmd in hooks {
         let output = tokio::process::Command::new("sh")

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -1585,7 +1585,6 @@ pub async fn process_batch_with_config(
     all_records
 }
 
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;


### PR DESCRIPTION
## Summary

Automated implementation for [#85](https://github.com/joshrotenberg/forza/issues/85) — refactor: extract orchestrator helpers into separate module.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 122.3s | - |
| implement | succeeded | 236.9s | - |
| test | succeeded | 27.2s | - |
| review | succeeded | 52.4s | - |

## Files changed

```
 src/orchestrator/helpers.rs                  | 328 +++++++++++++++++++++++++++
 src/{orchestrator.rs => orchestrator/mod.rs} | 319 +-------------------------
 2 files changed, 331 insertions(+), 316 deletions(-)
```

## Plan

## Context from plan stage

### File size
`src/orchestrator.rs` is 2,563 lines (issue cited 1,104 — it has grown).

### Functions to move to `src/orchestrator/helpers.rs`
All are currently private (not `pub`). Move with visibility `pub(super)` so `mod.rs` can call them:

| Function | Lines | Notes |
|---|---|---|
| `build_pr_planned_stage` | 836–861 | builds a `PlannedStage` for reactive PR mode |
| `generate_reactive_pr_prompt` | 863–914 | generates stage prompts for reactive PR stages |
| `handle_open_pr` | 1983–2064 | async; commits, rebases, pushes, creates PR |
| `build_pr_body` | 2066–2137 | sync; called only by `handle_open_pr` |
| `eval_stage_condition` | 2146–2172 | async; evaluates a shell condition |
| `run_stage_hooks` | 2174–2194 | async; runs pre/post/finally hook commands |
| `run_validation` | 2196–2216 | async; runs validation commands |

### Functions that stay in `mod.rs` (public pipeline)
`process_issue_with_config`, `process_pr_with_config`, `process_reactive_pr`,
`process_batch_for_repo`, `process_batch_with_config`, `process_issue`, `process_batch`

### `handle_merge` note
The issue requests extracting `handle_merge`, but no such function exists. Merge logic
is inline guard code inside the stage loops — not worth extracting into its own helper.

### Module conversion mechanics
- Rename `src/orchestrator.rs` → `src/orchestrator/mod.rs`
- Create `src/orchestrator/helpers.rs` with the extracted functions
- Add `mod helpers;` and `use helpers::*;` (or explicit imports) at top of `mod.rs`
- `src/lib.rs` needs no changes — `pub mod orchestrator` resolves automatically

### Imports needed in helpers.rs
`use std::path::Path;`, `use tracing::{warn, debug}`, `use crate::github`,
`use crate::error::Result`, `use crate::executor::StageResult`, `use crate::state::RunRecord`,
`use crate::planner::PlannedStage`, `use crate::workflow::{Stage, StageKind}`

### Tests
The `#[cfg(test)]` block (lines 2322–end) tests scheduling logic — stays in `mod.rs`.

### No public API changes
All extracted helpers are currently private; making them `pub(super)` preserves encapsulation.


## Review

## Context from review stage

### Verdict: PASS

The refactor for issue #85 is correct and complete. No issues found.

### Key findings

- All 7 helpers extracted as planned: `build_pr_planned_stage`, `generate_reactive_pr_prompt`, `handle_open_pr`, `build_pr_body`, `eval_stage_condition`, `run_stage_hooks`, `run_validation`
- All are `pub(super)` — visible only within the `orchestrator` module, not leaked to the public API
- `mod.rs` uses `mod helpers; use helpers::*;` — clean, idiomatic
- `src/lib.rs` unchanged; `pub mod orchestrator` resolves automatically to the new directory
- No logic changes; pure structural refactor
- 103/103 unit tests passed (confirmed by test stage)

### For open_pr stage

- Branch: `automation/85-refactor-extract-orchestrator-helpers-in`
- Commit message: `refactor(orchestrator): extract helper fns into orchestrator/helpers.rs closes #85`
- PR should close issue #85
- No special reviewer assignment needed; routine refactor


Closes #85