### PR TITLE
fix: check cost cap before stage execution, not after

### DIFF
--- a/src/orchestrator/helpers.rs
+++ b/src/orchestrator/helpers.rs
@@ -89,6 +89,22 @@ pub(super) async fn execute_stages(
             continue;
         }
 
+        // Check accumulated cost against cap before starting this stage.
+        if let Some(cap) = config.global.max_cost_per_issue
+            && let Some(total) = record.accumulated_cost_usd()
+            && total >= cap
+        {
+            warn!(
+                subject,
+                number,
+                total_cost = total,
+                cap,
+                "cost cap reached, aborting remaining stages"
+            );
+            all_succeeded = false;
+            break;
+        }
+
         // Look up per-stage hooks.
         let stage_hooks = config.stage_hooks.get(planned_stage.kind_name());
 
@@ -417,22 +433,6 @@ pub(super) async fn execute_stages(
                     break;
                 }
             }
-        }
-
-        // Check accumulated cost against cap.
-        if let Some(cap) = config.global.max_cost_per_issue
-            && let Some(total) = record.total_cost_usd
-            && total > cap
-        {
-            warn!(
-                subject,
-                number,
-                total_cost = total,
-                cap,
-                "cost cap exceeded, aborting remaining stages"
-            );
-            all_succeeded = false;
-            break;
         }
 
         // Run validation.

--- a/src/state.rs
+++ b/src/state.rs
@@ -231,6 +231,21 @@ impl RunRecord {
         }
     }
 
+    /// Returns the sum of costs recorded so far across completed stages.
+    pub fn accumulated_cost_usd(&self) -> Option<f64> {
+        let costs: Vec<f64> = self
+            .stages
+            .iter()
+            .filter_map(|s| s.result.as_ref())
+            .filter_map(|r| r.cost_usd)
+            .collect();
+        if costs.is_empty() {
+            None
+        } else {
+            Some(costs.iter().sum())
+        }
+    }
+
     /// Mark the run as finished.
     pub fn finish(&mut self, status: RunStatus) {
         self.status = status;
@@ -476,6 +491,17 @@ pub fn generate_run_id() -> String {
 mod tests {
     use super::*;
 
+    fn make_stage_result(cost: Option<f64>) -> crate::executor::StageResult {
+        crate::executor::StageResult {
+            stage: "implement".into(),
+            success: true,
+            duration_secs: 1.0,
+            cost_usd: cost,
+            output: String::new(),
+            files_modified: None,
+        }
+    }
+
     fn make_record(workflow: &str, status: RunStatus, cost: Option<f64>) -> RunRecord {
         RunRecord {
             run_id: generate_run_id(),
@@ -492,6 +518,74 @@ mod tests {
             subject_kind: SubjectKind::Issue,
             outcome: None,
         }
+    }
+
+    #[test]
+    fn accumulated_cost_usd_no_stages() {
+        let record = make_record("bug", RunStatus::Running, None);
+        assert!(record.accumulated_cost_usd().is_none());
+    }
+
+    #[test]
+    fn accumulated_cost_usd_stages_without_cost() {
+        let mut record = make_record("bug", RunStatus::Running, None);
+        record.record_stage(
+            StageKind::Plan,
+            StageStatus::Succeeded,
+            make_stage_result(None),
+        );
+        assert!(record.accumulated_cost_usd().is_none());
+    }
+
+    #[test]
+    fn accumulated_cost_usd_single_stage() {
+        let mut record = make_record("bug", RunStatus::Running, None);
+        record.record_stage(
+            StageKind::Plan,
+            StageStatus::Succeeded,
+            make_stage_result(Some(0.50)),
+        );
+        let total = record.accumulated_cost_usd().unwrap();
+        assert!((total - 0.50).abs() < 1e-9);
+    }
+
+    #[test]
+    fn accumulated_cost_usd_multiple_stages() {
+        let mut record = make_record("bug", RunStatus::Running, None);
+        record.record_stage(
+            StageKind::Plan,
+            StageStatus::Succeeded,
+            make_stage_result(Some(0.30)),
+        );
+        record.record_stage(
+            StageKind::Implement,
+            StageStatus::Succeeded,
+            make_stage_result(Some(0.70)),
+        );
+        let total = record.accumulated_cost_usd().unwrap();
+        assert!((total - 1.00).abs() < 1e-9);
+    }
+
+    #[test]
+    fn accumulated_cost_usd_mixed_cost_presence() {
+        let mut record = make_record("bug", RunStatus::Running, None);
+        record.record_stage(
+            StageKind::Plan,
+            StageStatus::Succeeded,
+            make_stage_result(Some(0.40)),
+        );
+        record.record_stage(
+            StageKind::Implement,
+            StageStatus::Succeeded,
+            make_stage_result(None),
+        );
+        record.record_stage(
+            StageKind::Review,
+            StageStatus::Succeeded,
+            make_stage_result(Some(0.60)),
+        );
+        let total = record.accumulated_cost_usd().unwrap();
+        assert!((total - 1.00).abs() < 1e-9);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Automated implementation for [#160](https://github.com/joshrotenberg/forza/issues/160) — fix: check cost cap before stage execution, not after.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 117.0s | - |
| implement | succeeded | 98.0s | - |
| test | succeeded | 23.4s | - |
| review | succeeded | 78.7s | - |

## Files changed

```
 src/orchestrator/helpers.rs | 32 +++++++--------
 src/state.rs                | 94 +++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 110 insertions(+), 16 deletions(-)
```

## Plan

# Plan Stage — Context Summary

## Root Cause

The existing per-issue cost cap check in `execute_stages()` (`src/orchestrator/helpers.rs` lines 420–434) has two bugs:

1. **Wrong timing**: The check runs *after* each stage completes, so the stage that blows the budget has already executed and billed.
2. **Dead check**: It checks `record.total_cost_usd`, which is only set by `RunRecord::finish()`. Since `finish()` is never called during the loop, `total_cost_usd` is always `None` and the `let Some(total)` arm never matches — the check silently never fires.

## Key Decision

Add `accumulated_cost_usd(&self) -> Option<f64>` to `RunRecord` in `src/state.rs`. This method sums `cost_usd` from all `stage.result` entries already recorded (same arithmetic as the `finish()` body). Using this avoids touching `finish()` semantics and gives a live running total callable at any point during execution.

## Implementation Plan

### `src/state.rs`

Add a new method to `RunRecord`:

```rust
/// Returns the sum of costs recorded so far across completed stages.
pub fn accumulated_cost_usd(&self) -> Option<f64> {
    let costs: Vec<f64> = self
        .stages
        .iter()
        .filter_map(|s| s.result.as_ref())
        .filter_map(|r| r.cost_usd)
        .collect();
    if costs.is_empty() {
        None
    } else {
        Some(costs.iter().sum())
    }
}
```

### `src/orchestrator/helpers.rs`

In the `execute_stages()` for loop:

1. **Remove** the post-stage cost cap block (lines 420–434).
2. **Add** a pre-stage cost cap check early in the loop body — after the optional-condition skip (`continue`) but before pre-hooks and `execute_stage`. Use `record.accumulated_cost_usd()` instead of `record.total_cost_usd`:

```rust
// Check accumulated cost before starting this stage.
if let Some(cap) = config.global.max_cost_per_issue
    && let Some(total) = record.accumulated_cost_usd()
    && total >= cap
{
    warn!(
        subject,
        number,
        total_cost = total,
        cap,
        "cost cap reached, aborting remaining stages"
    );
    all_succeeded = false;
    break;
}
```

Note the change from `>` to `>=` matches the phrasing "exceeded" more precisely (stop *at* cap, not one stage past it).

## Boundary notes

- The *hourly* cap check in `src/orchestrator/mod.rs` is a separate concern and is already correctly placed before the pipeline starts — no changes needed there.
- `total_cost_usd` on `RunRecord` is populated by `finish()` and used for historical reporting; leave it as-is.
- No config struct changes needed.
- Tests for `accumulated_cost_usd` should mirror the existing `hourly_cost` / `total_cost_usd` test patterns in `src/state.rs`.


## Review

# Review Stage — Context Summary

## Verdict: PASS

No issues found. The implementation is ready for open_pr.

## Key findings

- The fix is correct: the old `record.total_cost_usd` check was always `None` mid-run
  (the field is only set in `finish()`), so the cap was never enforced during execution.
- The new `accumulated_cost_usd()` method sums `cost_usd` from completed `StageRecord`
  results in real-time — the correct approach.
- The check now runs pre-stage (before the stage starts), not post-stage.
- Comparison changed from `> cap` to `>= cap` — correct tightening.
- The `total_cost_usd` field on `RunRecord` is untouched; `hourly_cost()` and final
  reporting are unaffected.
- 5 new unit tests in `src/state.rs` cover empty, no-cost, single, multi, and mixed
  cases.

## Files changed

- `src/state.rs`: new `accumulated_cost_usd()` method + 5 unit tests
- `src/orchestrator/helpers.rs`: removed dead post-stage check, added pre-stage check

## For open_pr

- Commit message: `fix(orchestrator): check cost cap before stage execution, not after closes #160`
- PR title suggestion: `fix(orchestrator): check cost cap before stage execution`
- No breaking changes. No migration needed.


Closes #160