### PR TITLE
refactor: SubjectType enum and RouteOutcome type

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -291,6 +291,16 @@ pub enum ConditionScope {
     All,
 }
 
+/// The kind of subject a route operates on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubjectType {
+    /// GitHub issue.
+    Issue,
+    /// GitHub pull request.
+    Pr,
+}
+
 /// A named route — maps type+trigger to an action.
 ///
 /// A route must have at least one trigger (`label` or `condition`) and
@@ -299,9 +309,9 @@ pub enum ConditionScope {
 /// PR state matches (e.g., CI failing, has conflicts).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Route {
-    /// "issue" or "pr".
+    /// What kind of subject this route operates on.
     #[serde(rename = "type")]
-    pub route_type: String,
+    pub route_type: SubjectType,
 
     /// GitHub label that triggers this route.
     #[serde(default)]
@@ -492,7 +502,7 @@ impl RunnerConfig {
         issue: &IssueCandidate,
     ) -> Option<(&'a str, &'a Route)> {
         for (name, route) in routes {
-            if route.route_type == "issue"
+            if route.route_type == SubjectType::Issue
                 && route
                     .label
                     .as_ref()
@@ -510,7 +520,7 @@ impl RunnerConfig {
         pr: &PrCandidate,
     ) -> Option<(&'a str, &'a Route)> {
         for (name, route) in routes {
-            if route.route_type == "pr"
+            if route.route_type == SubjectType::Pr
                 && route
                     .label
                     .as_ref()
@@ -528,7 +538,7 @@ impl RunnerConfig {
     }
 
     /// Get routes filtered by type ("issue" or "pr").
-    pub fn routes_by_type(&self, route_type: &str) -> Vec<(&str, &Route)> {
+    pub fn routes_by_type(&self, route_type: SubjectType) -> Vec<(&str, &Route)> {
         self.routes
             .iter()
             .filter(|(_, r)| r.route_type == route_type)
@@ -1193,7 +1203,7 @@ workflow = "bug"
         routes.insert(
             "bugfix".to_string(),
             Route {
-                route_type: "issue".to_string(),
+                route_type: SubjectType::Issue,
                 label: Some("bug".to_string()),
                 workflow: Some("bug".to_string()),
                 condition: None,
@@ -1347,7 +1357,7 @@ repo = "owner/repo"
     #[test]
     fn route_validate_requires_trigger_and_action() {
         let route = Route {
-            route_type: "pr".to_string(),
+            route_type: SubjectType::Pr,
             label: None,
             condition: None,
             workflow: Some("pr-fix".to_string()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,5 +28,6 @@ pub mod planner;
 pub mod state;
 pub mod workflow;
 
-pub use config::RunnerConfig;
+pub use config::{RunnerConfig, SubjectType};
 pub use orchestrator::process_pr_with_config;
+pub use state::RouteOutcome;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -135,6 +135,7 @@ mod tests {
             completed_at: Some(chrono::Utc::now()),
             total_cost_usd: Some(0.12),
             subject_kind: crate::state::SubjectKind::Issue,
+            outcome: None,
         }
     }
 

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -169,6 +169,10 @@ pub async fn process_issue_with_overrides(
                 cap = cap,
                 "hourly cost cap exceeded, aborting run"
             );
+            record.outcome = Some(state::RouteOutcome::Failed {
+                stage: "cost_cap".to_string(),
+                error: format!("hourly cost cap exceeded: ${spent:.4} >= ${cap:.4}"),
+            });
             record.finish(RunStatus::Failed);
             state::save_run(&record, state_dir)?;
             return Ok(record);
@@ -516,9 +520,30 @@ pub async fn process_issue_with_overrides(
     } else {
         RunStatus::Failed
     };
+    record.outcome = Some(if all_succeeded {
+        if let Some(pr) = record.pr_number {
+            state::RouteOutcome::PrCreated { number: pr }
+        } else {
+            state::RouteOutcome::CommentPosted
+        }
+    } else {
+        let failed_stage = record
+            .stages
+            .iter()
+            .find(|s| s.status == state::StageStatus::Failed);
+        state::RouteOutcome::Failed {
+            stage: failed_stage
+                .map(|s| s.kind_name().to_string())
+                .unwrap_or_default(),
+            error: failed_stage
+                .and_then(|s| s.result.as_ref())
+                .map(|r| r.output.chars().take(200).collect())
+                .unwrap_or_default(),
+        }
+    });
     record.finish(final_status);
     state::save_run(&record, state_dir)?;
-    info!(issue = number, run_id = record.run_id, status = ?final_status, cost = record.total_cost_usd, "run complete");
+    info!(issue = number, run_id = record.run_id, status = ?final_status, outcome = ?record.outcome, cost = record.total_cost_usd, "run complete");
 
     // Fire notifications (best-effort; errors are logged, never fatal).
     if let Some(notif_config) = config.global.notifications.as_ref() {
@@ -880,9 +905,26 @@ pub async fn process_pr_with_overrides(
     } else {
         RunStatus::Failed
     };
+    record.outcome = Some(if all_succeeded {
+        state::RouteOutcome::PrUpdated { number }
+    } else {
+        let failed_stage = record
+            .stages
+            .iter()
+            .find(|s| s.status == state::StageStatus::Failed);
+        state::RouteOutcome::Failed {
+            stage: failed_stage
+                .map(|s| s.kind_name().to_string())
+                .unwrap_or_default(),
+            error: failed_stage
+                .and_then(|s| s.result.as_ref())
+                .map(|r| r.output.chars().take(200).collect())
+                .unwrap_or_default(),
+        }
+    });
     record.finish(final_status);
     state::save_run(&record, state_dir)?;
-    info!(pr = number, run_id = record.run_id, status = ?final_status, cost = record.total_cost_usd, "run complete");
+    info!(pr = number, run_id = record.run_id, status = ?final_status, outcome = ?record.outcome, cost = record.total_cost_usd, "run complete");
 
     // Fire notifications.
     if let Some(notif_config) = config.global.notifications.as_ref() {
@@ -1127,9 +1169,28 @@ pub async fn process_reactive_pr(
     } else {
         RunStatus::Failed
     };
+    record.outcome = Some(if !stage_ran {
+        state::RouteOutcome::NothingToDo
+    } else if all_succeeded {
+        state::RouteOutcome::PrUpdated { number: pr_number }
+    } else {
+        let failed_stage = record
+            .stages
+            .iter()
+            .find(|s| s.status == state::StageStatus::Failed);
+        state::RouteOutcome::Failed {
+            stage: failed_stage
+                .map(|s| s.kind_name().to_string())
+                .unwrap_or_default(),
+            error: failed_stage
+                .and_then(|s| s.result.as_ref())
+                .map(|r| r.output.chars().take(200).collect())
+                .unwrap_or_default(),
+        }
+    });
     record.finish(final_status);
     state::save_run(&record, state_dir)?;
-    info!(pr = pr_number, run_id = record.run_id, status = ?final_status, "reactive PR run complete");
+    info!(pr = pr_number, run_id = record.run_id, status = ?final_status, outcome = ?record.outcome, "reactive PR run complete");
 
     // Fire notifications (best-effort).
     if let Some(notif_config) = config.global.notifications.as_ref() {
@@ -1238,7 +1299,11 @@ pub async fn process_batch_for_repo(
     // Discover PRs for label-based "pr"-type routes.
     let label_pr_routes: Vec<(&str, &Route)> = routes
         .iter()
-        .filter(|(_, r)| r.route_type == "pr" && r.label.is_some() && r.condition.is_none())
+        .filter(|(_, r)| {
+            r.route_type == crate::config::SubjectType::Pr
+                && r.label.is_some()
+                && r.condition.is_none()
+        })
         .map(|(name, route)| (name.as_str(), route))
         .collect();
 
@@ -1285,7 +1350,7 @@ pub async fn process_batch_for_repo(
     // Discover PRs for condition-based routes.
     let condition_routes: Vec<(&str, &Route)> = routes
         .iter()
-        .filter(|(_, r)| r.route_type == "pr" && r.condition.is_some())
+        .filter(|(_, r)| r.route_type == crate::config::SubjectType::Pr && r.condition.is_some())
         .map(|(name, route)| (name.as_str(), route))
         .collect();
 
@@ -1504,7 +1569,7 @@ pub async fn process_batch_for_repo(
     let pr_routes: Vec<(String, String)> = routes
         .iter()
         .filter(|(_, r)| {
-            r.route_type == "pr"
+            r.route_type == crate::config::SubjectType::Pr
                 && r.label.is_some()
                 && r.workflow.as_deref().is_some_and(|wf| {
                     config

--- a/src/state.rs
+++ b/src/state.rs
@@ -56,6 +56,26 @@ pub enum StageStatus {
     Waiting,
 }
 
+/// The outcome of a route execution — what the run produced.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RouteOutcome {
+    /// A new PR was created from an issue workflow.
+    PrCreated { number: u64 },
+    /// An existing PR was updated (rebased, CI fixed, etc.).
+    PrUpdated { number: u64 },
+    /// A PR was merged.
+    PrMerged { number: u64 },
+    /// A comment was posted (e.g., research workflow).
+    CommentPosted,
+    /// No action was needed (e.g., reactive mode found nothing to do).
+    NothingToDo,
+    /// The run failed at a specific stage.
+    Failed { stage: String, error: String },
+    /// Retry budget was exhausted — needs human intervention.
+    Exhausted { retries: usize },
+}
+
 /// A persisted run record.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunRecord {
@@ -84,6 +104,9 @@ pub struct RunRecord {
     /// Whether this run is for an issue or a PR.
     #[serde(default)]
     pub subject_kind: SubjectKind,
+    /// The outcome of the run — what it produced.
+    #[serde(default)]
+    pub outcome: Option<RouteOutcome>,
 }
 
 /// Per-stage record within a run.
@@ -148,6 +171,7 @@ impl RunRecord {
             completed_at: None,
             total_cost_usd: None,
             subject_kind: SubjectKind::Issue,
+            outcome: None,
         }
     }
 
@@ -172,6 +196,7 @@ impl RunRecord {
             completed_at: None,
             total_cost_usd: None,
             subject_kind: SubjectKind::Pr,
+            outcome: None,
         }
     }
 
@@ -465,6 +490,7 @@ mod tests {
             completed_at: None,
             total_cost_usd: cost,
             subject_kind: SubjectKind::Issue,
+            outcome: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Architecture review cleanup (#103):

- **SubjectType enum**: Replaces `route_type: String` with `SubjectType::Issue | SubjectType::Pr`. Compiler-enforced, no more string comparisons.
- **RouteOutcome enum**: Formalizes run outcomes — `PrCreated`, `PrUpdated`, `Failed`, `NothingToDo`, etc. Set by orchestrator, persisted in RunRecord, logged with structured fields.
- Both types exported from `lib.rs` for downstream use.

## Test plan

- [x] 89 unit tests pass
- [x] cargo clippy clean
- [x] All existing TOML configs parse correctly (serde rename_all handles it)

Closes #103