### PR TITLE
fix: log warning on breadcrumb read failures instead of silent swallow

### DIFF
--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -469,13 +469,22 @@ pub async fn process_issue_with_overrides(
                         .join("breadcrumbs")
                         .join(&run_id)
                         .join(format!("{}.md", planned_stage.kind_name()));
-                    if let Ok(content) = std::fs::read_to_string(&crumb_path) {
-                        info!(
-                            issue = number,
-                            stage = planned_stage.kind_name(),
-                            "loaded breadcrumb for next stage"
-                        );
-                        pending_breadcrumb = Some(content);
+                    match std::fs::read_to_string(&crumb_path) {
+                        Ok(content) => {
+                            info!(
+                                issue = number,
+                                stage = planned_stage.kind_name(),
+                                "loaded breadcrumb for next stage"
+                            );
+                            pending_breadcrumb = Some(content);
+                        }
+                        Err(e) => {
+                            warn!(
+                                path = %crumb_path.display(),
+                                error = %e,
+                                "failed to read breadcrumb; next stage will run without prior context"
+                            );
+                        }
                     }
                 }
                 record.record_stage(planned_stage.kind, status, result);
@@ -898,13 +907,22 @@ pub async fn process_pr_with_overrides(
                         .join("breadcrumbs")
                         .join(&run_id)
                         .join(format!("{}.md", planned_stage.kind_name()));
-                    if let Ok(content) = std::fs::read_to_string(&crumb_path) {
-                        info!(
-                            pr = number,
-                            stage = planned_stage.kind_name(),
-                            "loaded breadcrumb for next stage"
-                        );
-                        pending_breadcrumb = Some(content);
+                    match std::fs::read_to_string(&crumb_path) {
+                        Ok(content) => {
+                            info!(
+                                pr = number,
+                                stage = planned_stage.kind_name(),
+                                "loaded breadcrumb for next stage"
+                            );
+                            pending_breadcrumb = Some(content);
+                        }
+                        Err(e) => {
+                            warn!(
+                                path = %crumb_path.display(),
+                                error = %e,
+                                "failed to read breadcrumb; next stage will run without prior context"
+                            );
+                        }
                     }
                 }
                 record.record_stage(planned_stage.kind, status, result);


### PR DESCRIPTION
## Summary

Automated implementation for [#161](https://github.com/joshrotenberg/forza/issues/161) — fix: log warning on breadcrumb read failures instead of silent swallow.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 41.6s | - |
| implement | succeeded | 44.3s | - |
| test | succeeded | 25.5s | - |
| review | succeeded | 42.4s | - |

## Files changed

```
 src/orchestrator/mod.rs | 46 ++++++++++++++++++++++++++++++++--------------
 1 file changed, 32 insertions(+), 14 deletions(-)
```

## Plan

# Plan stage context

## Issue
Fix silent swallowing of breadcrumb read failures (invalid UTF-8, permissions, etc.) by logging at `warn!` level instead.

## Key findings

### File to change
`src/orchestrator/mod.rs` — one change only.

### Two identical patterns to fix (both in the same file)
1. **Issue workflow** (~line 472): inside `run_issue()`, after a stage completes successfully and there is a successor stage.
2. **PR workflow** (~line 901): inside `run_pr()`, same pattern.

Both currently use:
```rust
if let Ok(content) = std::fs::read_to_string(&crumb_path) {
    info!(..., "loaded breadcrumb for next stage");
    pending_breadcrumb = Some(content);
}
```

### Fix pattern
Replace each with a `match` that logs `warn!` with `path` and `error` fields on `Err`:
```rust
match std::fs::read_to_string(&crumb_path) {
    Ok(content) => {
        info!(..., "loaded breadcrumb for next stage");
        pending_breadcrumb = Some(content);
    }
    Err(e) => {
        warn!(
            path = %crumb_path.display(),
            error = %e,
            "failed to read breadcrumb; next stage will run without prior context"
        );
    }
}
```

### What NOT to change
`src/orchestrator/helpers.rs` lines 140–141 use `unwrap_or_default()` for plan/review crumbs when building the PR body. Missing files there are expected (e.g., stages may not have run), so silent fallback is correct.

## Commit message
`fix(orchestrator): log warning on breadcrumb read failures closes #161`


## Review

## Context from review stage

### Verdict: PASS

The fix for issue #161 is correct and complete.

### Key findings

- Two `if let Ok(...)` blocks in `src/orchestrator/mod.rs` (issue workflow ~line 472, PR workflow ~line 907) were converted to `match` expressions adding `warn!` logging on breadcrumb read failure.
- The `Ok` arm is structurally identical to the original; no behavior change on success.
- `warn!` was already imported; structured fields (`path`, `error`) match tracing conventions used throughout the file.
- Log message is actionable: "failed to read breadcrumb; next stage will run without prior context".
- `helpers.rs` breadcrumb reads (`unwrap_or_default()`) were intentionally left as silent fallbacks — appropriate since they feed PR body construction where empty string is a valid default.
- 93 tests pass. No new tests needed (logging-only change, no testable state change).

### For open_pr stage

- Branch: `automation/161-fix-log-warning-on-breadcrumb-read-failu`
- Commit: `fix(orchestrator): log warning on breadcrumb read failures closes #161`
- No source file modifications outstanding; only `.review_breadcrumb.md` and this breadcrumb file were written.
- PR is ready to open against `main`.


Closes #161