### PR TITLE
docs: document shell command trust boundary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,23 @@ The plan stage is special: it writes to `.plan_breadcrumb.md` in the repo root (
 `.forza/breadcrumbs/`). The implement stage reads it for the file list and exact commit
 message. Similarly `.review_breadcrumb.md` is written by review and read by open_pr.
 
+## Shell command trust boundary
+
+All shell commands that forza executes — `[validation].commands`, `[stage_hooks.*]`
+hook lists, agentless stage `command` fields, and stage `condition` fields — are run
+via `sh -c` with the string taken verbatim from the TOML config. There is no
+sandboxing or allowlisting.
+
+`forza.toml` is the trust boundary. These fields are equivalent to executable code:
+treat config changes that touch them the same as code changes.
+
+`authorization_level` in `[security]` controls what the Claude agent may do (merge,
+push, etc.), not what forza's own shell invocations may do. It does not restrict hooks,
+validation commands, agentless stages, or conditions.
+
+If forza is ever extended to accept config from untrusted sources (e.g., auto-applying
+PR-submitted `forza.toml` changes), these fields become a command injection vector.
+
 ## Agentless stages
 
 Set `agentless = true` and `command = "..."` on a stage to run a shell command directly

--- a/README.md
+++ b/README.md
@@ -341,6 +341,41 @@ forza serve         Start the REST API server
 forza mcp           Start the MCP server (stdio)
 ```
 
+## Security
+
+### Shell command trust boundary
+
+All shell commands that forza executes — validation commands, stage hooks, agentless
+stage commands, and stage conditions — are run via `sh -c` with the string taken
+directly from your `forza.toml`. This is by design: the config file is the trust
+boundary.
+
+**What this means in practice:**
+
+- Any string in `[validation].commands`, `[stage_hooks.*]` hook lists, agentless stage
+  `command` fields, and stage `condition` fields has full shell access to your
+  environment with the privileges of the forza process.
+- There is no sandboxing or command allowlisting for these config-driven shell
+  invocations.
+
+**The assumption:** `forza.toml` is trusted. Treat it like executable code — review
+changes to it the same way you would review code changes.
+
+**The risk:** If forza ever processes config from an untrusted source (for example,
+a PR that modifies `forza.toml`), those commands become an arbitrary code execution
+vector. Forza does not currently validate or restrict the content of commands in
+config.
+
+**Mitigations:**
+
+- Store `forza.toml` in version control and require review for all changes to it.
+- Do not configure forza to automatically apply config changes submitted by untrusted
+  contributors without explicit review.
+- Run forza with the minimum privileges needed for your workflows.
+- Note: `authorization_level` in `[security]` controls what the Claude agent can do,
+  not what forza's own shell invocations can do. It does not restrict hooks,
+  validation commands, agentless stages, or conditions.
+
 ## License
 
 MIT OR Apache-2.0

--- a/forza.toml
+++ b/forza.toml
@@ -33,11 +33,19 @@ auto_merge = true
 
 [security]
 # "trusted" allows merge and push operations.
+# authorization_level controls what the Claude agent is permitted to do (merge, push,
+# etc.). It does NOT restrict shell commands run by forza itself — see the note on
+# the shell command trust boundary below.
 authorization_level = "trusted"
 
 [validation]
 # These commands run between stages to catch regressions early.
 # If any command fails, the run stops.
+#
+# TRUST BOUNDARY: These strings are passed directly to `sh -c`. Treat this section
+# (and all hook, agentless command, and condition fields) as executable code. Only
+# values from a trusted forza.toml are safe to run; if untrusted sources can modify
+# this file they can execute arbitrary shell commands with forza's privileges.
 commands = [
     "cargo fmt --all -- --check",
     "cargo clippy --all-targets -- -D warnings",


### PR DESCRIPTION
## Summary

Automated implementation for [#155](https://github.com/joshrotenberg/forza/issues/155) — docs: document shell command trust boundary.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| implement | succeeded | 96.1s | - |
| test | succeeded | 35.3s | - |

## Files changed

```
 CLAUDE.md  | 17 +++++++++++++++++
 README.md  | 35 +++++++++++++++++++++++++++++++++++
 forza.toml |  8 ++++++++
 3 files changed, 60 insertions(+)
```

Closes #155