### PR TITLE
docs: add inline examples to CLI help text for all subcommands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,9 @@ enum Command {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_long_help = "Examples:\n  forza init --repo owner/name\n  forza init --repo owner/name --output ci.toml")]
+#[command(
+    after_long_help = "Examples:\n  forza init --repo owner/name\n  forza init --repo owner/name --output ci.toml"
+)]
 struct InitArgs {
     /// Repository in owner/name format (e.g. acme/myrepo).
     #[arg(long)]
@@ -63,7 +65,9 @@ struct InitArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_long_help = "Examples:\n  forza fix\n  forza fix --issue 42\n  forza fix --run <run-id>")]
+#[command(
+    after_long_help = "Examples:\n  forza fix\n  forza fix --issue 42\n  forza fix --run <run-id>"
+)]
 struct FixArgs {
     /// Run ID to fix (default: latest run).
     #[arg(long)]
@@ -74,7 +78,9 @@ struct FixArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_long_help = "Examples:\n  forza issue 42\n  forza issue 42 --dry-run --model claude-opus-4-6\n  forza issue 42 --skill ./skills/extra.md")]
+#[command(
+    after_long_help = "Examples:\n  forza issue 42\n  forza issue 42 --dry-run --model claude-opus-4-6\n  forza issue 42 --skill ./skills/extra.md"
+)]
 struct IssueArgs {
     /// Issue number to process.
     number: u64,
@@ -96,7 +102,9 @@ struct IssueArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_long_help = "Examples:\n  forza pr 123\n  forza pr 123 --route fix-pr\n  forza pr 123 --dry-run")]
+#[command(
+    after_long_help = "Examples:\n  forza pr 123\n  forza pr 123 --route fix-pr\n  forza pr 123 --dry-run"
+)]
 struct PrArgs {
     /// PR number to process.
     number: u64,
@@ -129,7 +137,9 @@ struct RunArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_long_help = "Examples:\n  forza watch\n  forza watch --repo-dir . --interval 30 --serve-api\n  forza watch --route bugfix")]
+#[command(
+    after_long_help = "Examples:\n  forza watch\n  forza watch --repo-dir . --interval 30 --serve-api\n  forza watch --route bugfix"
+)]
 struct WatchArgs {
     /// Override poll interval in seconds (uses per-route intervals by default).
     #[arg(long)]
@@ -155,7 +165,9 @@ struct WatchArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_long_help = "Examples:\n  forza status\n  forza status --all\n  forza status --run-id <id>\n  forza status --summary")]
+#[command(
+    after_long_help = "Examples:\n  forza status\n  forza status --all\n  forza status --run-id <id>\n  forza status --summary"
+)]
 struct StatusArgs {
     /// Show a specific run by ID.
     #[arg(long)]
@@ -183,7 +195,9 @@ struct McpArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_long_help = "Examples:\n  forza clean\n  forza clean --stale --days 7\n  forza clean --runs --dry-run")]
+#[command(
+    after_long_help = "Examples:\n  forza clean\n  forza clean --stale --days 7\n  forza clean --runs --dry-run"
+)]
 struct CleanArgs {
     /// Repository directory (default: current directory).
     #[arg(long)]
@@ -203,7 +217,9 @@ struct CleanArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_long_help = "Examples:\n  forza serve\n  forza serve --port 9090\n  forza serve --host 0.0.0.0 --port 9090")]
+#[command(
+    after_long_help = "Examples:\n  forza serve\n  forza serve --port 9090\n  forza serve --host 0.0.0.0 --port 9090"
+)]
 struct ServeArgs {
     /// Host address to bind to.
     #[arg(long, default_value = "127.0.0.1")]


### PR DESCRIPTION
## Summary

Automated implementation for [#221](https://github.com/joshrotenberg/forza/issues/221) — docs: add inline examples to CLI help text for all subcommands.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 103.5s | - |
| implement | succeeded | 72.5s | - |
| test | succeeded | 38.3s | - |
| review | succeeded | 85.1s | - |

## Files changed

```
 src/main.rs | 26 ++++++++++++++++++++++++++
 1 file changed, 26 insertions(+)
```

## Plan

# Context from plan stage

## Key findings

- All CLI code is in a single file: `src/main.rs`
- The project uses clap v4 with `derive` feature (`Parser`, `Subcommand`)
- Ten subcommand arg structs exist: `InitArgs`, `IssueArgs`, `PrArgs`, `RunArgs`, `WatchArgs`, `StatusArgs`, `FixArgs`, `CleanArgs`, `ServeArgs`, `McpArgs`
- None of the subcommand structs have `long_about` or `after_long_help` attributes — only the root `Cli` struct has a `long_about`
- Line ranges for each struct: `InitArgs` (55–62), `FixArgs` (64–72), `IssueArgs` (74–93), `PrArgs` (95–114), `RunArgs` (116–124), `WatchArgs` (126–149), `StatusArgs` (151–162), `McpArgs` (164–175), `CleanArgs` (177–194), `ServeArgs` (196–207)

## Decision

Use `#[command(after_long_help = "...")]` on each subcommand struct. This ensures:
- `-h` stays concise (no examples shown)
- `--help` shows the examples section at the bottom
- Matches the jpx-style pattern described in the issue

## What the implement stage must do

For each of the ten structs in `src/main.rs`, add a `#[command(after_long_help = "...")]` attribute directly after the `#[derive(Debug, Parser)]` line. Each block should follow this format:

```
Examples:
  forza <subcommand> <typical invocation>
  forza <subcommand> <invocation with key flags>
  ...
```

The examples to add per subcommand (from the issue and README):
- `init`:   `forza init --repo owner/name`, `forza init --repo owner/name --output ci.toml`
- `issue`:  `forza issue 42`, `forza issue 42 --dry-run --model claude-opus-4-6`, `forza issue 42 --skill ./skills/extra.md`
- `pr`:     `forza pr 123`, `forza pr 123 --route fix-pr`, `forza pr 123 --dry-run`
- `run`:    `forza run`, `forza run --repo-dir . --no-gate`
- `watch`:  `forza watch`, `forza watch --repo-dir . --interval 30 --serve-api`, `forza watch --route bugfix`
- `status`: `forza status`, `forza status --all`, `forza status --run-id <id>`, `forza status --summary`
- `fix`:    `forza fix`, `forza fix --issue 42`, `forza fix --run <run-id>`
- `clean`:  `forza clean`, `forza clean --stale --days 7`, `forza clean --runs --dry-run`
- `serve`:  `forza serve`, `forza serve --port 9090`, `forza serve --host 0.0.0.0 --port 9090`
- `mcp`:    `forza mcp`, `forza mcp --http --port 9090`

## Commit message

`docs(cli): add after_long_help examples to all subcommands closes #221`


## Review

## Context from review stage

### What was done

Reviewed the implementation of issue #221 (add `after_long_help` inline examples to CLI subcommands).

### Findings

- All 10 subcommands (`init`, `fix`, `issue`, `pr`, `run`, `watch`, `status`, `mcp`, `clean`, `serve`) have `after_long_help` examples added via `#[command(after_long_help = "...")]`.
- Flag names in examples are accurate (Clap snake_case→kebab-case conversion verified: `--serve-api`, `--run-id`, `--no-gate`, etc.).
- Change is docs-only — no functional impact.
- Style is consistent with existing code; `cargo fmt` accepted the formatting.
- All tests pass (validated in prior test stage).

### Verdict

**PASS** — no high-severity issues found.

### For the next stage (open_pr)

- Modified file: `src/main.rs` only.
- Commit `d4a9b7f` contains the implementation; a subsequent fmt-only fixup was also applied.
- The branch is `automation/221-docs-add-inline-examples-to-cli-help-tex`.
- PR title suggestion: `docs(cli): add after_long_help examples to all subcommands`
- Closes: #221


Closes #221