### PR TITLE
fix: replace unwrap() with proper error handling in server paths

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -130,7 +130,10 @@ async fn resolve_repo_for_api(
 ) -> Result<(String, PathBuf, IndexMap<String, Route>), ApiError> {
     let repos = config.iter_repos();
     let (repo_str, entry_repo_dir, routes) = if repos.len() == 1 {
-        repos.into_iter().next().unwrap()
+        repos
+            .into_iter()
+            .next()
+            .ok_or_else(|| ApiError::BadRequest("no repos configured".into()))?
     } else {
         match args_repo {
             Some(r) => match repos.into_iter().find(|(repo, _, _)| *repo == r) {
@@ -419,4 +422,102 @@ async fn trigger_batch(State(state): State<Arc<AppState>>) -> Result<Response, A
         }),
     )
         .into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::path::Path;
+
+    struct NoopGit;
+
+    #[async_trait]
+    impl crate::git::GitClient for NoopGit {
+        async fn fetch(&self, _: &Path) -> crate::error::Result<()> {
+            unimplemented!()
+        }
+        async fn worktree_add(&self, _: &Path, _: &str, _: &str) -> crate::error::Result<PathBuf> {
+            unimplemented!()
+        }
+        async fn worktree_remove(&self, _: &Path, _: &Path, _: bool) -> crate::error::Result<()> {
+            unimplemented!()
+        }
+        async fn remote_url(&self, _: &Path) -> crate::error::Result<String> {
+            unimplemented!()
+        }
+        async fn ref_exists(&self, _: &Path, _: &str) -> crate::error::Result<bool> {
+            unimplemented!()
+        }
+        async fn has_changes(&self, _: &Path) -> crate::error::Result<bool> {
+            unimplemented!()
+        }
+        async fn stage_tracked(&self, _: &Path) -> crate::error::Result<()> {
+            unimplemented!()
+        }
+        async fn commit(&self, _: &Path, _: &str) -> crate::error::Result<()> {
+            unimplemented!()
+        }
+        async fn rebase(&self, _: &Path, _: &str) -> crate::error::Result<bool> {
+            unimplemented!()
+        }
+        async fn rebase_abort(&self, _: &Path) -> crate::error::Result<()> {
+            unimplemented!()
+        }
+        async fn diff_stat(&self, _: &Path, _: &str) -> crate::error::Result<String> {
+            unimplemented!()
+        }
+        async fn push(&self, _: &Path, _: &str) -> crate::error::Result<()> {
+            unimplemented!()
+        }
+        async fn push_force(&self, _: &Path, _: &str) -> crate::error::Result<()> {
+            unimplemented!()
+        }
+        async fn version(&self) -> crate::error::Result<String> {
+            unimplemented!()
+        }
+    }
+
+    fn multi_repo_config() -> RunnerConfig {
+        toml::from_str(
+            r#"
+[global]
+
+[repos."owner/repo-a".routes.bugfix]
+type = "issue"
+label = "bug"
+workflow = "bug"
+
+[repos."owner/repo-b".routes.bugfix]
+type = "issue"
+label = "bug"
+workflow = "bug"
+"#,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn resolve_repo_for_api_multi_no_param_errors() {
+        let config = multi_repo_config();
+        let git = NoopGit;
+        let err = resolve_repo_for_api(None, &config, &git).await.unwrap_err();
+        assert!(matches!(err, ApiError::BadRequest(_)));
+        if let ApiError::BadRequest(msg) = err {
+            assert!(msg.contains("multiple repos configured"));
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_repo_for_api_multi_unknown_repo_errors() {
+        let config = multi_repo_config();
+        let git = NoopGit;
+        let err = resolve_repo_for_api(Some("owner/unknown"), &config, &git)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ApiError::BadRequest(_)));
+        if let ApiError::BadRequest(msg) = err {
+            assert!(msg.contains("not found in config"));
+        }
+    }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -104,7 +104,10 @@ struct ConfigValidateInput {
 fn resolve_repo(config: &RunnerConfig, repo: Option<&str>) -> Result<RepoResolution, String> {
     let repos = config.iter_repos();
     let (repo_str, entry_dir, routes) = if repos.len() == 1 {
-        repos.into_iter().next().unwrap()
+        repos
+            .into_iter()
+            .next()
+            .ok_or_else(|| "no repos configured".to_string())?
     } else {
         match repo {
             Some(r) => match repos.into_iter().find(|(s, _, _)| *s == r) {
@@ -479,4 +482,71 @@ pub async fn serve(
         .run()
         .await
         .map_err(|e| crate::error::Error::State(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn single_repo_config() -> RunnerConfig {
+        toml::from_str(
+            r#"
+[global]
+repo = "owner/repo"
+
+[routes.bugfix]
+type = "issue"
+label = "bug"
+workflow = "bug"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn multi_repo_config() -> RunnerConfig {
+        toml::from_str(
+            r#"
+[global]
+
+[repos."owner/repo-a".routes.bugfix]
+type = "issue"
+label = "bug"
+workflow = "bug"
+
+[repos."owner/repo-b".routes.bugfix]
+type = "issue"
+label = "bug"
+workflow = "bug"
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn resolve_repo_single_repo_succeeds() {
+        let config = single_repo_config();
+        let (repo, _dir, _routes) = resolve_repo(&config, None).unwrap();
+        assert_eq!(repo, "owner/repo");
+    }
+
+    #[test]
+    fn resolve_repo_multi_no_param_errors() {
+        let config = multi_repo_config();
+        let err = resolve_repo(&config, None).unwrap_err();
+        assert!(err.contains("multiple repos configured"));
+    }
+
+    #[test]
+    fn resolve_repo_multi_with_param_succeeds() {
+        let config = multi_repo_config();
+        let (repo, _dir, _routes) = resolve_repo(&config, Some("owner/repo-a")).unwrap();
+        assert_eq!(repo, "owner/repo-a");
+    }
+
+    #[test]
+    fn resolve_repo_multi_unknown_param_errors() {
+        let config = multi_repo_config();
+        let err = resolve_repo(&config, Some("owner/unknown")).unwrap_err();
+        assert!(err.contains("not found in config"));
+    }
 }


### PR DESCRIPTION
## Summary

Automated implementation for [#156](https://github.com/joshrotenberg/forza/issues/156) — fix: replace unwrap() with proper error handling in server paths.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 90.9s | - |
| implement | succeeded | 179.1s | - |
| test | succeeded | 23.3s | - |
| review | succeeded | 48.4s | - |

## Files changed

```
 src/api.rs | 103 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
 src/mcp.rs |  72 +++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 173 insertions(+), 2 deletions(-)
```

## Plan

## Context from plan stage

### Problem
`api.rs:133` and `mcp.rs:107` both have:
```rust
repos.into_iter().next().unwrap()
```
inside an `if repos.len() == 1` guard. The guard makes the panic unreachable today (because `iter_repos()` in `config.rs:593-604` always returns at least one entry), but `unwrap()` is unsafe code smell.

### Key finding: iter_repos() always returns >= 1 item
`iter_repos()` has two branches: legacy mode (`self.repos.is_empty()`) always pushes one entry with `self.global.repo.as_deref().unwrap_or("")`; multi-repo mode only runs when `self.repos` is non-empty. So the unwrap inside `len() == 1` cannot currently panic — but the fix is still correct defensiveness.

### Fix in api.rs (line 133)
- Return type of `resolve_repo_for_api` is `Result<..., ApiError>`
- Replace with: `repos.into_iter().next().ok_or_else(|| ApiError::BadRequest("no repos configured".into()))?`

### Fix in mcp.rs (line 107)
- Return type of `resolve_repo` is `Result<RepoResolution, String>`
- Replace with: `repos.into_iter().next().ok_or_else(|| "no repos configured".to_string())?`

### Tests to add
- `mcp.rs`: unit test for `resolve_repo` — single-repo config succeeds (exercises the previously-unwrapped path); this function is sync and testable directly.
- `api.rs`: `resolve_repo_for_api` is async and requires a `&dyn GitClient`, making it harder to unit-test directly. Add a test for the multiple-repo-no-repo-param error path at minimum, and the single-repo happy path using a mock git client if one is available.

### No other files need changes
`src/error.rs`, `src/config.rs`, and all other callers of `iter_repos()` are unaffected.

### Commit message
`fix(server): replace unwrap() with proper error returns in resolve_repo closes #156`


## Review

## Context from review stage

### Verdict: PASS — no high-severity issues

### What was reviewed
Issue #156: replace `unwrap()` with proper error returns in `resolve_repo`.

Two files changed:

**src/mcp.rs** — `resolve_repo` (sync, returns `Result<RepoResolution, String>`):
- Replaces `unwrap()` on the single-repo iterator `.next()` with `ok_or_else(|| "no repos configured".to_string())`.
- Multi-repo no-param path: `Err("multiple repos configured — specify the 'repo' field")`.
- Multi-repo unknown-param path: `Err("repo '{r}' not found in config")`.
- 4 unit tests cover all paths.

**src/api.rs** — `resolve_repo_for_api` (async, returns `Result<..., ApiError>`):
- Replaces `unwrap()` on the single-repo iterator `.next()` with `ok_or_else(|| ApiError::BadRequest("no repos configured"))`.
- Multi-repo no-param path: `Err(ApiError::BadRequest("multiple repos configured — use ?repo= to specify which one"))`.
- Multi-repo unknown-param path: `Err(ApiError::BadRequest("repo '{r}' not found in config"))`.
- 2 async tests cover the multi-repo error paths.

### For the open_pr stage
- Commit is `474c35d`: `fix(server): replace unwrap() with proper error returns in resolve_repo closes #156`
- Branch: `automation/156-fix-replace-unwrap-with-proper-error-han`
- No source changes are needed — implementation is correct and complete.
- All tests passed (113 tests, 0 failures) per the test stage.


Closes #156