### PR TITLE
chore: add [workspace.package] to deduplicate crate metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 members = ["crates/forza", "crates/forza-core"]
 resolver = "3"
 
+[workspace.package]
+edition = "2024"
+rust-version = "1.90.0"
+authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/joshrotenberg/forza"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/crates/forza-core/Cargo.toml
+++ b/crates/forza-core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "forza-core"
 version = "0.1.0"
-edition = "2024"
-rust-version = "1.90.0"
-authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Core abstractions for forza — workflow orchestrator for agent-driven development"
-repository = "https://github.com/joshrotenberg/forza"
+repository.workspace = true
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/forza/Cargo.toml
+++ b/crates/forza/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "forza"
 version = "0.2.0"
-edition = "2024"
-rust-version = "1.90.0"
-authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
 description = "Configurable workflow orchestrator for agent driven software development"
-repository = "https://github.com/joshrotenberg/forza"
+repository.workspace = true
 keywords = ["github", "automation", "issues", "pull-requests", "ci"]
 categories = ["command-line-utilities", "development-tools"]
 


### PR DESCRIPTION
## Summary
- Adds a `[workspace.package]` section to the root `Cargo.toml` with shared metadata fields (`edition`, `rust-version`, `authors`, `license`, `repository`)
- Updates `crates/forza/Cargo.toml` and `crates/forza-core/Cargo.toml` to inherit these fields from the workspace, eliminating duplication
- Ensures metadata stays consistent across crates without manual synchronization

## Files changed
- `Cargo.toml` — added `[workspace.package]` section with shared metadata
- `crates/forza-core/Cargo.toml` — replaced duplicated fields with `field.workspace = true` references
- `crates/forza/Cargo.toml` — replaced duplicated fields with `field.workspace = true` references

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test` passes
- [ ] `cargo metadata` shows correct inherited values for both crates

Closes #264