### PR TITLE
feat: auto-merge forza-owned PRs without requiring review approval

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,8 @@ Multi-repo config uses `[repos."owner/name".routes.name]`. Each route needs a `t
 [repos."owner/name".routes.auto-fix]
 type       = "pr"
 condition  = "ci_failing_or_conflicts"   # RouteCondition: ci_failing | has_conflicts |
-                                         #   ci_failing_or_conflicts | approved_and_green
+                                         #   ci_failing_or_conflicts | approved_and_green |
+                                         #   ci_green_no_objections
 workflow   = "pr-fix"
 scope      = "forza_owned"               # forza_owned (default) | all
 max_retries = 3                          # applies forza:needs-human after N failures
@@ -205,7 +206,7 @@ skills win if present, otherwise route skills, otherwise global.
 - **Full stage pipeline**: `triage`, `clarify`, `plan`, `implement`, `test`, `review`, `open_pr`, `revise_pr`, `fix_ci`, `merge`, `research`, `comment`
 - **Workflow modes**: `linear` (sequential) and `reactive` (condition-evaluated dispatch loop)
 - **Label routes**: fire when a GitHub label is applied to an issue or PR
-- **Condition routes**: fire automatically on PR state (`ci_failing`, `has_conflicts`, `ci_failing_or_conflicts`, `approved_and_green`)
+- **Condition routes**: fire automatically on PR state (`ci_failing`, `has_conflicts`, `ci_failing_or_conflicts`, `approved_and_green`, `ci_green_no_objections`)
 - **Agentless stages**: run shell commands directly (formatting, linting, scaffolding)
 - **Conditional stages**: gate stage execution via shell command exit code; pair with `optional = true` to skip cleanly
 - **Per-stage hooks**: `pre`, `post`, `finally` hooks keyed by `StageKind` name

--- a/forza.toml
+++ b/forza.toml
@@ -129,3 +129,12 @@ scope = "forza_owned"
 max_retries = 3
 concurrency = 2
 poll_interval = 60
+
+[repos."joshrotenberg/forza".routes.auto-merge]
+type = "pr"
+condition = "ci_green_no_objections"
+workflow = "pr-maintenance"
+scope = "forza_owned"
+max_retries = 3
+concurrency = 2
+poll_interval = 60

--- a/src/config.rs
+++ b/src/config.rs
@@ -275,6 +275,9 @@ pub enum RouteCondition {
     CiFailingOrConflicts,
     /// The PR is approved and CI is green.
     ApprovedAndGreen,
+    /// CI is green, no conflicts, and no CHANGES_REQUESTED review decision.
+    /// Does not require an explicit APPROVED decision — branch protection is the real gate.
+    CiGreenNoObjections,
 }
 
 impl RouteCondition {
@@ -299,6 +302,7 @@ impl RouteCondition {
         }
         let has_conflicts = pr.mergeable.as_deref() == Some("CONFLICTING");
         let approved = pr.review_decision.as_deref() == Some("APPROVED");
+        let changes_requested = pr.review_decision.as_deref() == Some("CHANGES_REQUESTED");
         let ci_green = pr.checks_passing == Some(true);
 
         match self {
@@ -306,6 +310,7 @@ impl RouteCondition {
             RouteCondition::HasConflicts => has_conflicts,
             RouteCondition::CiFailingOrConflicts => ci_failing || has_conflicts,
             RouteCondition::ApprovedAndGreen => approved && ci_green && !has_conflicts,
+            RouteCondition::CiGreenNoObjections => ci_green && !has_conflicts && !changes_requested,
         }
     }
 }
@@ -1609,6 +1614,21 @@ max_retries = 3
         pr.mergeable = None;
         assert!(!RouteCondition::HasConflicts.matches(&pr));
         assert!(!RouteCondition::CiFailingOrConflicts.matches(&pr));
+
+        // CiGreenNoObjections: CI green + no review decision → matches
+        pr.mergeable = Some("MERGEABLE".into());
+        pr.checks_passing = Some(true);
+        pr.review_decision = None;
+        assert!(RouteCondition::CiGreenNoObjections.matches(&pr));
+
+        // CiGreenNoObjections: CI green + CHANGES_REQUESTED → does not match
+        pr.review_decision = Some("CHANGES_REQUESTED".into());
+        assert!(!RouteCondition::CiGreenNoObjections.matches(&pr));
+
+        // CiGreenNoObjections: CI failing + no review decision → does not match
+        pr.review_decision = None;
+        pr.checks_passing = Some(false);
+        assert!(!RouteCondition::CiGreenNoObjections.matches(&pr));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Automated implementation for [#191](https://github.com/joshrotenberg/forza/issues/191) — feat: auto-merge forza-owned PRs without requiring review approval.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 179.8s | - |
| implement | succeeded | 88.2s | - |
| test | succeeded | 30.0s | - |
| review | succeeded | 64.8s | - |

## Files changed

```
 CLAUDE.md     |  5 +++--
 forza.toml    |  9 +++++++++
 src/config.rs | 20 ++++++++++++++++++++
 3 files changed, 32 insertions(+), 2 deletions(-)
```

## Plan

# Context from plan stage

## Root cause

The `auto-fix` route in `forza.toml` uses `condition = "ci_failing_or_conflicts"`, which
only fires when something is wrong. Once CI is fixed and conflicts are resolved, no route
fires anymore — so the merge stage in `pr-maintenance` is never reached. The merge stage
in the workflow template already has the correct shell condition (CI passing + no
CHANGES_REQUESTED), but the route never triggers it.

## Decision: add CiGreenNoObjections route condition

Add `RouteCondition::CiGreenNoObjections` (serializes as `"ci_green_no_objections"`) to
`src/config.rs`. Matches when:
- `ci_green = pr.checks_passing == Some(true)`
- `!has_conflicts` (mergeable != CONFLICTING)
- `review_decision != CHANGES_REQUESTED`

This is intentionally weaker than `ApprovedAndGreen` — it does not require an explicit
`APPROVED` decision. Branch protection rules remain the real safety gate.

## Files to change

1. **`src/config.rs`**
   - Add `CiGreenNoObjections` variant to `RouteCondition` enum (after `ApprovedAndGreen`,
     around line 277)
   - Add match arm in `matches()` (around line 308):
     `RouteCondition::CiGreenNoObjections => ci_green && !has_conflicts && !changes_requested`
   - Add `let changes_requested = pr.review_decision.as_deref() == Some("CHANGES_REQUESTED");`
     variable (near line 301 where `approved` is computed)
   - Add test cases in `route_condition_matches` test (around line 1586):
     - CI green + no review decision → matches
     - CI green + CHANGES_REQUESTED → does not match
     - CI failing + no review decision → does not match

2. **`forza.toml`**
   - Add new `auto-merge` route after the `auto-fix` route (after line 131):
     ```toml
     [repos."joshrotenberg/forza".routes.auto-merge]
     type = "pr"
     condition = "ci_green_no_objections"
     workflow = "pr-maintenance"
     scope = "forza_owned"
     max_retries = 3
     concurrency = 2
     poll_interval = 60
     ```

3. **`CLAUDE.md`**
   - Add `ci_green_no_objections` to the condition route table in the Route-based config
     section (the `RouteCondition` comment line listing variants)

## Key constraint

`changes_requested` variable must be added to `matches()` alongside `approved` — both
use `pr.review_decision`, so they can share the same field read.


## Review

## Context from review stage

### Verdict: PASS

Implementation is correct and ready for PR.

### Key findings

- `CiGreenNoObjections` added to `RouteCondition` enum in `src/config.rs`
- Serde `rename_all = "snake_case"` handles TOML deserialization of `ci_green_no_objections` automatically — no manual parsing needed
- Match logic: `ci_green && !has_conflicts && !changes_requested` — accurate
- 3 unit tests added (None decision matches, CHANGES_REQUESTED blocks, CI failing blocks)
- Two untested edge cases flagged as low-severity: APPROVED decision (should match — logic correct) and CONFLICTING mergeable (should not match — logic correct)
- `forza.toml` route config valid; CLAUDE.md updated in both locations

### For open_pr

- No source file modifications in this stage
- Issue to close: #191
- Commit: `feat(config): add CiGreenNoObjections route condition for auto-merge closes #191` (006349c)
- No breaking changes, no migrations needed


Closes #191