### PR TITLE
feat: allow REST API server to run alongside watch mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,15 @@ struct WatchArgs {
     /// Repository directory.
     #[arg(long)]
     repo_dir: Option<PathBuf>,
+    /// Also start the REST API server alongside the watch loop.
+    #[arg(long, default_value = "false")]
+    serve_api: bool,
+    /// Host address for the REST API server (default: 127.0.0.1).
+    #[arg(long)]
+    api_host: Option<String>,
+    /// Port for the REST API server (default: 8080).
+    #[arg(long)]
+    api_port: Option<u16>,
 }
 
 #[derive(Debug, Parser)]
@@ -744,6 +753,51 @@ async fn cmd_watch(
         tokio::signal::ctrl_c().await.ok();
         let _ = cancel_tx.send(true);
     });
+
+    // Optionally spawn the REST API server alongside the poll loops.
+    if args.serve_api {
+        use std::sync::Arc;
+        let host = args.api_host.as_deref().unwrap_or("127.0.0.1").to_string();
+        let port = args.api_port.unwrap_or(8080);
+        let addr: std::net::SocketAddr = match format!("{host}:{port}").parse() {
+            Ok(a) => a,
+            Err(e) => {
+                eprintln!("error: invalid API address {host}:{port}: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let state = Arc::new(forza::api::AppState {
+            config: config.clone(),
+            state_dir: sd.clone(),
+            gh: gh.clone(),
+            git: git.clone(),
+        });
+        let router = forza::api::router(state);
+        match tokio::net::TcpListener::bind(addr).await {
+            Ok(listener) => {
+                info!(address = %addr, "REST API server listening");
+                let mut api_cancel_rx = cancel_rx.clone();
+                tokio::spawn(async move {
+                    axum::serve(listener, router)
+                        .with_graceful_shutdown(async move {
+                            loop {
+                                if api_cancel_rx.changed().await.is_err() || *api_cancel_rx.borrow()
+                                {
+                                    break;
+                                }
+                            }
+                        })
+                        .await
+                        .ok();
+                    info!("REST API server stopped");
+                });
+            }
+            Err(e) => {
+                eprintln!("error: could not bind API server to {addr}: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
 
     // Spawn one independent poll-loop task per repo.
     let mut handles = Vec::new();


### PR DESCRIPTION
## Summary

Automated implementation for [#182](https://github.com/joshrotenberg/forza/issues/182) — feat: allow REST API server to run alongside watch mode.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 121.8s | - |
| implement | succeeded | 61.0s | - |
| test | succeeded | 23.0s | - |
| review | succeeded | 66.8s | - |

## Files changed

```
 src/main.rs | 54 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 54 insertions(+)
```

## Plan

## Context from plan stage

### Issue
#182: Add `--serve-api` flag to `watch` command so the REST API server runs alongside the repo poll loops.

### Key findings

**Only one file needs changes: `src/main.rs`**

`src/api.rs` requires no modifications — `AppState` (lines 23-29) is already a public struct with `Arc`-compatible fields, and `router(state)` (line 164) is already a public function. The API layer is fully reusable as-is.

### Current structures (main.rs)

- `WatchArgs` struct: lines 123-134. Currently has `interval`, `route`, `repo_dir` only.
- `ServeArgs` struct: lines 171-182. Has `host: String` (default "127.0.0.1"), `port: u16` (default 8080), `repo_dir`.
- `cmd_watch`: lines 689-814. Creates `tokio::sync::watch::channel(false)` at line 727, spawns signal handlers, then spawns one task per configured repo.
- `cmd_serve`: lines 1103-1175. Creates `Arc<AppState>`, calls `forza::api::router(state)`, binds TCP, calls `axum::serve().with_graceful_shutdown()`.

### Cancellation pattern
Both commands use identical patterns: `tokio::sync::watch::channel(false)`, cloned `cancel_tx` for SIGTERM and Ctrl-C handlers, and `cancel_rx.borrow()` / `with_graceful_shutdown` to stop gracefully. The same `cancel_tx` clone can drive the API server's shutdown.

### State directory
`cmd_watch` derives the state dir via `config.state_dir()` (called at lines ~697-700). This same value is passed to `AppState::state_dir` in `cmd_serve`.

### Implementation steps for implement stage

1. Add three fields to `WatchArgs`:
   ```rust
   #[arg(long, default_value = "false")]
   serve_api: bool,
   #[arg(long)]
   api_host: Option<String>,
   #[arg(long)]
   api_port: Option<u16>,
   ```

2. In `cmd_watch`, after the cancellation channel and signal handlers are set up (around line 750), add a conditional block:
   - If `args.serve_api` is true, resolve host (default "127.0.0.1") and port (default 8080)
   - Build `Arc<AppState> { config: config.clone(), state_dir: sd.clone(), gh: Arc::clone(&gh), git: Arc::clone(&git) }`
   - Call `forza::api::router(state)` to get the axum router
   - Bind `TcpListener::bind(addr).await`
   - Clone `cancel_rx` for the shutdown future
   - `tokio::spawn(async move { axum::serve(listener, router).with_graceful_shutdown(async move { loop { if *cancel_rx.borrow() { break; } cancel_rx.changed().await.ok(); } }).await })`
   - Push the handle into the `handles` vec (or a separate handle)

3. The existing `for handle in handles { handle.await }` at lines 808-810 naturally waits for the API server task too if its handle is included.

### Commit message
`feat(watch): add --serve-api flag to run REST API server alongside watch mode closes #182`


## Review

## Context from review stage

### Verdict: PASS

The implementation is correct and ready for PR creation.

### What was changed
Single commit on `src/main.rs` only:
- Added `serve_api: bool`, `api_host: Option<String>`, `api_port: Option<u16>` to `WatchArgs`
- Added a block in `cmd_watch` (after signal handlers, before poll-loop spawning) that, when `--serve-api` is set, builds a `forza::api::AppState`, calls `forza::api::router`, binds a `TcpListener`, and spawns `axum::serve` with graceful shutdown tied to the existing `cancel_rx` watch channel

### Minor findings (non-blocking)
- `#[arg(long, default_value = "false")]` on the bool flag is redundant (clap defaults bools to false)
- `api_host`/`api_port` use `Option<T>` + manual defaults; `ServeArgs` uses inline `default_value` — style inconsistency, not a bug

### For open_pr stage
- Commit message: `feat(watch): add --serve-api flag to run REST API server alongside watch mode closes #182`
- Branch: `automation/182-feat-allow-rest-api-server-to-run-alongs`
- No additional changes needed before opening the PR


Closes #182