### PR TITLE
feat: add forza explain command to visualize config and route paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -989,9 +989,7 @@ fn cmd_explain(args: ExplainArgs, config: &forza::RunnerConfig) -> ExitCode {
                         "ci_failing_or_conflicts"
                     }
                     forza::config::RouteCondition::ApprovedAndGreen => "approved_and_green",
-                    forza::config::RouteCondition::CiGreenNoObjections => {
-                        "ci_green_no_objections"
-                    }
+                    forza::config::RouteCondition::CiGreenNoObjections => "ci_green_no_objections",
                 };
                 println!("    Trigger:    condition {cond_name}");
                 println!("    Poll:       {}s", route.poll_interval);
@@ -1073,7 +1071,10 @@ fn cmd_explain(args: ExplainArgs, config: &forza::RunnerConfig) -> ExitCode {
             }
 
             // On failure label
-            println!("    On failure: {} label applied", config.global.failed_label);
+            println!(
+                "    On failure: {} label applied",
+                config.global.failed_label
+            );
         }
 
         println!();
@@ -1085,10 +1086,7 @@ fn cmd_explain(args: ExplainArgs, config: &forza::RunnerConfig) -> ExitCode {
     println!("  Max concurrency: {}", config.global.max_concurrency);
     println!("  Auto-merge:      {}", config.global.auto_merge);
     println!("  Draft PR:        {}", config.global.draft_pr);
-    println!(
-        "  Security level:  {}",
-        config.security.authorization_level
-    );
+    println!("  Security level:  {}", config.security.authorization_level);
 
     ExitCode::SUCCESS
 }


### PR DESCRIPTION
## Summary

Automated implementation for [#236](https://github.com/joshrotenberg/forza/issues/236) — feat: add forza explain command to visualize config and route paths.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 167.9s | - |
| implement | succeeded | 167.5s | - |
| test | succeeded | 33.2s | - |
| review | succeeded | 131.7s | - |

## Files changed

```
 src/main.rs | 174 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 173 insertions(+), 1 deletion(-)
```

## Plan

# Context from plan stage — forza explain (#236)

## Key findings

**Only one file needs to change: `src/main.rs`.**

All config types, workflow types, and resolution methods are already public and usable.
No changes to `src/config.rs` or `src/workflow.rs` are required.

## Architecture decisions

- `cmd_explain` is a **synchronous** function (no `async`) — same pattern as `cmd_status`.
  It receives `(args: ExplainArgs, config: &forza::RunnerConfig)`.
- The command must be added to the `!matches!` exclusion on line 312-319 of `main.rs`
  so dep-validation is skipped (no agent binary needed for a config-only operation).
- Dispatch: `Command::Explain(args) => cmd_explain(args, &config)` (no `gh` or `git`
  clients passed — purely local).

## ExplainArgs struct

```rust
#[derive(Debug, Parser)]
#[command(after_long_help = "Examples:\n  forza explain\n  forza explain --repo owner/name\n  forza explain --json")]
struct ExplainArgs {
    /// Filter output to a single repository (owner/name).
    #[arg(long)]
    repo: Option<String>,
    /// Output as JSON instead of human-readable text.
    #[arg(long)]
    json: bool,
}
```

## cmd_explain logic outline

1. If `--json`: serialize `config` with `serde_json::to_string_pretty` and print, return SUCCESS.
2. Iterate `config.iter_repos()` — respects both legacy single-repo and multi-repo modes.
3. If `--repo` filter provided, skip non-matching repos.
4. For each repo, print header `Repository: {slug}`.
5. For each route:
   - Trigger: label `"X"` (+ gate label if `config.global.gate_label` is set) OR condition variant name
   - Workflow: name + mode (linear/reactive)
   - Stages: resolved via `config.resolve_workflow(route.workflow)` — print stage kinds
     in order; mark optional stages, agentless stages, stages with conditions
   - Retries: `route.max_retries` if set, else "default (2 per stage)"
   - Poll: `route.poll_interval`s (only for condition routes)
   - Effective model: `config.effective_model(route)` → name or "(none)"
   - Effective skills: `config.effective_skills(route, None)` → list of paths
   - Validation: `config.effective_validation(route)` → list of commands
   - On failure: `forza:failed` label applied (from `config.global.failed_label`)
6. Print Global section: max_concurrency, auto_merge, draft_pr, security level.

## Useful types/methods confirmed present

| Method | Location | Purpose |
|---|---|---|
| `config.iter_repos()` | config.rs:593 | Iterate all repos |
| `config.resolve_workflow(name)` | config.rs:722 | Get WorkflowTemplate |
| `config.effective_model(route)` | config.rs:662 | Model resolution |
| `config.effective_skills(route, None)` | config.rs:667 | Skills resolution |
| `config.effective_validation(route)` | config.rs:698 | Validation commands |
| `config.effective_draft_pr(route)` | config.rs:706 | Draft PR setting |
| `StageKind::name(self)` | workflow.rs:129 | Stage display name |
| `WorkflowMode` | workflow.rs:8 | Linear / Reactive |
| `RouteCondition` | config.rs:~270 | Condition variant names |
| `SecurityConfig` | config.rs | auth level field |

## RouteCondition display

The `RouteCondition` enum has variants: `CiFailing`, `HasConflicts`,
`CiFailingOrConflicts`, `ApprovedAndGreen`, `CiGreenNoObjections`. These should be
displayed in snake_case (matching the serde `rename_all = "snake_case"` config).

## Stage display format

For linear workflows: `plan -> implement -> test -> [review?] -> open_pr -> merge`
  - Square brackets = optional stage
  - Mark agentless stages with `(agentless)` suffix
  - Mark conditional stages (within reactive workflows) with their condition truncated

For reactive workflows: each stage on its own line with its condition gate.


## Review

## Context from review stage — forza explain (#236)

### Verdict: PASS

No high-severity issues. Two low-severity UX observations noted (silent no-op when `--repo` filter matches nothing; no `Trigger:` line for routes missing both label and condition). Neither is a correctness bug.

### Implementation validated

- `ExplainArgs` struct: `--repo` (filter) and `--json` flag, consistent with other args structs.
- `Explain(_)` added to dep-validation skip list — correct for a read-only command.
- JSON path: `serde_json::to_string_pretty(config)` — works; all config types derive `Serialize`. Error handled.
- Human-readable path: uses `iter_repos`, `resolve_workflow`, `effective_model`, `effective_skills`, `effective_validation` — all public API, no internals bypassed.
- Stage annotation (agentless, conditional, optional bracket) is correct.
- No panics; no unsafe code.
- No tests in `main.rs` — consistent with project convention; underlying methods tested in `config.rs`.

### For open_pr stage

- Only file changed from `main`: `src/main.rs`
- Commit: `feat(cli): add explain command to visualize config and route paths closes #236`
- All CI checks pass (fmt, clippy, lib tests, integration tests)
- PR is ready to open against `main`


Closes #236