### PR TITLE
feat: reactive dispatch for condition routes, conflict detection

### DIFF
--- a/forza.toml
+++ b/forza.toml
@@ -115,13 +115,16 @@ concurrency = 2
 # These routes watch forza-owned PRs and automatically trigger fixes
 # when problems are detected. No manual labeling needed.
 
-# Auto-fix PRs with CI failures or merge conflicts.
-# Watches only forza-owned PRs (branches starting with "automation/").
+# Auto-maintain forza-owned PRs. Uses the reactive pr-maintenance workflow:
+# each poll cycle evaluates conditions and runs ONE action:
+#   - CI failing → fix CI
+#   - Review changes requested → address feedback
+#   - CI green + no objections → merge
 # After 3 failed attempts, applies forza:needs-human instead.
 [repos."joshrotenberg/forza".routes.auto-fix]
 type = "pr"
 condition = "ci_failing_or_conflicts"
-workflow = "pr-fix"
+workflow = "pr-maintenance"
 scope = "forza_owned"
 max_retries = 3
 concurrency = 2

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -1488,16 +1488,35 @@ pub async fn process_batch_for_repo(
                     }
                     PendingSubject::Pr(pr) => {
                         let pr_number = pr.number;
+                        let route_name_for_reactive = route_name.clone();
+                        let is_reactive = routes
+                            .get(&route_name)
+                            .and_then(|r| r.workflow.as_deref())
+                            .and_then(|wf| config.resolve_workflow(wf))
+                            .is_some_and(|t| t.mode == crate::workflow::WorkflowMode::Reactive);
                         join_set.spawn(async move {
-                            let result = process_pr_with_config(
-                                pr_number,
-                                &repo_owned,
-                                &routes_clone,
-                                &config_clone,
-                                &state_dir_owned,
-                                &repo_dir_owned,
-                            )
-                            .await;
+                            let result = if is_reactive {
+                                process_reactive_pr(
+                                    pr_number,
+                                    &repo_owned,
+                                    &route_name_for_reactive,
+                                    &routes_clone,
+                                    &config_clone,
+                                    &state_dir_owned,
+                                    &repo_dir_owned,
+                                )
+                                .await
+                            } else {
+                                process_pr_with_config(
+                                    pr_number,
+                                    &repo_owned,
+                                    &routes_clone,
+                                    &config_clone,
+                                    &state_dir_owned,
+                                    &repo_dir_owned,
+                                )
+                                .await
+                            };
                             (route_name, result)
                         });
                     }

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -202,6 +202,15 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
             name: "pr-maintenance".into(),
             mode: WorkflowMode::Reactive,
             stages: vec![
+                // Conflicts first — no point fixing CI on a conflicting branch.
+                Stage {
+                    condition: Some(
+                        "gh pr view --json mergeable --jq '.mergeable' 2>/dev/null \
+                         | grep -q CONFLICTING"
+                            .into(),
+                    ),
+                    ..Stage::new(StageKind::RevisePr)
+                },
                 Stage {
                     condition: Some("! gh pr checks --fail-fast 2>/dev/null".into()),
                     ..Stage::new(StageKind::FixCi)
@@ -221,7 +230,9 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                          | grep -q CHANGES_REQUESTED"
                             .into(),
                     ),
-                    ..Stage::new(StageKind::Merge).agentless("gh pr merge --squash --delete-branch")
+                    ..Stage::new(StageKind::Merge).agentless(
+                        "gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash",
+                    )
                 },
             ],
         },


### PR DESCRIPTION
## Summary

- Condition routes now correctly dispatch reactive vs linear workflows
- pr-maintenance workflow adds conflict detection (RevisePr stage before FixCi)
- Auto-fix route uses pr-maintenance (one action per poll cycle) instead of pr-fix (all at once)
- Merge command updated with auto/fallback pattern

## Test plan

- [x] 89 tests pass, clippy clean
- [x] Full end-to-end test passed (issue #131 → PR #132 → auto-merged)