### PR TITLE
chore: add SubjectType to re-exports in lib.rs docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,13 @@
 //! - **Platform** (`github`): Repository adapter for issues, PRs, comments, labels
 //! - **Domain** (`planner`, `workflow`): Orchestration logic
 //! - **Execution** (`executor`, `isolation`): Agent invocation and work isolation
+//!
+//! # Re-exports
+//!
+//! - [`RunnerConfig`]: top-level configuration loaded from `forza.toml`
+//! - [`SubjectType`]: distinguishes issue routes (`SubjectType::Issue`) from PR routes (`SubjectType::Pr`)
+//! - [`RouteOutcome`]: the final outcome recorded for a completed run
+//! - [`process_pr_with_config`]: entry point for reactive PR processing
 
 pub mod api;
 pub mod config;


### PR DESCRIPTION
## Summary

Automated implementation for [#135](https://github.com/joshrotenberg/forza/issues/135) — chore: add SubjectType to re-exports in lib.rs docs.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| implement | succeeded | 100.2s | - |
| test | succeeded | 33.2s | - |

## Files changed

```
 src/lib.rs | 7 +++++++
 1 file changed, 7 insertions(+)
```

Closes #135