### PR TITLE
fix: error on agentless stage with no command instead of silent echo

### DIFF
--- a/src/orchestrator/helpers.rs
+++ b/src/orchestrator/helpers.rs
@@ -208,10 +208,12 @@ pub(super) async fn execute_stages(
 
         // Agentless stages run a shell command directly — no agent invocation.
         if planned_stage.agentless {
-            let command = planned_stage
-                .command
-                .as_deref()
-                .unwrap_or("echo 'no command specified'");
+            let Some(command) = planned_stage.command.as_deref() else {
+                return Err(Error::Executor(format!(
+                    "agentless stage '{}' has no command",
+                    planned_stage.kind_name()
+                )));
+            };
             let start = std::time::Instant::now();
             let output = tokio::process::Command::new("sh")
                 .args(["-c", command])

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -593,10 +593,12 @@ pub async fn process_reactive_pr(
         let planned = build_pr_planned_stage(stage, &pr, &run_id, &template.stages);
 
         if planned.agentless {
-            let command = planned
-                .command
-                .as_deref()
-                .unwrap_or("echo 'no command specified'");
+            let Some(command) = planned.command.as_deref() else {
+                return Err(Error::Executor(format!(
+                    "agentless stage '{}' has no command",
+                    stage.kind.name()
+                )));
+            };
             let start = std::time::Instant::now();
             let output = tokio::process::Command::new("sh")
                 .args(["-c", command])


### PR DESCRIPTION
## Summary

Automated implementation for [#162](https://github.com/joshrotenberg/forza/issues/162) — fix: error on agentless stage with no command instead of silent echo.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 53.2s | - |
| implement | succeeded | 78.5s | - |
| test | succeeded | 29.6s | - |
| review | succeeded | 65.9s | - |

## Files changed

```
 src/orchestrator/helpers.rs | 10 ++++++----
 src/orchestrator/mod.rs     | 10 ++++++----
 2 files changed, 12 insertions(+), 8 deletions(-)
```

## Plan

# Context from plan stage

## Issue
Agentless stages with `agentless = true` but no `command` silently fall back to `echo 'no command specified'` instead of failing. This masks configuration mistakes.

## Root cause locations

Two spots with identical silent-fallback pattern:

1. `src/orchestrator/helpers.rs` ~line 211-214 — linear workflow agentless execution
2. `src/orchestrator/mod.rs` ~line 596-599 — reactive (PR) workflow agentless execution

Both read:
```rust
let command = planned_stage.command.as_deref().unwrap_or("echo 'no command specified'");
```

## Fix
Replace each `.unwrap_or(...)` with an explicit `None` check that returns `Err(anyhow::anyhow!("agentless stage '{}' has no command", stage_kind))` (or similar). The error will propagate through the existing stage failure recording path, surfacing the misconfiguration to the operator rather than silently succeeding.

## Key decisions
- Error at execution time (not config parse time) — keeps the fix minimal and consistent with how other runtime errors are handled in the orchestrator.
- Use `anyhow::anyhow!` since this is application code.
- No new tests required beyond checking the existing test suite still passes; however, a unit test for the new error path in the orchestrator would be worth adding if the existing coverage pattern supports it.

## Commit message
fix(orchestrator): error on agentless stage with no command closes #162


## Review

## Context from review stage

### Verdict: PASS — no issues found

### What was reviewed

Commit `69be0f2` on branch `automation/162-fix-error-on-agentless-stage-with-no-com`.

Two-location change:
- `src/orchestrator/helpers.rs:208` — `execute_stages` (issue pipeline)
- `src/orchestrator/mod.rs:595` — `process_reactive_pr` (reactive PR pipeline)

Both replace `unwrap_or("echo 'no command specified'")` with a `let-else` that returns
`Err(Error::Executor("agentless stage '{kind}' has no command"))`.

### Key findings for open_pr

- Implementation is correct and complete; both code paths are fixed symmetrically.
- No clippy, fmt, or test failures. All 97 lib + 10 integration tests pass.
- No high or medium severity issues. No source files should be modified before opening the PR.
- PR is ready to open targeting `main`.
- Commit message: `fix(orchestrator): error on agentless stage with no command closes #162`
- Issue reference: closes #162


Closes #162