### PR TITLE
feat: label-driven runtime config overrides

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -475,6 +475,44 @@ pub struct CliOverrides {
     pub skills: Vec<String>,
 }
 
+/// Overrides parsed from `forza:*` labels on an issue or PR.
+///
+/// Supported label prefixes:
+/// - `forza:model:<name>` → override model (e.g., `forza:model:opus`)
+/// - `forza:skill:<name>` → inject skill (e.g., `forza:skill:rust`)
+///
+/// Override chain: CLI > label > stage > route > global.
+#[derive(Debug, Clone, Default)]
+pub struct LabelOverrides {
+    /// Model override from labels.
+    pub model: Option<String>,
+    /// Skill overrides from labels.
+    pub skills: Vec<String>,
+}
+
+impl LabelOverrides {
+    /// Parse overrides from a set of GitHub labels.
+    pub fn from_labels(labels: &[String]) -> Self {
+        let mut model = None;
+        let mut skills = Vec::new();
+
+        for label in labels {
+            if let Some(m) = label.strip_prefix("forza:model:") {
+                model = Some(m.to_string());
+            } else if let Some(s) = label.strip_prefix("forza:skill:") {
+                skills.push(s.to_string());
+            }
+        }
+
+        Self { model, skills }
+    }
+
+    /// Returns true if no overrides were found.
+    pub fn is_empty(&self) -> bool {
+        self.model.is_none() && self.skills.is_empty()
+    }
+}
+
 // ── Implementation ──────────────────────────────────────────────────
 
 impl RunnerConfig {
@@ -1520,5 +1558,46 @@ repo = "owner/repo"
         assert_eq!(config.security.authorization_level, "contributor");
         assert!(config.security.allows_push());
         assert!(!config.security.allows_merge());
+    }
+
+    #[test]
+    fn label_overrides_parses_model() {
+        let labels = vec![
+            "bug".to_string(),
+            "forza:ready".to_string(),
+            "forza:model:opus".to_string(),
+        ];
+        let overrides = LabelOverrides::from_labels(&labels);
+        assert_eq!(overrides.model.as_deref(), Some("opus"));
+        assert!(overrides.skills.is_empty());
+    }
+
+    #[test]
+    fn label_overrides_parses_skills() {
+        let labels = vec![
+            "forza:skill:rust".to_string(),
+            "forza:skill:testing".to_string(),
+        ];
+        let overrides = LabelOverrides::from_labels(&labels);
+        assert!(overrides.model.is_none());
+        assert_eq!(overrides.skills, vec!["rust", "testing"]);
+    }
+
+    #[test]
+    fn label_overrides_empty_for_no_forza_labels() {
+        let labels = vec!["bug".to_string(), "enhancement".to_string()];
+        let overrides = LabelOverrides::from_labels(&labels);
+        assert!(overrides.is_empty());
+    }
+
+    #[test]
+    fn label_overrides_model_and_skills_together() {
+        let labels = vec![
+            "forza:model:haiku".to_string(),
+            "forza:skill:rust".to_string(),
+        ];
+        let overrides = LabelOverrides::from_labels(&labels);
+        assert_eq!(overrides.model.as_deref(), Some("haiku"));
+        assert_eq!(overrides.skills, vec!["rust"]);
     }
 }

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -88,6 +88,17 @@ pub async fn process_issue_with_overrides(
         .ok_or_else(|| Error::Triage("no route matches this issue's labels".into()))?;
     info!(issue = number, route = route_name, "matched route");
 
+    // 2b. Parse label overrides (forza:model:*, forza:skill:*).
+    let label_overrides = crate::config::LabelOverrides::from_labels(&issue.labels);
+    if !label_overrides.is_empty() {
+        info!(
+            issue = number,
+            model = ?label_overrides.model,
+            skills = ?label_overrides.skills,
+            "label overrides detected"
+        );
+    }
+
     // 2a. Security gates (checked before acquiring the lease so rejected issues never get
     //     the in_progress label applied).
     if let Some(ref required) = config.security.require_label
@@ -406,10 +417,13 @@ pub async fn process_issue_with_overrides(
         let stage_model = cli_overrides
             .model
             .as_deref()
+            .or(label_overrides.model.as_deref())
             .or(planned_stage.model.as_deref())
             .or_else(|| config.effective_model(route));
         let stage_skills = if !cli_overrides.skills.is_empty() {
             cli_overrides.skills.as_slice()
+        } else if !label_overrides.skills.is_empty() {
+            label_overrides.skills.as_slice()
         } else {
             config.effective_skills(route, planned_stage.skills.as_deref())
         };
@@ -644,6 +658,17 @@ pub async fn process_pr_with_overrides(
     // 2. Match route.
     let (route_name, route) = RunnerConfig::match_pr_route_in(routes, &pr)
         .ok_or_else(|| Error::Triage("no route matches this PR's labels".into()))?;
+
+    // 2b. Parse label overrides.
+    let label_overrides = crate::config::LabelOverrides::from_labels(&pr.labels);
+    if !label_overrides.is_empty() {
+        info!(
+            pr = number,
+            model = ?label_overrides.model,
+            skills = ?label_overrides.skills,
+            "label overrides detected"
+        );
+    }
     info!(pr = number, route = route_name, "matched route");
 
     // 3. Acquire lease.
@@ -822,10 +847,13 @@ pub async fn process_pr_with_overrides(
         let stage_model = cli_overrides
             .model
             .as_deref()
+            .or(label_overrides.model.as_deref())
             .or(planned_stage.model.as_deref())
             .or_else(|| config.effective_model(route));
         let stage_skills = if !cli_overrides.skills.is_empty() {
             cli_overrides.skills.as_slice()
+        } else if !label_overrides.skills.is_empty() {
+            label_overrides.skills.as_slice()
         } else {
             config.effective_skills(route, planned_stage.skills.as_deref())
         };
@@ -1013,6 +1041,9 @@ pub async fn process_reactive_pr(
     let pr = gh.fetch_pr(repo, pr_number).await?;
     info!(pr = pr_number, title = pr.title, "fetched PR");
 
+    // 1a. Parse label overrides.
+    let label_overrides = crate::config::LabelOverrides::from_labels(&pr.labels);
+
     // 2. Resolve route and template.
     let route = routes
         .get(route_name)
@@ -1131,11 +1162,16 @@ pub async fn process_reactive_pr(
                 },
             );
         } else {
-            let stage_model = planned
+            let stage_model = label_overrides
                 .model
                 .as_deref()
+                .or(planned.model.as_deref())
                 .or_else(|| config.effective_model(route));
-            let stage_skills = config.effective_skills(route, planned.skills.as_deref());
+            let stage_skills = if !label_overrides.skills.is_empty() {
+                label_overrides.skills.as_slice()
+            } else {
+                config.effective_skills(route, planned.skills.as_deref())
+            };
             let stage_mcp = config.effective_mcp_config(route, planned.mcp_config.as_deref());
             let stage_syspr = config.effective_append_system_prompt();
             let mut stage_adapter = ClaudeAdapter::new();


### PR DESCRIPTION
## Summary

Parse `forza:model:*` and `forza:skill:*` labels from issues/PRs to override runtime config without CLI flags. Fits the "labels are the API" philosophy.

Override chain: CLI > label > stage > route > global.

Applied in all three execution paths (issue, PR, reactive PR).

## Test plan

- [x] 93 unit tests pass (4 new for LabelOverrides parsing)
- [x] cargo clippy clean

Closes #50