### PR TITLE
chore: add Testing section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,29 @@ Each run records its final outcome in `RunRecord::outcome`. The `RouteOutcome` e
 `format_outcome` in `src/main.rs` renders these for the status display (e.g.,
 `pr_created (#42)`, `failed (stage: implement)`, `exhausted (3 retries)`).
 
+## Testing
+
+All tests are inline unit tests in `#[cfg(test)]` modules within the source files. There
+are no integration tests. Run the full suite with:
+
+```bash
+cargo test
+```
+
+Key test coverage by module:
+
+| Module | Focus |
+|--------|-------|
+| `src/config.rs` | Config parsing, validation, route resolution, effective skills |
+| `src/workflow.rs` | Stage/workflow construction, StageKind parsing |
+| `src/state.rs` | RunRecord serialization, RouteOutcome formatting |
+| `src/planner.rs` | Prompt assembly, breadcrumb instruction injection |
+| `src/orchestrator/mod.rs` | Stage execution logic, hook ordering |
+| `src/notifications.rs` | Notification formatting |
+
+Tests that require live GitHub API access or a running Claude process are not present;
+all tests are self-contained and use `tempfile` for filesystem fixtures where needed.
+
 ## Skill injection
 
 Skills are markdown files injected into the agent's context. Three levels of override


### PR DESCRIPTION
## Summary

Automated implementation for [#142](https://github.com/joshrotenberg/forza/issues/142) — chore: add Testing section to CLAUDE.md.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| implement | succeeded | 64.4s | - |
| test | succeeded | 27.4s | - |

## Files changed

```
 CLAUDE.md | 23 +++++++++++++++++++++++
 1 file changed, 23 insertions(+)
```

Closes #142