### PR TITLE
feat: show RouteOutcome in status output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -756,22 +756,23 @@ fn cmd_status(args: StatusArgs) -> ExitCode {
             return ExitCode::FAILURE;
         }
         println!(
-            "{:<30}  {:>6}  {:<20}  {:<10}  {:>8}  started_at",
-            "run_id", "issue#", "workflow", "status", "cost"
+            "{:<30}  {:>6}  {:<20}  {:<10}  {:>8}  {:<25}  started_at",
+            "run_id", "issue#", "workflow", "status", "cost", "outcome"
         );
-        println!("{}", "-".repeat(100));
+        println!("{}", "-".repeat(127));
         for r in &records {
             let cost = r
                 .total_cost_usd
                 .map(|c| format!("${c:.2}"))
                 .unwrap_or_else(|| "-".into());
             println!(
-                "{:<30}  {:>6}  {:<20}  {:<10}  {:>8}  {}",
+                "{:<30}  {:>6}  {:<20}  {:<10}  {:>8}  {:<25}  {}",
                 r.run_id,
                 r.issue_number,
                 r.workflow,
                 r.status_text(),
                 cost,
+                format_outcome(r.outcome.as_ref()),
                 r.started_at.format("%Y-%m-%d %H:%M:%S"),
             );
         }
@@ -1092,6 +1093,20 @@ async fn cmd_mcp(config: &forza::RunnerConfig) -> ExitCode {
     ExitCode::SUCCESS
 }
 
+fn format_outcome(outcome: Option<&forza::state::RouteOutcome>) -> String {
+    use forza::state::RouteOutcome;
+    match outcome {
+        None => "-".into(),
+        Some(RouteOutcome::PrCreated { number }) => format!("pr_created (#{number})"),
+        Some(RouteOutcome::PrUpdated { number }) => format!("pr_updated (#{number})"),
+        Some(RouteOutcome::PrMerged { number }) => format!("pr_merged (#{number})"),
+        Some(RouteOutcome::CommentPosted) => "comment_posted".into(),
+        Some(RouteOutcome::NothingToDo) => "nothing_to_do".into(),
+        Some(RouteOutcome::Failed { stage, .. }) => format!("failed (stage: {stage})"),
+        Some(RouteOutcome::Exhausted { retries }) => format!("exhausted ({retries} retries)"),
+    }
+}
+
 fn print_run_result(record: &forza::state::RunRecord) -> ExitCode {
     let subject = match record.subject_kind {
         forza::state::SubjectKind::Issue => format!("issue #{}", record.issue_number),
@@ -1104,6 +1119,7 @@ fn print_run_result(record: &forza::state::RunRecord) -> ExitCode {
         record.status_text(),
         subject
     );
+    println!("  Outcome:  {}", format_outcome(record.outcome.as_ref()));
     for stage in &record.stages {
         let cost = stage
             .result


### PR DESCRIPTION
## Summary

Automated implementation for [#119](https://github.com/joshrotenberg/forza/issues/119) — feat: show RouteOutcome in status output.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 67.5s | - |
| implement | succeeded | 50.8s | - |
| test | succeeded | 27.2s | - |
| review | succeeded | 63.9s | - |

## Files changed

```
 src/main.rs | 24 ++++++++++++++++++++----
 1 file changed, 20 insertions(+), 4 deletions(-)
```

## Plan

# Context from plan stage

## Key findings

- `RouteOutcome` is already fully defined in `src/state.rs` (lines 59–77) with variants: `PrCreated { number }`, `PrUpdated { number }`, `PrMerged { number }`, `CommentPosted`, `NothingToDo`, `Failed { stage, error }`, `Exhausted { retries }`.
- `RunRecord` already has `pub outcome: Option<RouteOutcome>` (line 109), serialized with `#[serde(default)]` so older JSON files without this field deserialize gracefully as `None`.
- **Only `src/main.rs` needs to change** — no state.rs modifications needed.

## Changes needed in src/main.rs

### 1. Add `format_outcome` helper function

```rust
fn format_outcome(outcome: Option<&forza::state::RouteOutcome>) -> String {
    use forza::state::RouteOutcome;
    match outcome {
        None => "-".into(),
        Some(RouteOutcome::PrCreated { number }) => format!("pr_created (#{number})"),
        Some(RouteOutcome::PrUpdated { number }) => format!("pr_updated (#{number})"),
        Some(RouteOutcome::PrMerged { number }) => format!("pr_merged (#{number})"),
        Some(RouteOutcome::CommentPosted) => "comment_posted".into(),
        Some(RouteOutcome::NothingToDo) => "nothing_to_do".into(),
        Some(RouteOutcome::Failed { stage, .. }) => format!("failed (stage: {stage})"),
        Some(RouteOutcome::Exhausted { retries }) => format!("exhausted ({retries} retries)"),
    }
}
```

### 2. Update `print_run_result` (line 1095)

After the `println!("Run {} — {} ({})", ...)` header line, add:

```rust
println!("  Outcome:  {}", format_outcome(record.outcome.as_ref()));
```

### 3. Update `cmd_status --all` table (lines 758–777)

- Extend the header line to include an `outcome` column (e.g., `{:<25}` after `cost`)
- Extend the separator to match the new width
- Add `format_outcome(r.outcome.as_ref())` to each row's format call

## Decisions

- Formatting is done in `main.rs` (not `state.rs`) to keep display logic separate from data model — consistent with how `status_text()` in `state.rs` is a minimal helper but table layout lives in main.
- `None` renders as `-` (consistent with how missing cost renders in the `--all` table).
- The `--all` table currently outputs ~100 chars wide; adding a 25-char outcome column pushes it to ~127 — acceptable.


## Review

## Context from review stage

### Verdict: PASS

### What was reviewed

Commit `36f113d` — `feat(status): show RouteOutcome in status output closes #119`

Only `src/main.rs` was changed (20 insertions / 4 deletions).

### Key findings

- New `format_outcome(Option<&RouteOutcome>) -> String` helper exhaustively matches all 7 variants of `RouteOutcome` from `src/state.rs`. No variants are missing.
- Column layout change: header and data rows both updated to `{:<25}` for `outcome` column; separator line correctly extended 100 → 127.
- `print_run_result` now prints `Outcome: <value>` immediately after the status line, consistent with the surrounding output style.
- No source file other than `src/main.rs` was touched.
- All pre-commit checks passed (fmt, clippy, 89 tests) per the test stage breadcrumb.

### For open_pr stage

- PR should reference: closes #119
- Single file changed: `src/main.rs`
- Branch: `automation/119-feat-show-routeoutcome-in-status-output`
- No breaking changes; purely additive output improvement


Closes #119