### PR TITLE
fix: log fetch errors in git client instead of silent drop

### DIFF
--- a/src/git/cli.rs
+++ b/src/git/cli.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use tracing::warn;
 
 use super::GitClient;
 use crate::error::{Error, Result};
@@ -58,7 +59,9 @@ impl GitClient for GitCliClient {
         let worktree_dir = repo_dir.join(worktree_base).join(&dir_name);
 
         // Fetch to ensure we have latest refs.
-        let _ = git(&["fetch", "origin"], repo_dir).await;
+        if let Err(e) = git(&["fetch", "origin"], repo_dir).await {
+            warn!(error = %e, "fetch origin failed (non-fatal)");
+        }
 
         // Check if branch already exists on remote or locally.
         let remote_ref = format!("origin/{branch}");


### PR DESCRIPTION
## Summary

Automated implementation for [#166](https://github.com/joshrotenberg/forza/issues/166) — fix: log fetch errors in git client instead of silent drop.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 42.2s | - |
| implement | succeeded | 49.5s | - |
| test | succeeded | 32.2s | - |
| review | succeeded | 33.3s | - |

## Files changed

```
 src/git/cli.rs | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
```

## Plan

# Context from plan stage

## Finding

Only one line needs changing: `src/git/cli.rs` line 61, inside `worktree_add()`:

```rust
let _ = git(&["fetch", "origin"], repo_dir).await;
```

This silently drops any error returned by the fetch. The `fetch()` method at line 46 is fine — it uses `?` and errors propagate correctly.

## Fix

Replace line 61 with:

```rust
if let Err(e) = git(&["fetch", "origin"], repo_dir).await {
    warn!(error = %e, "fetch origin failed (non-fatal)");
}
```

And add `use tracing::warn;` to the imports at the top of the file (currently `cli.rs` has no tracing import).

## Key decisions

- Single file, single line change plus one import.
- Must stay non-fatal: no `?`, no `return Err(...)`.
- Use `warn!` macro (not `tracing::warn!`) after adding the import, consistent with how the rest of the codebase uses it (e.g., `src/orchestrator/mod.rs`, `src/notifications.rs`).
- No other fetch calls in the file need changes.


## Review

## Context from review stage

### Verdict: PASS

The change in `src/git/cli.rs` is correct, minimal, and non-breaking.

### Key findings

- Only `src/git/cli.rs` was modified (3 lines changed + 1 import added).
- The inline `git fetch origin` inside `worktree_add` now logs at `warn` level on failure instead of silently discarding the error. This is the intended fix for #166.
- The `GitClient::fetch` method (a separate code path) correctly continues to propagate errors — it was not changed.
- No panics, unsafe code, or style inconsistencies introduced.
- All tests pass (verified in test stage breadcrumb).

### For open_pr stage

- Branch: `automation/166-fix-log-fetch-errors-in-git-client-inste`
- Commit: `fix(git): log fetch errors in git client instead of silent drop closes #166`
- Files changed: `src/git/cli.rs` only
- PR is ready to open against `main`. No blockers.


Closes #166