### PR TITLE
feat: add --no-gate flag to bypass gate_label requirement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,9 @@ struct RunArgs {
     /// Repository directory.
     #[arg(long)]
     repo_dir: Option<PathBuf>,
+    /// Bypass the gate_label requirement and process all matching issues immediately.
+    #[arg(long, default_value = "false")]
+    no_gate: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -140,6 +143,9 @@ struct WatchArgs {
     /// Port for the REST API server (default: 8080).
     #[arg(long)]
     api_port: Option<u16>,
+    /// Bypass the gate_label requirement and process all matching issues immediately.
+    #[arg(long, default_value = "false")]
+    no_gate: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -626,6 +632,11 @@ async fn cmd_run(
     gh: std::sync::Arc<dyn forza::github::GitHubClient>,
     git: std::sync::Arc<dyn forza::git::GitClient>,
 ) -> ExitCode {
+    let mut config = config.clone();
+    if args.no_gate {
+        config.global.gate_label = None;
+    }
+    let config = &config;
     let sd = state_dir();
 
     // Resolve a local directory for every configured repo before doing any work.
@@ -701,6 +712,11 @@ async fn cmd_watch(
     gh: std::sync::Arc<dyn forza::github::GitHubClient>,
     git: std::sync::Arc<dyn forza::git::GitClient>,
 ) -> ExitCode {
+    let mut config = config.clone();
+    if args.no_gate {
+        config.global.gate_label = None;
+    }
+    let config = &config;
     let sd = state_dir();
 
     // Use the override interval or the default of 60 seconds.


### PR DESCRIPTION
## Summary

Automated implementation for [#186](https://github.com/joshrotenberg/forza/issues/186) — feat: add --no-gate flag to bypass gate_label requirement.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 77.0s | - |
| implement | succeeded | 89.3s | - |
| test | succeeded | 28.6s | - |
| review | succeeded | 36.7s | - |

## Files changed

```
 src/main.rs | 16 ++++++++++++++++
 1 file changed, 16 insertions(+)
```

## Plan

## Context from plan stage

### Key findings

- `gate_label` is defined as `Option<String>` in `GlobalConfig` (src/config.rs ~line 97). Already optional, so setting it to `None` is the correct override approach.
- `WatchArgs` and `RunArgs` are both in `src/main.rs`. `WatchArgs` has several existing flags (`interval`, `route`, `repo_dir`, `serve_api`, `api_host`, `api_port`); `RunArgs` has only `repo_dir`.
- `cmd_watch` and `cmd_run` load config from disk, then call `process_batch_for_repo`. The override must happen after config load, before the processing loop.
- `process_batch_for_repo` in `src/orchestrator/mod.rs` reads `config.global.gate_label` to build the labels vec passed to `fetch_eligible_issues`. Setting it to `None` results in an empty label filter, meaning all issues matching a route are eligible.

### Implementation decisions

- Only `src/main.rs` needs to change.
- Add `#[arg(long, default_value = "false")] no_gate: bool` to both `WatchArgs` and `RunArgs`.
- In both `cmd_watch` and `cmd_run`, after loading config, add: `if args.no_gate { config.global.gate_label = None; }`
- No config struct changes needed since `gate_label` is already `Option<String>`.

### Files to modify

- src/main.rs (WatchArgs struct, RunArgs struct, cmd_watch body, cmd_run body)


## Review

## Context from review stage

### Verdict: PASS

The implementation is correct and minimal. No issues found.

### Summary of changes

- `--no-gate` flag added to both `RunArgs` and `WatchArgs` in `src/main.rs`
- Style matches the existing `--serve-api` flag (`#[arg(long, default_value = "false")]`)
- In `cmd_run` and `cmd_watch`, config is cloned and `global.gate_label` set to `None` when flag is set, then re-shadowed as immutable ref — clean, no side effects on the original config
- `gate_label` is `Option<String>` so `None` is the correct sentinel for "no gate"
- All paths that read `gate_label` (orchestrator label filtering, label removal on start) correctly handle `None` already

### No tests added

No new unit tests were added for the flag. This is acceptable: the logic is a two-line conditional on a CLI bool that sets an `Option` field to `None`. The existing 97 tests cover the downstream gate_label behavior.

### For open_pr stage

- Commit: `feat(cli): add --no-gate flag to watch and run to bypass gate_label closes #186`
- Closes: issue #186
- Only file changed: `src/main.rs`
- No breaking changes; purely additive


Closes #186