### PR TITLE
fix: log warning on schedule window parse failure

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use chrono::{DateTime, Datelike, NaiveTime, Timelike, Utc, Weekday};
 use serde::{Deserialize, Serialize};
 
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::error::{Error, Result};
 use crate::github::{IssueCandidate, PrCandidate};
@@ -235,19 +235,23 @@ impl ScheduleWindow {
         // Check day constraint.
         if !self.days.is_empty() {
             let today = now.weekday();
-            let day_match = self
-                .days
-                .iter()
-                .any(|d| d.parse::<Weekday>().map(|wd| wd == today).unwrap_or(false));
+            let day_match = self.days.iter().any(|d| {
+                d.parse::<Weekday>()
+                    .inspect_err(|_| warn!(value = %d, "failed to parse schedule window weekday"))
+                    .map(|wd| wd == today)
+                    .unwrap_or(false)
+            });
             if !day_match {
                 return false;
             }
         }
 
         let Ok(start) = NaiveTime::parse_from_str(&self.start, "%H:%M") else {
+            warn!(value = %self.start, "failed to parse schedule window start time");
             return false;
         };
         let Ok(end) = NaiveTime::parse_from_str(&self.end, "%H:%M") else {
+            warn!(value = %self.end, "failed to parse schedule window end time");
             return false;
         };
 


### PR DESCRIPTION
## Summary

Automated implementation for [#167](https://github.com/joshrotenberg/forza/issues/167) — fix: log warning on schedule window parse failure.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 51.0s | - |
| implement | succeeded | 58.6s | - |
| test | succeeded | 19.2s | - |
| review | succeeded | 47.5s | - |

## Files changed

```
 src/config.rs | 14 +++++++++-----
 1 file changed, 9 insertions(+), 5 deletions(-)
```

## Plan

# Context from plan stage

## Issue
#167 — `ScheduleWindow::is_active` silently returns `false` on parse failures, masking misconfiguration.

## Key findings

**File:** `src/config.rs`

**Three silent failure sites in `ScheduleWindow::is_active`:**

1. **Line 241** — weekday parse: `d.parse::<Weekday>().map(|wd| wd == today).unwrap_or(false)`
   — if a day string like `"Monday"` (invalid; must be `"Mon"`) is used, the day is silently treated as non-matching.

2. **Lines 247–249** — start time parse:
   ```rust
   let Ok(start) = NaiveTime::parse_from_str(&self.start, "%H:%M") else {
       return false;
   };
   ```
   — returns `false` with no log.

3. **Lines 250–252** — end time parse (same pattern as above).

**Existing infrastructure:** `use tracing::debug;` already at the top of `config.rs`. Only need to add `warn` to that import.

## Decision
Add `warn!` calls at each failure site with the bad value included (e.g., `warn!(value = %self.start, "failed to parse schedule window start time")`). No structural changes needed.

## What the implement stage needs to do
- In `src/config.rs`, change `use tracing::debug;` to `use tracing::{debug, warn};`
- In `ScheduleWindow::is_active`:
  - Replace `unwrap_or(false)` in the weekday loop with explicit warn + false on parse error
  - Replace the two silent `return false` arms for time parsing with `warn!` + `return false`
- Commit: `fix(config): log warning on schedule window parse failure closes #167`


## Review

## Context from review stage

### Verdict: PASS

The fix for issue #167 is correct and complete. Three `warn!` calls were added to
`ScheduleWindow::is_active` in `src/config.rs`:

- Line 240: invalid weekday string in `days` array (via `inspect_err`)
- Line 250: invalid `start` time string
- Line 254: invalid `end` time string

All three use structured tracing fields (`value = %...`) consistent with the rest of
the codebase. The `warn` import was already present. Fallback behavior is unchanged.

### Minor gap (low severity, non-blocking)

No tests cover the parse-failure warning paths. Happy-path `ScheduleWindow` tests are
thorough. This is not a blocker for merging.

### PR details

- Branch: `automation/167-fix-log-warning-on-schedule-window-parse`
- Target: `main`
- Closes: #167
- Commit: 74a7833
- Scope: single file (`src/config.rs`), no API or behavior changes


Closes #167