### PR TITLE
fix: early draft PR creation fails when no commits exist after plan stage

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -455,6 +455,9 @@ mod tests {
         async fn stage_tracked(&self, _: &Path) -> crate::error::Result<()> {
             unimplemented!()
         }
+        async fn stage_path(&self, _: &Path, _: &str) -> crate::error::Result<()> {
+            unimplemented!()
+        }
         async fn commit(&self, _: &Path, _: &str) -> crate::error::Result<()> {
             unimplemented!()
         }

--- a/src/git/cli.rs
+++ b/src/git/cli.rs
@@ -145,6 +145,11 @@ impl GitClient for GitCliClient {
         Ok(())
     }
 
+    async fn stage_path(&self, work_dir: &Path, path: &str) -> Result<()> {
+        let _ = git(&["add", path], work_dir).await?;
+        Ok(())
+    }
+
     async fn commit(&self, work_dir: &Path, message: &str) -> Result<()> {
         let _ = git(&["commit", "-m", message], work_dir).await?;
         Ok(())

--- a/src/git/gix_client.rs
+++ b/src/git/gix_client.rs
@@ -138,6 +138,12 @@ impl GitClient for GixClient {
         Ok(())
     }
 
+    async fn stage_path(&self, work_dir: &Path, path: &str) -> Result<()> {
+        // gix index manipulation is complex — use CLI.
+        let _ = git_cli(&["add", path], work_dir).await?;
+        Ok(())
+    }
+
     async fn commit(&self, work_dir: &Path, message: &str) -> Result<()> {
         // gix commit creation requires tree building — use CLI.
         let _ = git_cli(&["commit", "-m", message], work_dir).await?;

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -57,6 +57,9 @@ pub trait GitClient: Send + Sync {
     /// Stage all tracked file changes.
     async fn stage_tracked(&self, work_dir: &Path) -> Result<()>;
 
+    /// Stage a specific path (tracked or untracked).
+    async fn stage_path(&self, work_dir: &Path, path: &str) -> Result<()>;
+
     /// Create a commit with the given message.
     async fn commit(&self, work_dir: &Path, message: &str) -> Result<()>;
 

--- a/src/orchestrator/helpers.rs
+++ b/src/orchestrator/helpers.rs
@@ -623,6 +623,20 @@ pub(super) async fn create_early_draft_pr(
     gh: &dyn GitHubClient,
     git: &dyn GitClient,
 ) -> Result<github::PullRequest> {
+    // Stage and commit the plan breadcrumb so the branch has at least one commit
+    // diverging from main — GitHub requires a diff to create a PR.
+    let breadcrumbs_dir = work_dir.join(".forza").join("breadcrumbs");
+    if breadcrumbs_dir.exists() {
+        if let Err(e) = git.stage_path(work_dir, ".forza/breadcrumbs/").await {
+            warn!(error = %e, "failed to stage breadcrumbs (non-fatal)");
+        } else if let Err(e) = git
+            .commit(work_dir, &format!("plan: {}", issue.title))
+            .await
+        {
+            warn!(error = %e, "failed to commit plan breadcrumb (non-fatal)");
+        }
+    }
+
     // Push the branch so a PR can be created.
     git.push(work_dir, branch).await?;
 


### PR DESCRIPTION
## Summary

Automated implementation for [#240](https://github.com/joshrotenberg/forza/issues/240) — fix: early draft PR creation fails when no commits exist after plan stage.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 124.6s | - |
| implement | succeeded | 87.6s | - |
| test | succeeded | 34.3s | - |
| review | succeeded | 82.4s | - |

## Files changed

```
 src/api.rs                  |  3 +++
 src/git/cli.rs              |  5 +++++
 src/git/gix_client.rs       |  6 ++++++
 src/git/mod.rs              |  3 +++
 src/orchestrator/helpers.rs | 14 ++++++++++++++
 5 files changed, 31 insertions(+)
```

## Plan

# Context from plan stage

## Problem

`create_early_draft_pr` (helpers.rs:617) calls `git.push()` before GitHub can accept a
PR, because the branch has zero commits diverging from main. The plan stage writes
`.forza/breadcrumbs/{run_id}/plan.md` but does not commit it, so the push succeeds
(empty push) or fails and GitHub rejects `gh pr create --draft` with a "no diff" error.

## Root cause

`git.push()` is called at helpers.rs:627 with no prior commit. GitHub requires at least
one commit difference from the base branch to create a PR.

## Fix

Add `stage_path(work_dir: &Path, path: &str)` to the `GitClient` trait and all three
implementations:

- `src/git/mod.rs` — trait declaration (after `stage_tracked`)
- `src/git/cli.rs` — `git add <path>`
- `src/git/gix_client.rs` — delegate to `git_cli` like other write ops
- `src/api.rs` — stub `unimplemented!()` alongside other stubs

Then in `create_early_draft_pr` (helpers.rs:617), before `git.push()`:
1. Check if `.forza/breadcrumbs/` directory exists in `work_dir`
2. Call `git.stage_path(work_dir, ".forza/breadcrumbs/").await`
3. Call `git.commit(work_dir, &format!("plan: {}", issue.title)).await`
4. Proceed with existing `git.push()` call

The commit is best-effort (if staging/commit fails, still try to push and create the
PR, since existing behavior is non-fatal anyway).

## Key decisions

- Use a new `stage_path` trait method (not `stage_tracked`) because breadcrumb files
  are **untracked** — `git add -u` won't pick them up.
- Only stage `.forza/breadcrumbs/` (not all untracked files) to avoid accidentally
  committing agent artifacts.
- Commit is unconditional (no `has_changes` check) since breadcrumbs are always freshly
  written by the plan stage before `create_early_draft_pr` is called.

## Files to modify

1. `src/git/mod.rs` — add `stage_path` method to trait
2. `src/git/cli.rs` — implement `stage_path`
3. `src/git/gix_client.rs` — implement `stage_path`
4. `src/api.rs` — add stub for `stage_path`
5. `src/orchestrator/helpers.rs` — add commit step before push in `create_early_draft_pr`


## Review

## Context from review stage

### Verdict: PASS

The implementation for issue #240 is correct. No high-severity issues were found.

### What was changed

- `GitClient` trait gained `stage_path(&self, work_dir, path)` method (src/git/mod.rs:61)
- All three implementations updated: `CliGit` (src/git/cli.rs:148), `GixClient` (src/git/gix_client.rs:141), test mock in `src/api.rs:458`
- `create_early_draft_pr` in `src/orchestrator/helpers.rs` now stages `.forza/breadcrumbs/` and commits `"plan: {title}"` before pushing, ensuring the branch has at least one commit

### Key decisions confirmed

- Non-fatal error handling: both `stage_path` and `commit` failures log `warn!` and proceed — correct, since early draft PR creation should not be blocked by a missing breadcrumb commit
- `else if` chaining: commit is only attempted when staging succeeds — avoids a redundant "nothing to commit" error
- `GixClient` delegates to CLI for `stage_path` (same pattern as `commit` and `rebase`)
- The `.forza/breadcrumbs/` check is on the parent dir, not run-specific subdir — acceptable for the branch-per-issue model

### Low-severity notes for open_pr stage

1. The breadcrumb commit `"plan: <title>"` will be in branch history; reviewers will see it alongside implementation commits — no action needed
2. No new tests were added; the existing 114 tests all pass

### For open_pr stage

- `.review_breadcrumb.md` is written and ready
- Branch has at least one commit before the push (the fix's core guarantee)
- PR can be created normally via `handle_open_pr`


Closes #240