### PR TITLE
fix: handle mergeable=UNKNOWN in condition route matching

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -281,10 +281,21 @@ impl RouteCondition {
     /// Evaluate whether this condition holds for the given PR.
     pub fn matches(&self, pr: &crate::github::PrCandidate) -> bool {
         let ci_failing = pr.checks_passing == Some(false);
-        if let Some(m) = pr.mergeable.as_deref() && m != "MERGEABLE" && m != "CONFLICTING" {
-            debug!(pr = pr.number, mergeable = m, "mergeability not yet resolved, skipping cycle");
+        if let Some(m) = pr.mergeable.as_deref()
+            && m != "MERGEABLE"
+            && m != "CONFLICTING"
+        {
+            debug!(
+                pr = pr.number,
+                mergeable = m,
+                "mergeability not yet resolved, skipping cycle"
+            );
         } else if pr.mergeable.is_none() {
-            debug!(pr = pr.number, mergeable = "None", "mergeability not yet resolved, skipping cycle");
+            debug!(
+                pr = pr.number,
+                mergeable = "None",
+                "mergeability not yet resolved, skipping cycle"
+            );
         }
         let has_conflicts = pr.mergeable.as_deref() == Some("CONFLICTING");
         let approved = pr.review_decision.as_deref() == Some("APPROVED");


### PR DESCRIPTION
## Summary

Automated implementation for [#177](https://github.com/joshrotenberg/forza/issues/177) — fix: handle mergeable=UNKNOWN in condition route matching.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 81.7s | - |
| implement | succeeded | 88.9s | - |
| test | succeeded | 37.0s | - |
| review | succeeded | 70.4s | - |

## Files changed

```
 src/config.rs | 29 +++++++++++++++++++++++++++++
 1 file changed, 29 insertions(+)
```

## Plan

# Context from plan stage — issue #177

## Problem

`RouteCondition::matches` in `src/config.rs` computes:
```rust
let has_conflicts = pr.mergeable.as_deref() == Some("CONFLICTING");
```
When `mergeable` is `None` or `"UNKNOWN"` (GitHub's transient state while computing mergeability), `has_conflicts` is already `false` and the PR is silently skipped. The functional behavior (soft retry via next poll cycle) is correct, but there is no log output explaining why the condition didn't match.

## Key findings

- `RouteCondition::matches` is in `src/config.rs` at line ~280
- The method takes `&PrCandidate` (defined in `src/github/mod.rs`) and returns `bool`
- `PrCandidate::mergeable` is `Option<String>` — possible values: `"MERGEABLE"`, `"CONFLICTING"`, `"UNKNOWN"`, `None`
- `config.rs` currently has no `tracing` import
- The orchestrator calls `condition.matches(pr)` at `src/orchestrator/mod.rs:1514` and simply `continue`s on `false` — no retry budget is consumed
- The polling loop naturally retries on the next cycle, so `UNKNOWN` → skip-cycle is already correct semantically

## Decision

Treat `UNKNOWN`/`None` as a **soft skip** (correct behavior already). The only change needed is:
1. Add `tracing` to `use` imports in `src/config.rs`
2. Before computing `has_conflicts`, check if `mergeable` is `None` or `"UNKNOWN"` and emit `debug!` with PR number and raw value
3. Add unit tests for `UNKNOWN` (should not match `has_conflicts` or `ci_failing_or_conflicts`) and `None` (same)

## Exact change location

`src/config.rs`, function `RouteCondition::matches`, lines ~280–292. Add `use tracing::debug;` near the top of the file (other imports at lines 6–13).

## Commit message
`fix(config): log debug when mergeable is UNKNOWN or None closes #177`


## Review

# Context from review stage — issue #177

## Verdict: PASS

## What was reviewed

Changes are confined to `src/config.rs`:
- `use tracing::debug;` import added (line 12)
- `RouteCondition::matches` updated to log debug when `mergeable` is neither `MERGEABLE` nor `CONFLICTING` (covers `UNKNOWN` and any other transient state), and separately when `mergeable` is `None`
- Two new assertions appended to `condition_matches_ci_failing` test

## Key findings

- **Correctness**: The fix is correct. `has_conflicts` is still computed as `pr.mergeable.as_deref() == Some("CONFLICTING")`, so `UNKNOWN` and `None` both yield `has_conflicts = false`. The debug log is purely informational and does not alter control flow.
- **Tests**: New test cases (lines 1602–1611) verify `HasConflicts` and `CiFailingOrConflicts` return false for both `UNKNOWN` and `None` mergeability. All 97 tests pass.
- **Style**: Matches surrounding code. If-let chain uses Rust 2024 style. `debug!` macro call uses structured field syntax consistent with rest of codebase.
- **Minor notes**: `ApprovedAndGreen` with `UNKNOWN` mergeable is untested but behaves reasonably (not treated as conflicting); the debug log documents the transient state clearly.

## For the next stage (open_pr)

- Branch: `automation/177-fix-handle-mergeable-unknown-in-conditio`
- Commit: `fix(config): log debug when mergeable is UNKNOWN or None closes #177`
- All checks pass; no source changes needed
- PR should reference issue #177 for auto-close


Closes #177