### PR TITLE
fix: merge stage command — auto fallback, no --delete-branch

### DIFF
--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -156,7 +156,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::Review).optional(),
                 Stage::new(StageKind::OpenPr),
                 Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash --delete-branch"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
             ],
             ..Default::default()
         },
@@ -169,7 +169,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::Review).optional(),
                 Stage::new(StageKind::OpenPr),
                 Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash --delete-branch"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
             ],
             ..Default::default()
         },
@@ -180,7 +180,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::Test),
                 Stage::new(StageKind::OpenPr),
                 Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash --delete-branch"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
             ],
             ..Default::default()
         },
@@ -230,7 +230,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::FixCi),
                 Stage::new(StageKind::Merge)
                     .optional()
-                    .agentless("gh pr merge --auto --squash --delete-branch"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
             ],
             ..Default::default()
         },
@@ -240,7 +240,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::RevisePr),
                 Stage::new(StageKind::Merge)
                     .optional()
-                    .agentless("gh pr merge --auto --squash --delete-branch"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
             ],
             ..Default::default()
         },
@@ -251,7 +251,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::FixCi),
                 Stage::new(StageKind::Merge)
                     .optional()
-                    .agentless("gh pr merge --auto --squash --delete-branch"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
             ],
             ..Default::default()
         },
@@ -259,7 +259,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
             name: "pr-merge".into(),
             stages: vec![
                 Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash --delete-branch"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
             ],
             ..Default::default()
         },


### PR DESCRIPTION
## Summary

Fix the agentless merge stage so full auto pipeline works end-to-end.

- `--auto` first (queues for CI), direct merge fallback (no required checks)
- Drop `--delete-branch` (fails in worktrees, cleanup handles it)

Verified: issue #131 went through full pipeline (implement → test → open PR → merge) with zero human intervention.

## Test plan

- [x] Full end-to-end test: issue → PR → auto-merge succeeded
- [x] 89 tests pass, clippy clean