### PR TITLE
fix: prevent condition route ping-pong between auto-fix and auto-merge

### DIFF
--- a/forza.toml
+++ b/forza.toml
@@ -122,25 +122,18 @@ concurrency = 2
 # ── Condition routes (monitors) ──────────────────────────────────────
 # These routes watch forza-owned PRs and automatically trigger fixes
 # when problems are detected. No manual labeling needed.
+#
+# A single any_actionable route replaces separate auto-fix and auto-merge
+# routes. Using one route prevents ping-pong: previously two routes could
+# both match the same PR in consecutive poll cycles, causing repeated
+# forza:in-progress label add/remove cycles. The reactive pr-maintenance
+# workflow handles priority ordering internally (conflicts → CI → merge).
+# Exponential backoff (poll_interval * 2^prior_fails, capped at 64x) is
+# applied automatically when prior failures are detected.
 
-# Auto-maintain forza-owned PRs. Uses the reactive pr-maintenance workflow:
-# each poll cycle evaluates conditions and runs ONE action:
-#   - CI failing → fix CI
-#   - Review changes requested → address feedback
-#   - CI green + no objections → merge
-# After 3 failed attempts, applies forza:needs-human instead.
-[repos."joshrotenberg/forza".routes.auto-fix]
+[repos."joshrotenberg/forza".routes.auto-maintain]
 type = "pr"
-condition = "ci_failing_or_conflicts"
-workflow = "pr-maintenance"
-scope = "forza_owned"
-max_retries = 3
-concurrency = 2
-poll_interval = 60
-
-[repos."joshrotenberg/forza".routes.auto-merge]
-type = "pr"
-condition = "ci_green_no_objections"
+condition = "any_actionable"
 workflow = "pr-maintenance"
 scope = "forza_owned"
 max_retries = 3

--- a/src/config.rs
+++ b/src/config.rs
@@ -284,6 +284,10 @@ pub enum RouteCondition {
     /// CI is green, no conflicts, and no CHANGES_REQUESTED review decision.
     /// Does not require an explicit APPROVED decision — branch protection is the real gate.
     CiGreenNoObjections,
+    /// Matches any PR that needs attention: CI failing, has conflicts, or CI green with no
+    /// objections (ready to merge). Combines `CiFailingOrConflicts` and `CiGreenNoObjections`
+    /// into a single route to prevent ping-pong between two condition routes.
+    AnyActionable,
 }
 
 impl RouteCondition {
@@ -317,6 +321,9 @@ impl RouteCondition {
             RouteCondition::CiFailingOrConflicts => ci_failing || has_conflicts,
             RouteCondition::ApprovedAndGreen => approved && ci_green && !has_conflicts,
             RouteCondition::CiGreenNoObjections => ci_green && !has_conflicts && !changes_requested,
+            RouteCondition::AnyActionable => {
+                ci_failing || has_conflicts || ci_green && !changes_requested
+            }
         }
     }
 }
@@ -1660,6 +1667,47 @@ max_retries = 3
         pr.review_decision = None;
         pr.checks_passing = Some(false);
         assert!(!RouteCondition::CiGreenNoObjections.matches(&pr));
+    }
+
+    #[test]
+    fn condition_matches_any_actionable() {
+        let mut pr = crate::github::PrCandidate {
+            number: 1,
+            repo: "owner/repo".into(),
+            title: "test".into(),
+            body: String::new(),
+            labels: vec![],
+            state: "open".into(),
+            html_url: String::new(),
+            head_branch: "automation/1-test".into(),
+            base_branch: "main".into(),
+            is_draft: false,
+            mergeable: Some("MERGEABLE".into()),
+            review_decision: None,
+            checks_passing: Some(false),
+        };
+        // CI failing → matches
+        assert!(RouteCondition::AnyActionable.matches(&pr));
+
+        // Has conflicts → matches
+        pr.checks_passing = Some(true);
+        pr.mergeable = Some("CONFLICTING".into());
+        assert!(RouteCondition::AnyActionable.matches(&pr));
+
+        // CI green, no conflicts, no objections → matches (ready to merge)
+        pr.mergeable = Some("MERGEABLE".into());
+        pr.checks_passing = Some(true);
+        pr.review_decision = None;
+        assert!(RouteCondition::AnyActionable.matches(&pr));
+
+        // CI green, no conflicts, but CHANGES_REQUESTED → does not match
+        pr.review_decision = Some("CHANGES_REQUESTED".into());
+        assert!(!RouteCondition::AnyActionable.matches(&pr));
+
+        // CI not yet resolved (None), no conflicts → does not match
+        pr.review_decision = None;
+        pr.checks_passing = None;
+        assert!(!RouteCondition::AnyActionable.matches(&pr));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -990,6 +990,7 @@ fn cmd_explain(args: ExplainArgs, config: &forza::RunnerConfig) -> ExitCode {
                     }
                     forza::config::RouteCondition::ApprovedAndGreen => "approved_and_green",
                     forza::config::RouteCondition::CiGreenNoObjections => "ci_green_no_objections",
+                    forza::config::RouteCondition::AnyActionable => "any_actionable",
                 };
                 println!("    Trigger:    condition {cond_name}");
                 println!("    Poll:       {}s", route.poll_interval);

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -946,31 +946,60 @@ pub async fn process_batch_for_repo(
                     continue;
                 }
 
-                // Check retry budget.
-                if let Some(max) = route.max_retries {
-                    let workflow_name = route.workflow.as_deref().unwrap_or("");
-                    let prior_runs =
-                        state::count_failed_runs_for_subject(pr.number, workflow_name, state_dir);
-                    if prior_runs >= max {
-                        warn!(
+                // Check retry budget and exponential backoff.
+                let workflow_name = route.workflow.as_deref().unwrap_or("");
+                let prior_fails =
+                    state::count_failed_runs_for_subject(pr.number, workflow_name, state_dir);
+                if let Some(max) = route.max_retries
+                    && prior_fails >= max
+                {
+                    warn!(
+                        pr = pr.number,
+                        route = route_name,
+                        prior_fails = prior_fails,
+                        max_retries = max,
+                        "retry budget exhausted, applying needs-human label"
+                    );
+                    let _ = gh.add_pr_label(repo, pr.number, "forza:needs-human").await;
+                    let _ = gh
+                        .comment_on_pr(
+                            repo,
+                            pr.number,
+                            &format!(
+                                "Retry budget exhausted for route `{route_name}` \
+                             ({prior_fails}/{max} attempts). Applying `forza:needs-human` \
+                             for manual review."
+                            ),
+                        )
+                        .await;
+                    continue;
+                }
+
+                // Exponential backoff: if there are prior failures, wait before retrying.
+                // backoff_secs = poll_interval * 2^(prior_fails - 1), capped at 2^6 = 64x.
+                if prior_fails > 0
+                    && let Some(last) = state::find_last_completed_run_for_subject(
+                        pr.number,
+                        workflow_name,
+                        state_dir,
+                    )
+                    && let Some(completed_at) = last.completed_at
+                {
+                    let exponent = (prior_fails - 1).min(6) as u32;
+                    let backoff_secs = route.poll_interval * 2u64.pow(exponent);
+                    let elapsed = chrono::Utc::now()
+                        .signed_duration_since(completed_at)
+                        .num_seconds()
+                        .max(0) as u64;
+                    if elapsed < backoff_secs {
+                        tracing::debug!(
                             pr = pr.number,
                             route = route_name,
-                            prior_runs = prior_runs,
-                            max_retries = max,
-                            "retry budget exhausted, applying needs-human label"
+                            prior_fails = prior_fails,
+                            elapsed_secs = elapsed,
+                            backoff_secs = backoff_secs,
+                            "skipping PR: within exponential backoff window"
                         );
-                        let _ = gh.add_pr_label(repo, pr.number, "forza:needs-human").await;
-                        let _ = gh
-                            .comment_on_pr(
-                                repo,
-                                pr.number,
-                                &format!(
-                                    "Retry budget exhausted for route `{route_name}` \
-                                 ({prior_runs}/{max} attempts). Applying `forza:needs-human` \
-                                 for manual review."
-                                ),
-                            )
-                            .await;
                         continue;
                     }
                 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -327,6 +327,20 @@ pub fn find_latest_run_for_issue(
         .find(|r| r.issue_number == issue_number)
 }
 
+/// Find the most recent completed run for a given PR number and workflow.
+///
+/// Returns the first (most recent, since `load_all_runs` sorts descending by `started_at`)
+/// record that has a `completed_at` timestamp, matching both `issue_number` and `workflow`.
+pub fn find_last_completed_run_for_subject(
+    pr_number: u64,
+    workflow: &str,
+    state_dir: &std::path::Path,
+) -> Option<RunRecord> {
+    load_all_runs(state_dir)
+        .into_iter()
+        .find(|r| r.issue_number == pr_number && r.workflow == workflow && r.completed_at.is_some())
+}
+
 /// Count completed runs for a given issue/PR number with a specific workflow.
 pub fn count_runs_for_subject(
     issue_number: u64,


### PR DESCRIPTION
## Summary

Automated implementation for [#235](https://github.com/joshrotenberg/forza/issues/235) — fix: prevent condition route ping-pong between auto-fix and auto-merge.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 217.4s | - |
| implement | succeeded | 191.3s | - |
| test | succeeded | 27.8s | - |
| review | succeeded | 98.0s | - |

## Files changed

```
 forza.toml              | 29 ++++++++------------
 src/config.rs           | 48 ++++++++++++++++++++++++++++++++
 src/main.rs             |  1 +
 src/orchestrator/mod.rs | 73 ++++++++++++++++++++++++++++++++++---------------
 src/state.rs            | 14 ++++++++++
 5 files changed, 125 insertions(+), 40 deletions(-)
```

## Plan

# Context from plan stage — Issue #235

## Problem

Two condition routes (`auto-fix`: `ci_failing_or_conflicts`, `auto-merge`: `ci_green_no_objections`) share the same `pr-maintenance` workflow. Because condition route discovery iterates all routes against a single `all_prs` snapshot per poll cycle, and because the `forza:in-progress` label is only added when processing begins (not during discovery), the same PR can be queued by alternating routes across successive poll cycles. This causes repeated add/remove cycles of `forza:in-progress`.

## Key findings

### Architecture
- `RouteCondition` enum is in `src/config.rs` lines 275–321 with a `matches()` method evaluating against `PrCandidate` fields (`checks_passing: Option<bool>`, `mergeable: Option<String>`, `review_decision: Option<String>`).
- Condition route discovery is in `src/orchestrator/mod.rs` lines 879–987. All routes share one `all_prs` fetch; each route independently evaluates and pushes to `pending`. No cross-route deduplication exists.
- The in-progress label guard only reads the fetched snapshot labels — no live re-check before queuing.
- Retry budget uses `state::count_failed_runs_for_subject()` (failed/exhausted outcomes only, not NothingToDo).
- `src/main.rs` lines 984–993 has a `match cond { ... }` display block for condition names — needs `AnyActionable` arm.

### State helpers available
- `state::count_failed_runs_for_subject(pr_number, workflow, state_dir)` — count of Failed/Exhausted runs
- `state::load_all_runs(state_dir)` — all persisted `RunRecord`s; no per-subject-last-run helper exists yet

## Implementation plan

### 1. `src/config.rs`
- Add `AnyActionable` variant to `RouteCondition` enum with doc comment:
  `/// Matches any PR that needs attention: CI failing, has conflicts, or CI green with no objections (ready to merge).`
- Add match arm in `matches()`:
  `RouteCondition::AnyActionable => ci_failing || has_conflicts || (ci_green && !has_conflicts && !changes_requested)`
- Add unit tests for `AnyActionable` in the existing `#[cfg(test)]` block (lines ~1610–1665)

### 2. `src/state.rs`
- Add helper `find_last_run_for_subject(pr_number: u64, workflow: &str, state_dir: &Path) -> Option<RunRecord>`:
  Filter `load_all_runs()` by `issue_number == pr_number && workflow == workflow`, return the first (most recent, since `load_all_runs` sorts descending by `started_at`).

### 3. `src/orchestrator/mod.rs`
- After the retry budget block (line ~976), add exponential backoff check:
  1. Get `prior_fails` (already computed above in retry budget check, or recompute)
  2. If `prior_fails > 0`, call `find_last_run_for_subject()` to get the last run
  3. If `last_run.completed_at` is Some, compute `backoff_secs = poll_interval * 2^(prior_fails - 1).min(6)`
  4. If `now - completed_at < backoff_secs`, log debug and `continue`

### 4. `src/main.rs`
- Add `forza::config::RouteCondition::AnyActionable => "any_actionable"` arm to the `match cond` display block at lines 985–992.

### 5. `forza.toml`
- Remove `[repos."joshrotenberg/forza".routes.auto-fix]` and `[repos."joshrotenberg/forza".routes.auto-merge]` sections
- Add single `[repos."joshrotenberg/forza".routes.auto-maintain]` section:
  ```toml
  [repos."joshrotenberg/forza".routes.auto-maintain]
  type = "pr"
  condition = "any_actionable"
  workflow = "pr-maintenance"
  scope = "forza_owned"
  max_retries = 3
  concurrency = 2
  poll_interval = 60
  ```
- Update the comment block above the condition routes section to reflect the single-route design.

## Decisions made
- `AnyActionable` = `ci_failing || has_conflicts || (ci_green && !has_conflicts && !changes_requested)`. Does NOT include `approved_and_green` (which requires an explicit APPROVED review). This matches the existing `CiGreenNoObjections` semantics since branch protection is the real merge gate.
- Backoff uses `prior_fails` (failed/exhausted runs only) as the exponent, capped at 6 (max 64x poll_interval = ~64 minutes at default 60s). Resets naturally when a run succeeds and `prior_fails` drops to 0.
- No new state files needed — derive everything from existing `RunRecord` fields.
- The `NothingToDo` outcome does NOT consume the retry budget and does NOT contribute to backoff exponent, which is correct: if the reactive workflow found nothing to do it wasn't a failure.


## Review

## Context from review stage — Issue #235

### Verdict: PASS

No high-severity issues found. Implementation is correct and ready for PR.

### Key findings

- **`AnyActionable` logic correct**: `ci_failing || has_conflicts || (ci_green && !changes_requested)` — operator precedence is fine in Rust.
- **Backoff math correct**: `poll_interval * 2^(prior_fails - 1)`, capped at 64x.
- **Route consolidation correct**: `forza.toml` replaces `auto-fix` + `auto-merge` with single `auto-maintain` using `any_actionable` — this is the direct fix for the ping-pong root cause.
- **Test coverage adequate**: `condition_matches_any_actionable` covers all 5 relevant cases.
- **Two low-severity notes**: (1) `find_last_completed_run_for_subject` lacks a dedicated unit test; (2) backoff anchor is "most recent completed run" regardless of outcome — benign in practice.

### For open_pr

- Branch: `automation/235-fix-prevent-condition-route-ping-pong-be`
- Base: `main`
- Single commit: `fix(config,orchestrator): prevent condition route ping-pong with any_actionable and exponential backoff closes #235`
- Files changed: `forza.toml`, `src/config.rs`, `src/main.rs`, `src/orchestrator/mod.rs`, `src/state.rs`
- PR title suggestion: `fix: prevent condition route ping-pong with any_actionable and exponential backoff`
- Closes: #235


Closes #235