### PR TITLE
feat: print next-steps guidance after forza init

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -514,7 +514,20 @@ workflow = "feature"
         return ExitCode::FAILURE;
     }
 
-    println!("Created {}", args.output.display());
+    println!("Config written to {}", args.output.display());
+    println!();
+    println!("Next steps:");
+    println!(
+        "  1. Review and customize {} for your project",
+        args.output.display()
+    );
+    println!("  2. Add validation commands (e.g., cargo fmt, cargo test) to catch regressions");
+    println!("  3. Label a GitHub issue with \"bug\" and \"forza:ready\"");
+    println!("  4. Run: forza issue <number> --dry-run    (preview what forza would do)");
+    println!("  5. Run: forza issue <number>              (let forza work the issue)");
+    println!("  6. Run: forza watch --repo-dir .          (continuous mode)");
+    println!();
+    println!("Docs: https://github.com/joshrotenberg/forza");
     ExitCode::SUCCESS
 }
 


### PR DESCRIPTION
## Summary

Automated implementation for [#224](https://github.com/joshrotenberg/forza/issues/224) — feat: print next-steps guidance after forza init.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 90.4s | - |
| implement | succeeded | 38.7s | - |
| test | succeeded | 29.4s | - |
| review | succeeded | 50.1s | - |

## Files changed

```
 src/main.rs | 15 ++++++++++++++-
 1 file changed, 14 insertions(+), 1 deletion(-)
```

## Plan

# Context from plan stage

## Key findings

- The only file that needs changing is `src/main.rs`.
- The `cmd_init` function is at lines 309–395. It ends with `println!("Created {}", args.output.display())` at line 393, then returns `ExitCode::SUCCESS`.
- The insert point is immediately after line 393 (after printing the filename, before the return).

## What to add

After `println!("Created {}", args.output.display())`, add a blank line then the next-steps block:

```
println!();
println!("Next steps:");
println!("  1. Review and customize {} for your project", args.output.display());
println!("  2. Add validation commands (e.g., cargo fmt, cargo test) to catch regressions");
println!("  3. Label a GitHub issue with \"bug\" and \"forza:ready\"");
println!("  4. Run: forza issue <number> --dry-run    (preview what forza would do)");
println!("  5. Run: forza issue <number>              (let forza work the issue)");
println!("  6. Run: forza watch --repo-dir .          (continuous mode)");
println!();
println!("Docs: https://github.com/joshrotenberg/forza");
```

Note: the first line of output before "Next steps:" should be `Config written to <filename>` per the issue spec — currently the code says `Created <filename>`. The implement stage should change that message to match the issue's spec (`Config written to forza.toml`).

## Decisions

- No new functions, structs, or modules needed — purely additive `println!()` calls.
- Output style matches existing CLI patterns (plain println!, blank lines for separation).
- Use `args.output.display()` in step 1 so it reflects non-default `--output` paths.
- Change existing "Created" message to "Config written to" to match the issue spec exactly.

## Commit message
`feat(init): print next-steps guidance after forza init closes #224`


## Review

# Review Stage Breadcrumb

## What was done

Reviewed the implementation for issue #224 — print next-steps guidance after `forza init`.

## Findings

- **Correctness**: Implementation matches intent. `cmd_init` now prints a numbered next-steps list after successfully writing the config file.
- **Tests**: No new tests added. The function is a CLI output path that writes to stdout; existing 113 tests continue to pass. The output is cosmetic/UX and not load-bearing logic, so absence of new tests is acceptable.
- **Code quality**: No bugs, panics, or unsafe patterns. Change is purely additive (+14, -1). The only change to existing behavior is the first `println!` message changing from `"Created {}"` to `"Config written to {}"` — a minor wording improvement, not a behavioral change.
- **Consistency**: Style matches surrounding code exactly (same `println!` pattern, same indentation, same use of `args.output.display()`).

## Verdict

PASS — no high-severity issues found.

## For the next stage (open_pr)

- Branch: `automation/224-feat-print-next-steps-guidance-after-for`
- Commit: `feat(init): print next-steps guidance after forza init closes #224` (e48b523)
- Only file changed: `src/main.rs` (+14, -1)
- Ready to open PR against `main`.


Closes #224