### PR TITLE
docs: add use cases and progressive complexity section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,26 @@ Autonomous GitHub issue runner. Turns issues into pull requests through configur
 GitHub Issue  ->  Route Match  ->  Workflow  ->  Stages  ->  Pull Request  ->  Auto-Merge
 ```
 
-Point it at a repo, it picks up labeled issues, matches them to routes, executes staged workflows (plan, implement, test, review), opens PRs, and optionally auto-merges them. Each stage runs a bounded agent session in an isolated git worktree.
+When an issue is labeled (or a PR enters a matching state), forza:
+
+1. **Picks it up** — the watch loop finds issues with `forza:ready` or PRs matching a condition route
+2. **Matches a route** — compares the label or PR state against your configured routes to select a workflow
+3. **Executes stages** — runs each stage in order (e.g., plan → implement → test → review → open_pr), with validation commands between stages and breadcrumbs carrying context forward
+4. **Opens a PR** — commits the work to an isolated git worktree and opens a PR against your branch
+5. **Merges (optional)** — if `auto_merge = true` and CI passes, the merge stage completes the lifecycle
 
 For PRs, condition routes automatically detect CI failures and merge conflicts, fix them reactively, and merge when green.
+
+### forza vs. running Claude directly
+
+| | forza | Claude directly |
+|---|---|---|
+| Stage sequencing | Deterministic, configured per workflow | Ad-hoc, single session |
+| Context hand-off | Breadcrumbs carry forward between stages | Manual copy-paste |
+| Validation | Commands run between every stage | None by default |
+| Retry / escalation | `max_retries` + `forza:needs-human` label | Manual |
+| Worktree isolation | Each run gets a clean git worktree | Working directory |
+| PR lifecycle | Automated open, update, merge | Manual |
 
 ## Quick start
 
@@ -41,6 +58,155 @@ forza run
 # Watch mode (continuous polling + auto-fix)
 forza watch --interval 60
 ```
+
+## When to use forza
+
+**Solo developer** — label a backlog issue `forza:ready` and let forza open a PR while you work on something else. Good for bug fixes, dependency updates, documentation PRs, and chores that follow a clear pattern.
+
+**Team with an issue backlog** — apply `forza:ready` to issues you're comfortable automating. Forza triages, plans, and implements while the team focuses on review. Pair with `gate_label` so nothing runs until you've explicitly opted it in.
+
+**CI maintenance** — configure condition routes (`ci_failing_or_conflicts`, `approved_and_green`) so forza watches your forza-owned PRs and fixes failures, rebases stale branches, and merges when green — without anyone having to manually re-trigger CI or click merge.
+
+**Research and exploration** — use a `research` route with the `research -> comment` workflow. Forza investigates a question (API compatibility, migration path, alternative approaches) and posts findings directly on the issue as a comment. No code changes, no PR.
+
+## Progressive complexity
+
+### Minimal
+
+Get started with a single repo and one label route. No validation, default workflow, no auto-merge.
+
+```toml
+[global]
+model = "claude-sonnet-4-6"
+
+[repos."owner/name"]
+
+[repos."owner/name".routes.bugfix]
+type = "issue"
+label = "bug"
+workflow = "bug"
+```
+
+### Standard
+
+Add validation, multiple routes, and auto-merge. This is the recommended starting point for most projects.
+
+```toml
+[global]
+model = "claude-sonnet-4-6"
+gate_label = "forza:ready"
+branch_pattern = "automation/{issue}-{slug}"
+auto_merge = true
+
+[security]
+authorization_level = "trusted"
+
+[validation]
+commands = [
+    "cargo fmt --all -- --check",
+    "cargo clippy --all-targets -- -D warnings",
+    "cargo test --lib",
+]
+
+[repos."owner/name"]
+
+[repos."owner/name".routes.bugfix]
+type = "issue"
+label = "bug"
+workflow = "bug"
+concurrency = 1
+
+[repos."owner/name".routes.features]
+type = "issue"
+label = "enhancement"
+workflow = "feature"
+concurrency = 2
+
+[repos."owner/name".routes.fix-pr]
+type = "pr"
+label = "forza:fix-pr"
+workflow = "pr-fix"
+
+[repos."owner/name".routes.auto-fix]
+type = "pr"
+condition = "ci_failing_or_conflicts"
+workflow = "pr-maintenance"
+scope = "forza_owned"
+max_retries = 3
+```
+
+### Advanced
+
+Multiple repos, custom workflow templates, per-stage hooks, skill injection, and reactive PR maintenance.
+
+```toml
+[global]
+model = "claude-sonnet-4-6"
+gate_label = "forza:ready"
+auto_merge = true
+max_concurrency = 5
+
+[security]
+authorization_level = "trusted"
+
+[validation]
+commands = ["cargo test --all-features"]
+
+[agent_config]
+skills = ["./skills/rust.md"]
+mcp_config = ".mcp.json"
+
+[stage_hooks.implement]
+post    = ["cargo fmt --all"]
+finally = ["echo 'implement done'"]
+
+# First repo — standard issue routes
+[repos."org/backend"]
+
+[repos."org/backend".routes.bugfix]
+type = "issue"
+label = "bug"
+workflow = "bug"
+concurrency = 1
+skills = ["./skills/backend.md"]
+
+[repos."org/backend".routes.auto-merge]
+type = "pr"
+condition = "ci_green_no_objections"
+workflow = "pr-maintenance"
+scope = "forza_owned"
+max_retries = 2
+
+# Second repo — docs and research only
+[repos."org/docs"]
+
+[repos."org/docs".routes.docs]
+type = "issue"
+label = "documentation"
+workflow = "chore"
+concurrency = 3
+
+[repos."org/docs".routes.research]
+type = "issue"
+label = "research"
+workflow = "research"
+concurrency = 5
+
+# Custom workflow template
+[[workflow_templates]]
+name = "safe-feature"
+stages = [
+  { kind = "plan" },
+  { kind = "implement" },
+  { kind = "test", optional = true, condition = "git diff --quiet HEAD~1 -- tests/" },
+  { kind = "review" },
+  { kind = "open_pr" },
+]
+```
+
+### Self-hosting
+
+For a complete real-world example, see [`forza.toml`](forza.toml) in this repository. It is the config forza uses to process its own issues and PRs, with bug, feature, chore, and research routes plus condition-based PR maintenance.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

Automated implementation for [#222](https://github.com/joshrotenberg/forza/issues/222) — docs: add use cases and progressive complexity section to README.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 50.4s | - |
| implement | succeeded | 92.6s | - |
| test | succeeded | 33.9s | - |
| review | succeeded | 50.5s | - |

## Files changed

```
 README.md | 168 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 167 insertions(+), 1 deletion(-)
```

## Plan

# Context from plan stage — issue #222

## Summary

Documentation-only change. Only `README.md` needs to be modified.

## Current README structure (line reference)

- Lines 1–9: Title, badges, one-line description
- Lines 10–18: `## How it works` — one-line ASCII diagram + two prose sentences
- Lines 20–43: `## Quick start` — CLI snippets
- Lines 45–94: `## Configuration` — TOML quick-start example
- Lines 96–143: `## Concepts` — Route, Workflow Template, Stage, Modes, Labels, Outcomes
- Lines 144–160: `## Architecture` — ASCII layer diagram
- Lines 162–176: `## CLI` — command list
- Lines 178–180: `## License`

## What needs to be added

### 1. Expand `## How it works` (replace/augment lines 10–18)

Add a prose walkthrough of the full lifecycle (issue labeled → route matched → workflow selected → stages executed → PR opened → merged/failed) and a short "forza vs. running Claude directly" comparison table or bullet list covering: deterministic stages, retry budgets, breadcrumbs (inter-stage context), validation between stages, worktree isolation.

### 2. New `## When to use forza` section (insert after Quick start, before Configuration)

Four use-case personas:
1. Solo developer — automate bug fixes, dep updates, docs PRs
2. Team with issue backlog — label issues `forza:ready`, forza triages and implements while team reviews
3. CI maintenance — condition routes auto-fix broken PRs, rebase stale branches, merge approved PRs
4. Research and exploration — research routes investigate questions and post findings as comments

### 3. New `## Progressive complexity` section (insert after "When to use forza", before Configuration)

Four copy-pasteable TOML examples with brief commentary:
- **Minimal** (~5 lines): single repo, one label route, no validation, default workflow
- **Standard**: bug + feature routes, validation commands, auto_merge — essentially the current Configuration example
- **Advanced**: multi-repo, condition routes, custom workflow_templates, per-stage hooks, skill injection, reactive maintenance
- **Self-hosting**: prose + pointer to `forza.toml` in the repo root as a real-world example

## Key decisions

- The existing `## Configuration` section already serves as a "Standard" example; the progressive section should label it as such and keep it consistent so there's no duplication. The new minimal example is distinctly simpler; the advanced example is distinctly more complex.
- The `forza.toml` in the repo root is a complete real-world self-hosting config and should be referenced by name/path rather than duplicated inline.
- "How it works" already exists as a section header — expand it in place rather than creating a new section, to avoid restructuring the TOC.
- No source code, no new files beyond README.md edits.

## Commit message

docs: add use cases and progressive complexity section to README closes #222


## Review

# Context from review stage — issue #222

## Summary

Review passed. Documentation-only change; no source code modifications.

## Findings

- Only `README.md` was modified (167 lines added, 1 replaced). No code touched.
- All three planned additions are present and complete:
  1. Expanded `## How it works` with numbered lifecycle walkthrough and comparison table
  2. New `## When to use forza` section with four use-case personas
  3. New `## Progressive complexity` section with Minimal / Standard / Advanced / Self-hosting TOML examples
- TOML examples use valid, documented config keys consistent with `src/config.rs`.
- No duplication with existing `## Configuration` section.
- All tests continued to pass (confirmed by test stage).

## Verdict

**PASS** — no high-severity issues found.

## Next stage notes

- Branch: `automation/222-docs-add-use-cases-and-progressive-compl`
- Commit: `1d7168a docs: add use cases and progressive complexity section to README closes #222`
- Ready to open PR. Closes issue #222.
- Base branch: `main`


Closes #222