### PR TITLE
fix(orchestrator): add in-progress label and rebase instructions for reactive PRs

### DIFF
--- a/src/orchestrator/helpers.rs
+++ b/src/orchestrator/helpers.rs
@@ -74,15 +74,19 @@ pub(super) fn generate_reactive_pr_prompt(
             breadcrumb = breadcrumb,
         ),
         StageKind::RevisePr => format!(
-            "Address the review feedback for PR #{number}: {title}\n\n\
+            "Revise PR #{number}: {title}\n\n\
              ## Steps\n\n\
-             1. Run `gh pr view {number} --json reviews` to see review comments.\n\
-             2. Address each CHANGES_REQUESTED comment.\n\
-             3. Commit the revisions and push (`git push`).\n\n\
-             Branch: `{branch}`{breadcrumb}",
+             1. Check for merge conflicts: `git fetch origin && git rebase origin/{base_branch}`\n\
+             2. If the rebase has conflicts, resolve them. Read the conflicting files, \
+                understand both sides, and produce the correct merged result.\n\
+             3. Check for review feedback: `gh pr view {number} --json reviews`\n\
+             4. Address any CHANGES_REQUESTED comments.\n\
+             5. Commit any changes and push: `git push --force-with-lease origin {branch}`\n\n\
+             Branch: `{branch}` -> `{base_branch}`{breadcrumb}",
             number = pr.number,
             title = pr.title,
             branch = pr.head_branch,
+            base_branch = pr.base_branch,
             breadcrumb = breadcrumb,
         ),
         _ => format!(

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -1087,7 +1087,12 @@ pub async fn process_reactive_pr(
     let pr = gh.fetch_pr(repo, pr_number).await?;
     info!(pr = pr_number, title = pr.title, "fetched PR");
 
-    // 1a. Parse label overrides.
+    // 1a. Acquire in-progress lease.
+    let _ = gh
+        .add_pr_label(repo, pr_number, &config.global.in_progress_label)
+        .await;
+
+    // 1b. Parse label overrides.
     let label_overrides = crate::config::LabelOverrides::from_labels(&pr.labels);
 
     // 2. Resolve route and template.
@@ -1312,6 +1317,11 @@ pub async fn process_reactive_pr(
     record.finish(final_status);
     state::save_run(&record, state_dir)?;
     info!(pr = pr_number, run_id = record.run_id, status = ?final_status, outcome = ?record.outcome, "reactive PR run complete");
+
+    // Release in-progress lease.
+    let _ = gh
+        .remove_pr_label(repo, pr_number, &config.global.in_progress_label)
+        .await;
 
     // Fire notifications (best-effort).
     if let Some(notif_config) = config.global.notifications.as_ref() {


### PR DESCRIPTION
## Summary

- Apply `forza:in-progress` label during `process_reactive_pr` to prevent re-queuing and provide visibility that forza is working on a PR
- Update the reactive `RevisePr` prompt to include rebase/conflict resolution instructions — previously it only addressed review feedback, causing the agent to report success without resolving merge conflicts

## Context

Discovered during live testing: PRs #173 and #174 had merge conflicts, the `auto-fix` condition route matched and ran `RevisePr`, which succeeded without doing anything because the prompt didn't mention rebasing. Additionally, without the in-progress label, condition routes could re-queue PRs that were already being processed.

## Test plan

- [x] `cargo test --lib --all-features` (97 passed)
- [x] `cargo clippy --all-targets --all-features` (clean)
- [ ] Verify reactive PRs get `forza:in-progress` label during processing
- [ ] Verify `RevisePr` resolves merge conflicts on conflicting PRs

Closes #187, closes #188