### PR TITLE
fix: add logging for condition route PR discovery

### DIFF
--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -1478,7 +1478,14 @@ pub async fn process_batch_for_repo(
 
     if !condition_routes.is_empty() {
         let all_prs = match gh.fetch_all_open_prs(repo, 100).await {
-            Ok(prs) => prs,
+            Ok(prs) => {
+                info!(
+                    repo = repo,
+                    count = prs.len(),
+                    "fetched open PRs for condition route evaluation"
+                );
+                prs
+            }
             Err(e) => {
                 warn!(error = %e, "failed to fetch open PRs for condition routes");
                 vec![]
@@ -1494,6 +1501,7 @@ pub async fn process_batch_for_repo(
 
         for (route_name, route) in &condition_routes {
             let condition = route.condition.as_ref().unwrap();
+            let mut matched: usize = 0;
             for pr in &all_prs {
                 // Skip PRs already in progress or marked needs-human.
                 if pr
@@ -1501,6 +1509,11 @@ pub async fn process_batch_for_repo(
                     .iter()
                     .any(|l| l == &config.global.in_progress_label || l == "forza:needs-human")
                 {
+                    tracing::debug!(
+                        pr = pr.number,
+                        route = route_name,
+                        "skipping PR: in-progress or needs-human label"
+                    );
                     continue;
                 }
 
@@ -1508,10 +1521,21 @@ pub async fn process_batch_for_repo(
                 if route.scope == crate::config::ConditionScope::ForzaOwned
                     && !pr.head_branch.starts_with(branch_prefix)
                 {
+                    tracing::debug!(
+                        pr = pr.number,
+                        route = route_name,
+                        "skipping PR: outside forza_owned scope"
+                    );
                     continue;
                 }
 
                 if !condition.matches(pr) {
+                    tracing::debug!(
+                        pr = pr.number,
+                        route = route_name,
+                        condition = ?condition,
+                        "skipping PR: condition not matched"
+                    );
                     continue;
                 }
 
@@ -1551,7 +1575,14 @@ pub async fn process_batch_for_repo(
                     "condition matched, queuing PR"
                 );
                 pending.push_back((route_name.to_string(), PendingSubject::Pr(pr.clone())));
+                matched += 1;
             }
+            info!(
+                repo = repo,
+                route = route_name,
+                count = matched,
+                "found eligible PRs for condition route"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

Automated implementation for [#176](https://github.com/joshrotenberg/forza/issues/176) — fix: add logging for condition route PR discovery.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 45.8s | - |
| implement | succeeded | 52.7s | - |
| test | succeeded | 30.5s | - |
| review | succeeded | 85.7s | - |

## Files changed

```
 src/orchestrator/mod.rs | 33 ++++++++++++++++++++++++++++++++-
 1 file changed, 32 insertions(+), 1 deletion(-)
```

## Plan

# Context from plan stage

## Key findings

The condition route discovery block is in `src/orchestrator/mod.rs` at approximately lines 1472–1555, inside `process_batch_for_repo`.

**What already exists:**
- After fetching `all_prs`, there is no log of the count.
- Inside the per-PR loop there are zero debug-level skip logs — the three `continue` branches (in-progress label, scope filter, condition not matched) are completely silent.
- After the loop there is a single `info!` for individual matched PRs (`"condition matched, queuing PR"`) but no per-route summary count.
- The retry-budget exhaustion path already has a `warn!` — that is fine and should not be changed.

**What label routes do (the target pattern):**
- Log `info!(repo, route, count, "found eligible PRs")` once per route after collecting actionable PRs (lines 1456–1461).

## Exact change needed (one file only)

`src/orchestrator/mod.rs` — inside the `if !condition_routes.is_empty()` block:

1. **After** the `fetch_all_open_prs` success arm, add:
   ```rust
   info!(repo = repo, count = all_prs.len(), "fetched open PRs for condition route evaluation");
   ```

2. **Skip: in-progress/needs-human** (first `continue` in per-PR loop):
   ```rust
   tracing::debug!(pr = pr.number, route = route_name, "skipping PR: in-progress or needs-human label");
   ```

3. **Skip: scope filter** (second `continue`):
   ```rust
   tracing::debug!(pr = pr.number, route = route_name, "skipping PR: outside forza_owned scope");
   ```

4. **Skip: condition not matched** (third `continue` after `!condition.matches(pr)`):
   ```rust
   tracing::debug!(pr = pr.number, route = route_name, condition = ?condition, "skipping PR: condition not matched");
   ```

5. **Per-route summary** — introduce a `matched` counter per route loop and after the inner `for pr in &all_prs` loop, add:
   ```rust
   info!(repo = repo, route = route_name, count = matched, "found eligible PRs for condition route");
   ```

## No other files need changes.

The existing `"condition matched, queuing PR"` individual info log (line ~1547) should be kept as-is — it is per-PR detail that complements the new summary.


## Review

## Context from review stage

### Verdict: PASS

### What was reviewed

Commit `f1ff69b` — `fix(orchestrator): add logging for condition route PR discovery closes #176`

Single file changed: `src/orchestrator/mod.rs` (+32 lines, -1 line), all within `process_batch_for_repo`.

### Findings

The diff is purely additive logging — no logic changes. Six log statements added to the condition route PR discovery path:

1. `info!` after `fetch_all_open_prs` succeeds — records `repo` and `count` (line 1482)
2. `debug!` for each skip: in-progress/needs-human label (line 1512), outside forza_owned scope (line 1524), condition not matched (line 1533) — all include `pr` number and `route` name
3. `info!` when a PR is queued (already existed pre-patch at line 1571)
4. `info!` per-route summary with `matched` count after the inner loop (line 1580)

A `matched: usize` counter was introduced to support the per-route summary log.

### Test coverage

No new tests added. Acceptable: the change is observability-only. Existing tests in `#[cfg(test)]` cover scheduling logic but not `process_batch_for_repo` end-to-end (which requires a live `GitHubClient`). No test gaps introduced.

### Style

Log field names (`repo`, `route`, `pr`, `count`, `condition`) are consistent with surrounding code. Mix of `info!` / `debug!` / `tracing::debug!` mirrors existing style in the same function (both forms are used elsewhere).

### For open_pr stage

- Branch is `automation/176-fix-add-logging-for-condition-route-pr-d`
- Commit message: `fix(orchestrator): add logging for condition route PR discovery closes #176`
- No follow-up changes needed; ready to open PR against `main`


Closes #176