### PR TITLE
fix(forza-core): add Display impl for StageStatus closes #253

### DIFF
--- a/crates/forza-core/src/run.rs
+++ b/crates/forza-core/src/run.rs
@@ -80,6 +80,16 @@ pub enum StageStatus {
     Skipped,
 }
 
+impl std::fmt::Display for StageStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StageStatus::Succeeded => f.write_str("succeeded"),
+            StageStatus::Failed => f.write_str("failed"),
+            StageStatus::Skipped => f.write_str("skipped"),
+        }
+    }
+}
+
 /// The result of executing a single stage.
 ///
 /// Captures everything about what happened during the stage for later
@@ -486,5 +496,12 @@ mod tests {
         assert_eq!(RunStatus::Succeeded.to_string(), "succeeded");
         assert_eq!(RunStatus::Failed.to_string(), "failed");
         assert_eq!(RunStatus::Running.to_string(), "running");
+    }
+
+    #[test]
+    fn stage_status_display() {
+        assert_eq!(StageStatus::Succeeded.to_string(), "succeeded");
+        assert_eq!(StageStatus::Failed.to_string(), "failed");
+        assert_eq!(StageStatus::Skipped.to_string(), "skipped");
     }
 }


### PR DESCRIPTION
## Summary
- Adds a `Display` impl for `StageStatus` in `crates/forza-core/src/run.rs`
- Maps variants to lowercase strings: `Succeeded` → `"succeeded"`, `Failed` → `"failed"`, `Skipped` → `"skipped"`
- Follows the same pattern already used by `RunStatus` and `Outcome` `Display` impls in the same file
- Adds a `stage_status_display` unit test mirroring the existing `run_status_display` test

## Files changed
- `crates/forza-core/src/run.rs` — added `Display` impl for `StageStatus` and corresponding unit test

## Test plan
- [ ] All 107 forza-core tests pass (`cargo test -p forza-core`)
- [ ] `StageStatus::Succeeded`, `Failed`, and `Skipped` display as `"succeeded"`, `"failed"`, `"skipped"` respectively
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo fmt --check` passes

Closes #253