### PR TITLE
chore: add auto_merge documentation to example config

### DIFF
--- a/examples/runner.toml
+++ b/examples/runner.toml
@@ -31,6 +31,9 @@ gate_label = "runner:ready"
 # Default branch pattern. {issue} = number, {slug} = slugified title.
 branch_pattern = "automation/{issue}-{slug}"
 
+# Automatically merge PRs once all CI checks pass. Default: false.
+# auto_merge = false
+
 # ── Security ─────────────────────────────────────────────────────────
 
 [security]


### PR DESCRIPTION
## Summary

Automated implementation for [#121](https://github.com/joshrotenberg/forza/issues/121) — chore: add auto_merge documentation to example config.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| implement | succeeded | 50.7s | - |
| test | succeeded | 25.7s | - |

## Files changed

```
 examples/runner.toml | 3 +++
 1 file changed, 3 insertions(+)
```

Closes #121