### PR TITLE
fix: reject routes with both label and condition set

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -405,6 +405,11 @@ pub struct Route {
 impl Route {
     /// Validate that a route has at least one trigger and one action.
     pub fn validate(&self, name: &str) -> Result<()> {
+        if self.label.is_some() && self.condition.is_some() {
+            return Err(Error::Policy(format!(
+                "route '{name}' cannot have both a label and a condition"
+            )));
+        }
         if self.label.is_none() && self.condition.is_none() {
             return Err(Error::Policy(format!(
                 "route '{name}' must have a label or a condition"
@@ -1561,9 +1566,17 @@ repo = "owner/repo"
         let route4 = Route {
             condition: Some(RouteCondition::CiFailing),
             workflow: Some("pr-fix".to_string()),
-            ..route
+            ..route.clone()
         };
         assert!(route4.validate("test").is_ok()); // condition + workflow
+
+        let route5 = Route {
+            label: Some("bug".to_string()),
+            condition: Some(RouteCondition::CiFailing),
+            workflow: Some("bug".to_string()),
+            ..route
+        };
+        assert!(route5.validate("test").is_err()); // both label and condition
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Automated implementation for [#159](https://github.com/joshrotenberg/forza/issues/159) — fix: reject routes with both label and condition set.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 38.5s | - |
| implement | succeeded | 60.4s | - |
| test | succeeded | 25.4s | - |
| review | succeeded | 55.5s | - |

## Files changed

```
 src/config.rs | 15 ++++++++++++++-
 1 file changed, 14 insertions(+), 1 deletion(-)
```

## Plan

## Context from plan stage

### Finding
`Route::validate()` in `src/config.rs` (line 407-419) currently checks that at least one trigger (`label` or `condition`) is present and that `workflow` is set. It does NOT check for the invalid case where both `label` and `condition` are set together.

### Decision
Add validation in `Route::validate()` to return `Error::Policy` when both `label` and `condition` are `Some`. This is the clearest fix — explicit rejection with a helpful error message is preferable to silent precedence rules.

### Changes needed
**`src/config.rs`**:
1. Add a check at the top of `Route::validate()`:
   ```rust
   if self.label.is_some() && self.condition.is_some() {
       return Err(Error::Policy(format!(
           "route '{name}' cannot have both a label and a condition"
       )));
   }
   ```
2. Add a test case in `route_validate_requires_trigger_and_action` for the both-set case.

### Key context
- `Error::Policy` is the correct error type for config validation failures (already used in the same function).
- The existing test at line 1527 covers the no-trigger and no-action cases; extend it rather than writing a new test function.
- No other files need changes — validation is called from `RunnerConfig` loading which propagates the error up to the caller.


## Review

## Context from review stage

### Verdict: PASS

### What was reviewed

`src/config.rs` — the only file changed for issue #159.

### Key findings

- The fix adds a single early-return guard in `Route::validate()` (line 408-412) returning
  `Error::Policy` when both `label` and `condition` are present on a route.
- Placement is correct: before the "no trigger at all" check, consistent with existing style.
- Error message: `"route '{name}' cannot have both a label and a condition"` — clear and actionable.
- `validate()` is called in `RunnerConfig::from_file()` for both top-level routes and per-repo
  routes, so the guard fires at config load time (lines 577-583).
- New test case `route5` covers the error path; all 107 lib tests pass.
- No panics, no unsafe code, no regressions.

### PR ready

- Branch: `automation/159-fix-reject-routes-with-both-label-and-co`
- Commit: `fix(config): reject routes with both label and condition set closes #159`
- Target: `main`
- Closes: #159


Closes #159