### PR TITLE
bug: prs can merge before ci passes

### DIFF
--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -162,7 +162,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::Review).optional(),
                 Stage::new(StageKind::OpenPr),
                 Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || (gh pr checks --watch && gh pr merge --squash)"),
             ],
             ..Default::default()
         },
@@ -175,7 +175,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::Review).optional(),
                 Stage::new(StageKind::OpenPr),
                 Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || (gh pr checks --watch && gh pr merge --squash)"),
             ],
             ..Default::default()
         },
@@ -186,7 +186,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::Test),
                 Stage::new(StageKind::OpenPr),
                 Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || (gh pr checks --watch && gh pr merge --squash)"),
             ],
             ..Default::default()
         },
@@ -231,7 +231,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                             .into(),
                     ),
                     ..Stage::new(StageKind::Merge).agentless(
-                        "gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash",
+                        "gh pr merge --auto --squash 2>/dev/null || (gh pr checks --watch && gh pr merge --squash)",
                     )
                 },
             ],
@@ -247,7 +247,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::FixCi),
                 Stage::new(StageKind::Merge)
                     .optional()
-                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || (gh pr checks --watch && gh pr merge --squash)"),
             ],
             ..Default::default()
         },
@@ -257,7 +257,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::RevisePr),
                 Stage::new(StageKind::Merge)
                     .optional()
-                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || (gh pr checks --watch && gh pr merge --squash)"),
             ],
             ..Default::default()
         },
@@ -268,7 +268,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::FixCi),
                 Stage::new(StageKind::Merge)
                     .optional()
-                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || (gh pr checks --watch && gh pr merge --squash)"),
             ],
             ..Default::default()
         },
@@ -276,7 +276,7 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
             name: "pr-merge".into(),
             stages: vec![
                 Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash"),
+                    .agentless("gh pr merge --auto --squash 2>/dev/null || (gh pr checks --watch && gh pr merge --squash)"),
             ],
             ..Default::default()
         },


### PR DESCRIPTION
## Summary

Automated implementation for [#205](https://github.com/joshrotenberg/forza/issues/205) — bug: prs can merge before ci passes.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 32.9s | - |
| implement | succeeded | 37.6s | - |
| test | succeeded | 28.6s | - |
| review | succeeded | 68.5s | - |

## Files changed

```
 src/workflow.rs | 16 ++++++++--------
 1 file changed, 8 insertions(+), 8 deletions(-)
```

## Plan

## Context from plan stage

### Problem
In `src/workflow.rs`, all 8 merge-stage agentless commands use:
```sh
gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash
```
The `--auto` fallback runs `gh pr merge --squash` immediately without waiting for CI, causing PRs to merge with CI still in progress.

### Fix
Replace every occurrence of:
```sh
gh pr merge --auto --squash 2>/dev/null || gh pr merge --squash
```
with:
```sh
gh pr merge --auto --squash 2>/dev/null || (gh pr checks --watch && gh pr merge --squash)
```

### Affected locations in src/workflow.rs (all inside `builtin_templates()`)
- `bug` template, Merge stage (~line 165)
- `feature` template, Merge stage (~line 178)
- `chore` template, Merge stage (~line 189)
- `pr-maintenance` template, Merge stage condition block (~line 234)
- `pr-fix-ci` template, Merge stage (~line 250)
- `pr-rebase` template, Merge stage (~line 260)
- `pr-fix` template, Merge stage (~line 271)
- `pr-merge` template, Merge stage (~line 279)

All 8 occurrences are identical strings — a `replace_all` edit on `src/workflow.rs` will handle them all in one operation.

### Commit message
`fix(workflow): wait for ci checks before fallback merge closes #205`

### Notes
- The existing `src/prompts/pr_merge.md` already documents `gh pr checks --watch` as the correct pattern, confirming the approach.
- No new tests needed beyond verifying existing tests still pass; the test suite checks structure/presence of stages, not the command strings.
- The `--delete-branch` flag is not added here to avoid unintended behavior changes; the existing commands don't include it and that is a separate concern.


## Review

## Context from review stage

### Verdict: PASS

The implementation for issue #205 is correct and complete.

### Key findings

- **8 merge commands updated** across all builtin templates in `src/workflow.rs`
- **Shell logic is correct**: parentheses `(gh pr checks --watch && gh pr merge --squash)` properly group the fallback so CI must pass before merge proceeds
- **No old form in executable code**: every `.agentless(...)` call uses the new pattern
- **One low-severity note**: comment at line 154 shows the old fallback as a user-facing override example — stale but not blocking

### For open_pr stage

- Branch: `automation/205-bug-prs-can-merge-before-ci-passes`
- Commit: `e85d795` — `fix(workflow): wait for ci checks before fallback merge closes #205`
- Only file changed: `src/workflow.rs`
- All tests pass (103 unit, 10 integration)
- No high-severity issues — PR is ready to open


Closes #205