### PR TITLE
fix: use typed error matching instead of string matching in octocrab client

### DIFF
--- a/src/github/octocrab_client.rs
+++ b/src/github/octocrab_client.rs
@@ -4,7 +4,7 @@ use std::{path::Path, sync::Arc};
 
 use async_trait::async_trait;
 use http::{
-    Uri,
+    StatusCode, Uri,
     header::{AUTHORIZATION, USER_AGENT},
 };
 use hyper_rustls::HttpsConnectorBuilder;
@@ -232,7 +232,17 @@ impl GitHubClient for OctocrabClient {
             .await;
         if let Err(e) = result {
             // If it already exists, that's fine (idempotent).
-            if !e.to_string().contains("already_exists") {
+            let is_already_exists = matches!(
+                &e,
+                octocrab::Error::GitHub { source, .. }
+                    if source.status_code == StatusCode::UNPROCESSABLE_ENTITY
+                        && source.errors.as_ref().is_some_and(|errs| {
+                            errs.iter().any(|err| {
+                                err.get("code").and_then(|c| c.as_str()) == Some("already_exists")
+                            })
+                        })
+            );
+            if !is_already_exists {
                 return Err(Error::GitHub(format!("create label '{name}': {e}")));
             }
         }


### PR DESCRIPTION
## Summary

Automated implementation for [#163](https://github.com/joshrotenberg/forza/issues/163) — fix: use typed error matching instead of string matching in octocrab client.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 105.7s | - |
| implement | succeeded | 92.2s | - |
| test | succeeded | 28.8s | - |
| review | succeeded | 95.1s | - |

## Files changed

```
 src/github/octocrab_client.rs | 14 ++++++++++++--
 1 file changed, 12 insertions(+), 2 deletions(-)
```

## Plan

## Context from plan stage

### Finding
One file needs changing: `src/github/octocrab_client.rs`, in the `create_label` method (~lines 220–240). The problematic line is:

```rust
if !e.to_string().contains("already_exists") {
```

### Fix
Replace string matching with typed matching on the octocrab error hierarchy:

- `octocrab::Error::GitHub { source, .. }` — the variant for GitHub API errors
- `source.status_code: http::StatusCode` — check for `UNPROCESSABLE_ENTITY` (422)
- `source.errors: Option<Vec<serde_json::Value>>` — check for `"code": "already_exists"` in the array

Best approach is to match both the status code and the structured error code for precision (422 alone covers all validation errors, not just duplicates).

### Imports
No new crate dependencies needed. `http` is already in `Cargo.toml` (version 1) and `http::StatusCode` is already transitively available. The existing `use http::{Uri, header::...}` import block at the top of the file just needs `StatusCode` added.

### Pattern for implement stage
```rust
if let Err(e) = result {
    let is_already_exists = matches!(
        &e,
        octocrab::Error::GitHub { source, .. }
            if source.status_code == http::StatusCode::UNPROCESSABLE_ENTITY
                && source.errors.as_ref().is_some_and(|errs| {
                    errs.iter().any(|err| {
                        err.get("code").and_then(|c| c.as_str()) == Some("already_exists")
                    })
                })
    );
    if !is_already_exists {
        return Err(Error::GitHub(format!("create label '{name}': {e}")));
    }
}
```

### No test changes required
There are no existing tests for `create_label` in `octocrab_client.rs` (it makes live API calls). No test file changes needed.

### Commit message
`fix(github): use typed error matching for idempotent label creation closes #163`


## Review

## Context from review stage

### Verdict: PASS

The fix in `src/github/octocrab_client.rs` (`create_label`, line ~235) is correct and ready for a PR.

### Key findings

- Single commit `fb07a3c` touches only `src/github/octocrab_client.rs` (14 lines).
- Replaces fragile `e.to_string().contains("already_exists")` with a typed `matches!` guard on `octocrab::Error::GitHub { source, .. }` requiring both `status_code == UNPROCESSABLE_ENTITY` and `errors[].code == "already_exists"` — correctly scoped, no false positives.
- No panic paths; `Option` handled via `is_some_and`.
- No test coverage added, consistent with module convention (no live-API tests in unit suite).

### For open_pr stage

- Branch: `automation/163-fix-use-typed-error-matching-instead-of`
- Target: `main`
- Closes: issue #163
- Suggested title: `fix(github): use typed error matching for idempotent label creation`
- No changelog or doc updates needed.


Closes #163