### PR TITLE
chore: add merge fallback comment to workflow.rs

### DIFF
--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -146,6 +146,12 @@ impl StageKind {
 
 /// Built-in workflow templates.
 pub fn builtin_templates() -> Vec<WorkflowTemplate> {
+    // Merge stages use `gh pr merge --auto --squash --delete-branch` by default.
+    // `--auto` queues the merge; GitHub completes it once all required status checks pass.
+    // For repos without branch protection or required checks, `--auto` is not supported and
+    // the command will fail. In that case, override the merge stage in your workflow template
+    // with a fallback command:
+    //   command = "gh pr merge --auto --squash --delete-branch || gh pr merge --squash --delete-branch"
     vec![
         WorkflowTemplate {
             name: "bug".into(),


### PR DESCRIPTION
## Summary

Automated implementation for [#131](https://github.com/joshrotenberg/forza/issues/131) — chore: add merge fallback comment to workflow.rs.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| implement | succeeded | 83.7s | - |
| test | succeeded | 24.8s | - |

## Files changed

```
 src/workflow.rs | 6 ++++++
 1 file changed, 6 insertions(+)
```

Closes #131