### PR TITLE
chore: add [workspace.dependencies] to deduplicate shared dep versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,36 @@ authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/joshrotenberg/forza"
 
+[workspace.dependencies]
+# shared
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+thiserror = "2"
+tracing = "0.1"
+async-trait = "0.1.89"
+indexmap = { version = "2", features = ["serde"] }
+toml = "0.8"
+tokio = { version = "1", features = ["process", "fs"] }
+tempfile = "3"
+# forza
+forza-core = { path = "crates/forza-core" }
+tower-mcp = { version = "0.9", features = ["http"] }
+schemars = "1"
+claude-wrapper = "0.4"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
+clap = { version = "4", features = ["derive"] }
+dirs = "6"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+http = "1"
+hyper-util = { version = "0.1", features = ["client-legacy", "tokio"] }
+hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio", "http1", "tls12"] }
+regex = "1"
+axum = "0.8"
+octocrab = "0.49.5"
+gix = "0.80.0"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/crates/forza-core/Cargo.toml
+++ b/crates/forza-core/Cargo.toml
@@ -9,16 +9,16 @@ description = "Core abstractions for forza — workflow orchestrator for agent-d
 repository.workspace = true
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-chrono = { version = "0.4", features = ["serde"] }
-thiserror = "2"
-tracing = "0.1"
-async-trait = "0.1.89"
-indexmap = { version = "2", features = ["serde"] }
-toml = "0.8"
-tokio = { version = "1", features = ["process", "fs"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+async-trait = { workspace = true }
+indexmap = { workspace = true }
+toml = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/forza/Cargo.toml
+++ b/crates/forza/Cargo.toml
@@ -11,34 +11,34 @@ keywords = ["github", "automation", "issues", "pull-requests", "ci"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
-forza-core = { path = "../forza-core" }
-indexmap = { version = "2", features = ["serde"] }
-tower-mcp = { version = "0.9", features = ["http"] }
-schemars = "1"
-claude-wrapper = "0.4"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-toml = "0.8"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "process", "fs", "sync", "signal", "time", "net"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tracing-appender = "0.2"
-chrono = { version = "0.4", features = ["serde"] }
-thiserror = "2"
-clap = { version = "4", features = ["derive"] }
-dirs = "6"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-http = "1"
-hyper-util = { version = "0.1", features = ["client-legacy", "tokio"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio", "http1", "tls12"] }
-regex = "1"
-axum = "0.8"
-async-trait = "0.1.89"
-octocrab = "0.49.5"
-gix = "0.80.0"
+forza-core = { workspace = true }
+indexmap = { workspace = true }
+tower-mcp = { workspace = true }
+schemars = { workspace = true }
+claude-wrapper = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "signal", "time", "net"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-appender = { workspace = true }
+chrono = { workspace = true }
+thiserror = { workspace = true }
+clap = { workspace = true }
+dirs = { workspace = true }
+reqwest = { workspace = true }
+http = { workspace = true }
+hyper-util = { workspace = true }
+hyper-rustls = { workspace = true }
+regex = { workspace = true }
+axum = { workspace = true }
+async-trait = { workspace = true }
+octocrab = { workspace = true }
+gix = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile = { workspace = true }
 
 [[bin]]
 name = "forza"


### PR DESCRIPTION
## Summary
- Move all shared crate dependencies into `[workspace.dependencies]` in the root `Cargo.toml`
- Update `crates/forza/Cargo.toml` and `crates/forza-core/Cargo.toml` to reference workspace deps via `workspace = true`
- Centralizes version management so shared dependency versions only need to be updated in one place
- No functional changes — purely a build/maintenance improvement

## Files changed
- `Cargo.toml` — added `[workspace.dependencies]` table with all shared dependencies and their versions
- `crates/forza-core/Cargo.toml` — updated all dependencies to use `workspace = true`
- `crates/forza/Cargo.toml` — updated all dependencies to use `workspace = true`

## Test plan
- [ ] `cargo build --workspace` succeeds
- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes

Closes #263