### PR TITLE
bug: auto fixed PRs get stuck

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -303,12 +303,14 @@ impl RouteCondition {
                 mergeable = m,
                 "mergeability not yet resolved, skipping cycle"
             );
+            return false;
         } else if pr.mergeable.is_none() {
             debug!(
                 pr = pr.number,
                 mergeable = "None",
                 "mergeability not yet resolved, skipping cycle"
             );
+            return false;
         }
         let has_conflicts = pr.mergeable.as_deref() == Some("CONFLICTING");
         let approved = pr.review_decision.as_deref() == Some("APPROVED");
@@ -1642,16 +1644,23 @@ max_retries = 3
         pr.review_decision = Some("APPROVED".into());
         assert!(RouteCondition::ApprovedAndGreen.matches(&pr));
 
-        // UNKNOWN mergeability: transient GitHub state — treated as not-conflicting
+        // UNKNOWN mergeability: transient GitHub state — must return false for all conditions
         pr.mergeable = Some("UNKNOWN".into());
         pr.checks_passing = Some(true);
+        pr.review_decision = Some("APPROVED".into());
         assert!(!RouteCondition::HasConflicts.matches(&pr));
         assert!(!RouteCondition::CiFailingOrConflicts.matches(&pr));
+        assert!(!RouteCondition::ApprovedAndGreen.matches(&pr));
+        assert!(!RouteCondition::CiGreenNoObjections.matches(&pr));
+        assert!(!RouteCondition::AnyActionable.matches(&pr));
 
-        // None mergeability: also treated as not-conflicting
+        // None mergeability: also returns false for all conditions
         pr.mergeable = None;
         assert!(!RouteCondition::HasConflicts.matches(&pr));
         assert!(!RouteCondition::CiFailingOrConflicts.matches(&pr));
+        assert!(!RouteCondition::ApprovedAndGreen.matches(&pr));
+        assert!(!RouteCondition::CiGreenNoObjections.matches(&pr));
+        assert!(!RouteCondition::AnyActionable.matches(&pr));
 
         // CiGreenNoObjections: CI green + no review decision → matches
         pr.mergeable = Some("MERGEABLE".into());

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -231,7 +231,8 @@ fn checks_passing(rollup: &[GhStatusCheck]) -> Option<bool> {
                 return Some(false);
             }
             Some("SUCCESS") | Some("SKIPPED") | Some("NEUTRAL") => {}
-            _ => all_concluded = false,
+            None => all_concluded = false,
+            Some(_) => return Some(false),
         }
     }
     if all_concluded { Some(true) } else { None }
@@ -964,4 +965,59 @@ pub async fn comment_on_issue(repo: &str, number: u64, body: &str) -> Result<()>
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_check(conclusion: Option<&str>) -> GhStatusCheck {
+        GhStatusCheck {
+            conclusion: conclusion.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn checks_passing_empty_rollup_returns_none() {
+        assert_eq!(checks_passing(&[]), None);
+    }
+
+    #[test]
+    fn checks_passing_all_success() {
+        let rollup = vec![
+            make_check(Some("SUCCESS")),
+            make_check(Some("SKIPPED")),
+            make_check(Some("NEUTRAL")),
+        ];
+        assert_eq!(checks_passing(&rollup), Some(true));
+    }
+
+    #[test]
+    fn checks_passing_failure_returns_false() {
+        let rollup = vec![make_check(Some("SUCCESS")), make_check(Some("FAILURE"))];
+        assert_eq!(checks_passing(&rollup), Some(false));
+    }
+
+    #[test]
+    fn checks_passing_timed_out_returns_false() {
+        let rollup = vec![make_check(Some("TIMED_OUT"))];
+        assert_eq!(checks_passing(&rollup), Some(false));
+    }
+
+    #[test]
+    fn checks_passing_pending_conclusion_returns_none() {
+        let rollup = vec![make_check(Some("SUCCESS")), make_check(None)];
+        assert_eq!(checks_passing(&rollup), None);
+    }
+
+    #[test]
+    fn checks_passing_unknown_conclusion_returns_false() {
+        // Any concluded-but-unknown state (STARTUP_FAILURE, STALE, future values)
+        // is treated as a failure rather than leaving the PR in a dead zone.
+        let rollup = vec![make_check(Some("STARTUP_FAILURE"))];
+        assert_eq!(checks_passing(&rollup), Some(false));
+
+        let rollup = vec![make_check(Some("STALE"))];
+        assert_eq!(checks_passing(&rollup), Some(false));
+    }
 }


### PR DESCRIPTION
## Summary

Automated implementation for [#249](https://github.com/joshrotenberg/forza/issues/249) — bug: auto fixed PRs get stuck.

## Stages

| Stage | Status | Duration | Cost |
|-------|--------|----------|------|
| plan | succeeded | 111.0s | - |
| implement | succeeded | 128.0s | - |
| test | succeeded | 30.1s | - |
| review | succeeded | 110.0s | - |

## Files changed

```
 src/config.rs     | 13 +++++++++++--
 src/github/mod.rs | 58 ++++++++++++++++++++++++++++++++++++++++++++++++++++++-
 2 files changed, 68 insertions(+), 3 deletions(-)
```

## Plan

# Plan Stage — Issue #249

## Key Findings

### Bug 1: `src/config.rs` — `RouteCondition::matches()` lines 297-312

The code logs "mergeability not yet resolved, skipping cycle" for both the
`Some("UNKNOWN")` (or any non-MERGEABLE/CONFLICTING string) and `None` cases, but
**never returns `false`**. Execution falls through, `has_conflicts` evaluates to `false`,
and `ApprovedAndGreen` / `CiGreenNoObjections` / `AnyActionable` can all match — leading
to no-op runs that immediately re-queue on the next poll.

**Fix**: add `return false;` in both branches of the `if let … && m != … else if
pr.mergeable.is_none()` block.

Existing tests (`condition_matches_ci_failing`, lines 1645-1654) only assert that
`HasConflicts` and `CiFailingOrConflicts` return false for unresolved mergeable. They do
NOT cover `ApprovedAndGreen`, `CiGreenNoObjections`, or `AnyActionable` in those states.
New test cases are needed.

### Bug 2: `src/github/mod.rs` — `checks_passing()` lines 228-235

The catch-all `_ => all_concluded = false` treats any non-enumerated check conclusion
(e.g. `STARTUP_FAILURE`, `STALE`, hypothetical future GitHub values) as "still pending"
rather than "failed". PRs with such checks are stuck in a dead zone where neither
`ci_green` nor `ci_failing` is true.

**Fix**: split the catch-all:
- `None => all_concluded = false` — truly in-progress, no conclusion yet
- `Some(_) => return Some(false)` — any concluded-but-unknown state is a failure

No existing tests for `checks_passing()` in `src/github/mod.rs` (`#[cfg(test)]` module
is absent). A new test module covering success, failure, pending, and unknown-conclusion
cases must be added.

### Bug 3: `forza.toml` — Already resolved

PR #247 already consolidated the two condition routes into a single `auto-maintain` route
using `condition = "any_actionable"`. No changes needed here.

## Files to modify

- `src/config.rs` — add `return false;` in both unresolved-mergeable branches; add
  test assertions for `ApprovedAndGreen`, `CiGreenNoObjections`, `AnyActionable` with
  `UNKNOWN` and `None` mergeable
- `src/github/mod.rs` — fix the catch-all in `checks_passing()`; add `#[cfg(test)]`
  module with tests for unknown conclusions

## Commit message

```
fix(config,github): return false for unresolved mergeable and treat unknown check conclusions as failures closes #249
```


## Review

## Review stage — issue #249

### Verdict: PASS

No high-severity issues found. The implementation is correct and complete.

### Key findings

1. **`src/config.rs` — mergeable early returns**: `matches()` now returns `false` immediately for `UNKNOWN` and `None` mergeable states. Fix is correct — prevents all condition routes from firing when GitHub hasn't resolved mergeability.

2. **`src/config.rs` — `AnyActionable`**: Logic `ci_failing || has_conflicts || ci_green && !changes_requested` is correct (operator precedence: `&&` binds tighter). Covers all three actionable states. `forza.toml` updated to use single `auto-maintain` route.

3. **`src/github/mod.rs` — `checks_passing()`**: `Some(_)` wildcard now returns `Some(false)` instead of clearing `all_concluded`. Concluded-but-unknown check states (STARTUP_FAILURE, STALE) are treated as failures, eliminating the dead zone where neither `ci_green` nor `ci_failing` held.

4. **Tests**: All new tests pass (121 total). Coverage is thorough for both changed functions.

### For open_pr stage

- Branch: `automation/249-bug-auto-fixed-prs-get-stuck`
- Target: `main`
- Commit: `9634423`
- Commit message: `fix(config,github): return false for unresolved mergeable and treat unknown check conclusions as failures closes #249`
- No source files need modification — review is clean PASS.


Closes #249