### PR TITLE
chore: add forza version to status output header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -755,6 +755,7 @@ fn cmd_status(args: StatusArgs) -> ExitCode {
             eprintln!("no runs found");
             return ExitCode::FAILURE;
         }
+        println!("forza {}", env!("CARGO_PKG_VERSION"));
         println!(
             "{:<30}  {:>6}  {:<20}  {:<10}  {:>8}  {:<25}  started_at",
             "run_id", "issue#", "workflow", "status", "cost", "outcome"
@@ -785,6 +786,7 @@ fn cmd_status(args: StatusArgs) -> ExitCode {
             eprintln!("no runs found");
             return ExitCode::FAILURE;
         }
+        println!("forza {}", env!("CARGO_PKG_VERSION"));
         println!(
             "{:<20}  {:>6}  {:>9}  {:>6}  {:>8}  {:>8}  {:>8}",
             "workflow", "total", "succeeded", "failed", "min $", "max $", "avg $"
@@ -1114,7 +1116,8 @@ fn print_run_result(record: &forza::state::RunRecord) -> ExitCode {
     };
     println!();
     println!(
-        "Run {} — {} ({})",
+        "forza {} — Run {} — {} ({})",
+        env!("CARGO_PKG_VERSION"),
         record.run_id,
         record.status_text(),
         subject


### PR DESCRIPTION
## Summary

Automated implementation for [#124](https://github.com/joshrotenberg/forza/issues/124) — chore: add forza version to status output header.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| implement | succeeded | 151.0s | - |
| test | succeeded | 25.3s | - |

## Files changed

```
 src/main.rs | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
```

Closes #124