### PR TITLE
fix: atomic state persistence with write-to-temp + rename

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -269,13 +269,18 @@ impl RunRecord {
 /// Save a run record to disk.
 pub fn save_run(record: &RunRecord, state_dir: &std::path::Path) -> crate::error::Result<()> {
     std::fs::create_dir_all(state_dir)?;
-    let path = state_dir.join(format!("{}.json", record.run_id));
-    let json = serde_json::to_string_pretty(record)?;
-    std::fs::write(&path, json)?;
 
-    // Update latest pointer.
-    let latest = state_dir.join("latest");
-    std::fs::write(latest, &record.run_id)?;
+    // Write run record atomically.
+    let final_path = state_dir.join(format!("{}.json", record.run_id));
+    let tmp_path = state_dir.join(format!("{}.json.tmp", record.run_id));
+    let json = serde_json::to_string_pretty(record)?;
+    std::fs::write(&tmp_path, &json)?;
+    std::fs::rename(&tmp_path, &final_path)?;
+
+    // Update latest pointer atomically.
+    let latest_tmp = state_dir.join("latest.tmp");
+    std::fs::write(&latest_tmp, &record.run_id)?;
+    std::fs::rename(&latest_tmp, state_dir.join("latest"))?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Automated implementation for [#157](https://github.com/joshrotenberg/forza/issues/157) — fix: atomic state persistence with write-to-temp + rename.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 38.7s | - |
| implement | succeeded | 39.4s | - |
| test | succeeded | 25.9s | - |
| review | succeeded | 43.4s | - |

## Files changed

```
 src/state.rs | 15 ++++++++++-----
 1 file changed, 10 insertions(+), 5 deletions(-)
```

## Plan

# Context from plan stage

## Key findings

**Problem**: `save_run` in `src/state.rs:270-281` does two sequential non-atomic writes:
1. `std::fs::write(&path, json)` — writes `{run_id}.json`
2. `std::fs::write(latest, &record.run_id)` — writes the `latest` pointer

A crash between these two leaves `latest` pointing to a stale or nonexistent run ID.

**Fix**: Write each file to a `.tmp` sibling in the same directory, then `std::fs::rename` into the final path. `rename` is atomic on POSIX when src and dst are on the same filesystem. Using a `.tmp` sibling (not `/tmp`) ensures same-filesystem semantics.

**Dependency note**: `tempfile` is only in `[dev-dependencies]`, so the implementation must use `std::fs` directly — write to `{run_id}.json.tmp` / `latest.tmp`, then rename.

**No other files need changes** — all callers go through `save_run`; the load functions are unaffected.

## What to implement

In `src/state.rs`, replace the body of `save_run` (lines 270-281) with:

```rust
pub fn save_run(record: &RunRecord, state_dir: &std::path::Path) -> crate::error::Result<()> {
    std::fs::create_dir_all(state_dir)?;

    // Write run record atomically.
    let final_path = state_dir.join(format!("{}.json", record.run_id));
    let tmp_path = state_dir.join(format!("{}.json.tmp", record.run_id));
    let json = serde_json::to_string_pretty(record)?;
    std::fs::write(&tmp_path, &json)?;
    std::fs::rename(&tmp_path, &final_path)?;

    // Update latest pointer atomically.
    let latest_tmp = state_dir.join("latest.tmp");
    std::fs::write(&latest_tmp, &record.run_id)?;
    std::fs::rename(&latest_tmp, state_dir.join("latest"))?;

    Ok(())
}
```

## Commit message
`fix(state): atomic state persistence with write-to-temp + rename closes #157`


## Review

## Context from review stage

### Verdict: PASS

### What was reviewed

`src/state.rs` — `save_run` function (lines 270–286). Only file changed in this branch.

### Key findings

- Implementation is correct. Both the run record and the `latest` pointer are written atomically: temp file in `state_dir` → `std::fs::rename` to final path.
- Same-filesystem placement ensures POSIX `rename(2)` atomicity (no cross-device rename issue).
- Readers (`load_all_runs`, `list_run_files`) filter by `.json` extension, so leftover `.tmp` files from a crash are never surfaced.
- No new dependencies, no unsafe code, no panics introduced.
- Existing 107 tests pass; no dedicated atomicity test needed (OS guarantee, not app logic).

### For open_pr stage

- Branch: `automation/157-fix-atomic-state-persistence-with-write`
- Commit: `a08d96f` — `fix(state): atomic state persistence with write-to-temp + rename closes #157`
- Only `src/state.rs` modified
- Ready to open PR against `main`
- Suggested PR title: `fix(state): atomic state persistence with write-to-temp + rename`


Closes #157