### PR TITLE
refactor: extract shared stage execution from issue/PR paths

### DIFF
--- a/src/orchestrator/helpers.rs
+++ b/src/orchestrator/helpers.rs
@@ -231,31 +231,8 @@ pub(super) async fn execute_stages(
                     planned_stage.kind_name()
                 )));
             };
-            let start = std::time::Instant::now();
-            // SAFETY: input is config-trusted, not user/GitHub-controlled
-            let output = tokio::process::Command::new("sh")
-                .args(["-c", command])
-                .current_dir(worktree_dir)
-                .output()
-                .await;
-            let duration = start.elapsed();
-            let (success, output_text) = match output {
-                Ok(o) => {
-                    let stdout = String::from_utf8_lossy(&o.stdout).to_string();
-                    let stderr = String::from_utf8_lossy(&o.stderr).to_string();
-                    let text = if stderr.is_empty() { stdout } else { stderr };
-                    (o.status.success(), text)
-                }
-                Err(e) => (false, e.to_string()),
-            };
-            let result = StageResult {
-                stage: planned_stage.kind_name().to_string(),
-                success,
-                duration_secs: duration.as_secs_f64(),
-                cost_usd: None,
-                output: output_text,
-                files_modified: None,
-            };
+            let (success, output_text, duration) =
+                run_agentless_stage(command, worktree_dir, None).await;
             info!(
                 subject,
                 number,
@@ -264,6 +241,14 @@ pub(super) async fn execute_stages(
                 duration = format!("{:.1}s", duration.as_secs_f64()),
                 "agentless stage complete"
             );
+            let result = StageResult {
+                stage: planned_stage.kind_name().to_string(),
+                success,
+                duration_secs: duration.as_secs_f64(),
+                cost_usd: None,
+                output: output_text,
+                files_modified: None,
+            };
             let failed = !success;
             record.record_stage(
                 planned_stage.kind,
@@ -294,39 +279,15 @@ pub(super) async fn execute_stages(
             continue;
         }
 
-        let stage_model = ctx
-            .cli_overrides
-            .model
-            .as_deref()
-            .or(ctx.label_overrides.model.as_deref())
-            .or(planned_stage.model.as_deref())
-            .or_else(|| config.effective_model(route));
-        let stage_skills = if !ctx.cli_overrides.skills.is_empty() {
-            ctx.cli_overrides.skills.as_slice()
-        } else if !ctx.label_overrides.skills.is_empty() {
-            ctx.label_overrides.skills.as_slice()
-        } else {
-            config.effective_skills(route, planned_stage.skills.as_deref())
-        };
-        let stage_mcp = config.effective_mcp_config(route, planned_stage.mcp_config.as_deref());
-        let stage_syspr = config.effective_append_system_prompt();
-        let mut stage_adapter = ClaudeAdapter::new();
-        if let Some(m) = stage_model {
-            stage_adapter = stage_adapter.model(m);
-        }
-        if !stage_skills.is_empty() {
-            stage_adapter = stage_adapter.skills(stage_skills.iter().cloned());
-        }
-        if let Some(p) = stage_mcp {
-            stage_adapter = stage_adapter.mcp_config(p);
-        }
-        if let Some(s) = stage_syspr {
-            stage_adapter = stage_adapter.append_system_prompt(s);
-        }
-
-        match stage_adapter
-            .execute_stage(&stage_for_exec, worktree_dir)
-            .await
+        match run_agent_stage(
+            &stage_for_exec,
+            config,
+            route,
+            worktree_dir,
+            ctx.cli_overrides,
+            ctx.label_overrides,
+        )
+        .await
         {
             Ok(result) => {
                 let status = if result.success {
@@ -759,6 +720,82 @@ pub(super) fn build_pr_body(
     body.push_str(&format!("\nCloses #{issue_number}"));
 
     body
+}
+
+/// Run an agentless stage command and return `(success, output_text, duration)`.
+///
+/// If `pr_number` is `Some`, the `FORZA_PR_NUMBER` environment variable is set on
+/// the child process (reactive mode). Otherwise no extra env vars are added (linear
+/// mode).
+pub(super) async fn run_agentless_stage(
+    command: &str,
+    worktree_dir: &Path,
+    pr_number: Option<u64>,
+) -> (bool, String, std::time::Duration) {
+    let start = std::time::Instant::now();
+    // SAFETY: input is config-trusted, not user/GitHub-controlled
+    let mut cmd = tokio::process::Command::new("sh");
+    cmd.args(["-c", command]).current_dir(worktree_dir);
+    if let Some(n) = pr_number {
+        cmd.env("FORZA_PR_NUMBER", n.to_string());
+    }
+    let output = cmd.output().await;
+    let duration = start.elapsed();
+    let (success, output_text) = match output {
+        Ok(o) => {
+            let stdout = String::from_utf8_lossy(&o.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&o.stderr).to_string();
+            let text = if stderr.is_empty() { stdout } else { stderr };
+            (o.status.success(), text)
+        }
+        Err(e) => (false, e.to_string()),
+    };
+    (success, output_text, duration)
+}
+
+/// Build a `ClaudeAdapter` with resolved model/skills/mcp/system-prompt and execute
+/// the given planned stage.
+///
+/// Both the linear (`execute_stages`) and reactive (`process_reactive_pr`) paths share
+/// this adapter-construction and execution logic. Pass `CliOverrides::default()` for
+/// the reactive path which has no CLI overrides.
+pub(super) async fn run_agent_stage(
+    planned: &planner::PlannedStage,
+    config: &RunnerConfig,
+    route: &Route,
+    worktree_dir: &Path,
+    cli_overrides: &CliOverrides,
+    label_overrides: &LabelOverrides,
+) -> Result<StageResult> {
+    let stage_model = cli_overrides
+        .model
+        .as_deref()
+        .or(label_overrides.model.as_deref())
+        .or(planned.model.as_deref())
+        .or_else(|| config.effective_model(route));
+    let stage_skills = if !cli_overrides.skills.is_empty() {
+        cli_overrides.skills.as_slice()
+    } else if !label_overrides.skills.is_empty() {
+        label_overrides.skills.as_slice()
+    } else {
+        config.effective_skills(route, planned.skills.as_deref())
+    };
+    let stage_mcp = config.effective_mcp_config(route, planned.mcp_config.as_deref());
+    let stage_syspr = config.effective_append_system_prompt();
+    let mut stage_adapter = ClaudeAdapter::new();
+    if let Some(m) = stage_model {
+        stage_adapter = stage_adapter.model(m);
+    }
+    if !stage_skills.is_empty() {
+        stage_adapter = stage_adapter.skills(stage_skills.iter().cloned());
+    }
+    if let Some(p) = stage_mcp {
+        stage_adapter = stage_adapter.mcp_config(p);
+    }
+    if let Some(s) = stage_syspr {
+        stage_adapter = stage_adapter.append_system_prompt(s);
+    }
+    stage_adapter.execute_stage(planned, worktree_dir).await
 }
 
 pub(super) async fn run_stage_hooks(hooks: &[String], work_dir: &Path, label: &str) {

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use crate::config::{CliOverrides, Route, RunnerConfig};
 use crate::error::{Error, Result};
-use crate::executor::{AgentAdapter, ClaudeAdapter, StageResult};
+use crate::executor::StageResult;
 use crate::git::GitClient;
 use crate::github;
 use crate::github::GitHubClient;
@@ -601,27 +601,12 @@ pub async fn process_reactive_pr(
                     stage.kind.name()
                 )));
             };
-            let start = std::time::Instant::now();
-            let output = tokio::process::Command::new("sh")
-                .args(["-c", command])
-                .current_dir(&worktree_dir)
-                .env("FORZA_PR_NUMBER", pr_number.to_string())
-                .output()
-                .await;
-            let duration = start.elapsed();
-            let (success, output_text) = match output {
-                Ok(o) => {
-                    let stdout = String::from_utf8_lossy(&o.stdout).to_string();
-                    let stderr = String::from_utf8_lossy(&o.stderr).to_string();
-                    let text = if stderr.is_empty() { stdout } else { stderr };
-                    (o.status.success(), text)
-                }
-                Err(e) => (false, e.to_string()),
-            };
+            let (success, output_text, duration) =
+                run_agentless_stage(command, &worktree_dir, Some(pr_number)).await;
             info!(
                 pr = pr_number,
                 stage = planned.kind_name(),
-                success = success,
+                success,
                 duration = format!("{:.1}s", duration.as_secs_f64()),
                 "reactive agentless stage complete"
             );
@@ -642,33 +627,16 @@ pub async fn process_reactive_pr(
                 },
             );
         } else {
-            let stage_model = label_overrides
-                .model
-                .as_deref()
-                .or(planned.model.as_deref())
-                .or_else(|| config.effective_model(route));
-            let stage_skills = if !label_overrides.skills.is_empty() {
-                label_overrides.skills.as_slice()
-            } else {
-                config.effective_skills(route, planned.skills.as_deref())
-            };
-            let stage_mcp = config.effective_mcp_config(route, planned.mcp_config.as_deref());
-            let stage_syspr = config.effective_append_system_prompt();
-            let mut stage_adapter = ClaudeAdapter::new();
-            if let Some(m) = stage_model {
-                stage_adapter = stage_adapter.model(m);
-            }
-            if !stage_skills.is_empty() {
-                stage_adapter = stage_adapter.skills(stage_skills.iter().cloned());
-            }
-            if let Some(p) = stage_mcp {
-                stage_adapter = stage_adapter.mcp_config(p);
-            }
-            if let Some(s) = stage_syspr {
-                stage_adapter = stage_adapter.append_system_prompt(s);
-            }
-
-            match stage_adapter.execute_stage(&planned, &worktree_dir).await {
+            match run_agent_stage(
+                &planned,
+                config,
+                route,
+                &worktree_dir,
+                &CliOverrides::default(),
+                &label_overrides,
+            )
+            .await
+            {
                 Ok(result) => {
                     info!(
                         pr = pr_number,


### PR DESCRIPTION
## Summary

Automated implementation for [#164](https://github.com/joshrotenberg/forza/issues/164) — refactor: extract shared stage execution from issue/PR paths.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 165.5s | - |
| implement | succeeded | 274.9s | - |
| test | succeeded | 28.1s | - |
| review | succeeded | 72.6s | - |

## Files changed

```
 src/orchestrator/helpers.rs | 153 +++++++++++++++++++++++++++-----------------
 src/orchestrator/mod.rs     |  60 ++++-------------
 2 files changed, 109 insertions(+), 104 deletions(-)
```

## Plan

# Plan Stage — Issue #164

## Key findings

### What is already shared
`process_issue_with_overrides` and `process_pr_with_overrides` (mod.rs) already delegate
their inner stage loops entirely to `execute_stages()` in helpers.rs via a `StageContext`
struct. The stage execution loop duplication between those two functions was extracted
previously.

### Real duplication: `process_reactive_pr`
The remaining duplication is in `process_reactive_pr` (mod.rs lines 560–708). This
function inlines:
- **Condition evaluation** (lines 564–584): exits 0 = run stage (semantics are REVERSED
  from `execute_stages()` where exit 0 = skip stage)
- **Agentless execution** (lines 595–641): identical `sh -c` pattern + result recording
- **Agent execution** (lines 642–703): identical ClaudeAdapter construction
  (label_overrides, config.effective_model/skills/mcp/append_system_prompt) + execute_stage

### What is NOT duplicated in reactive mode
`process_reactive_pr` does not call `run_stage_hooks()`, load breadcrumbs, or run
validation. The reactive loop also only executes ONE stage per cycle (breaks after first).

## Implementation plan

Extract two `pub(super)` helpers into `helpers.rs`:

### 1. `run_agentless_stage()`
Signature (approx):
```rust
pub(super) async fn run_agentless_stage(
    command: &str,
    worktree_dir: &Path,
    subject_number: u64,
    env_var_name: &str,   // "FORZA_PR_NUMBER" or similar
) -> (bool, String, std::time::Duration)
```
Replaces the `sh -c` blocks in `execute_stages()` (agentless path) and `process_reactive_pr`.

### 2. `run_agent_stage()`
Signature (approx):
```rust
pub(super) async fn run_agent_stage(
    planned: &planner::PlannedStage,
    config: &RunnerConfig,
    route: &Route,
    worktree_dir: &Path,
    cli_overrides: &CliOverrides,
    label_overrides: &LabelOverrides,
) -> Result<StageResult>
```
Builds the ClaudeAdapter with resolved model/skills/mcp/system-prompt and calls
`execute_stage()`. Replaces adapter-build + execute blocks in both callers.

### Files changed
- `src/orchestrator/helpers.rs`: add `run_agentless_stage()` and `run_agent_stage()`
- `src/orchestrator/mod.rs`: replace inline blocks in `process_reactive_pr` with calls
  to the new helpers; also update `execute_stages()` call sites in helpers.rs

## Notes for implement stage
- Condition semantics differ: keep them separate (linear = exit 0 means skip; reactive = exit 0 means run)
- `process_reactive_pr` does not fire hooks — do not add hook calls when refactoring
- The `FORZA_PR_NUMBER` env var is set in reactive agentless execution; the linear path
  does not set it — check whether to unify or keep separate
- All existing tests should pass without modification; behavior must be identical
- Run `cargo test` to confirm after changes


## Review

## Review stage — issue #164

### What was reviewed

Commit `b35b796` — `refactor(orchestrator): extract shared stage execution helpers closes #164`

Changed files: `src/orchestrator/helpers.rs`, `src/orchestrator/mod.rs`

### Key findings

**Correctness:** The refactor is correct. Two blocks of duplicated code were extracted into named helpers:

- `run_agentless_stage(command, worktree_dir, pr_number: Option<u64>)` — consolidates the agentless shell-command execution that was duplicated verbatim in `execute_stages` (linear path) and `process_reactive_pr` (reactive path). The `Option<u64>` parameter cleanly handles the difference: reactive path passes `Some(pr_number)` to set `FORZA_PR_NUMBER`; linear path passes `None`.

- `run_agent_stage(planned, config, route, worktree_dir, cli_overrides, label_overrides)` — consolidates the `ClaudeAdapter` construction + `execute_stage` call, also duplicated across both paths. Reactive path passes `&CliOverrides::default()` since it has no CLI overrides.

**Import cleanup:** `AgentAdapter` and `ClaudeAdapter` imports removed from `mod.rs` (no longer used there). Correct.

**Behavior preserved:** No logic changes — pure extraction. `StageResult` construction was moved 8 lines later in the agentless path (after the `info!` log), which has no semantic effect.

**Tests:** No new tests required; this is a pure refactor. All 103 unit tests and 10 integration tests pass unchanged.

**Code quality:** Doc comments on both new helpers accurately describe their purpose and usage. Style matches surrounding code.

### Verdict: PASS

### For open_pr stage

- Branch: `automation/164-refactor-extract-shared-stage-execution`
- Commit: `b35b796` already in place — no additional commits needed
- PR title suggestion: `refactor(orchestrator): extract shared stage execution helpers`
- Closes: #164


Closes #164