### PR TITLE
docs(runner): add doc comment to generate_branch

### DIFF
--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -599,7 +599,20 @@ fn to_core_stage_kind(kind: crate::workflow::StageKind) -> forza_core::StageKind
     }
 }
 
-/// Generate a branch name from the pattern.
+/// Generate a branch name from a pattern by substituting issue metadata.
+///
+/// The pattern supports two placeholders:
+/// - `{issue}` — replaced with the issue or PR number.
+/// - `{slug}` — replaced with a URL-safe slug derived from `title`: lowercased,
+///   non-alphanumeric characters converted to hyphens, consecutive hyphens collapsed,
+///   and truncated to 40 characters (trimming any trailing hyphen).
+///
+/// # Examples
+///
+/// ```
+/// // "automation/{issue}-{slug}" with number=42, title="Fix the bug"
+/// // → "automation/42-fix-the-bug"
+/// ```
 fn generate_branch(pattern: &str, number: u64, title: &str) -> String {
     let slug: String = title
         .to_lowercase()


### PR DESCRIPTION
## Summary
- Added a comprehensive doc comment to the `generate_branch` private function in `crates/forza/src/runner.rs`
- Documents the two supported placeholders: `{issue}` (issue/PR number) and `{slug}` (URL-safe title slug)
- Describes the slug derivation rules: lowercased, non-alphanumeric chars to hyphens, consecutive hyphens collapsed, truncated to 40 characters
- Includes a usage example showing the expected output

## Files changed
- `crates/forza/src/runner.rs` — added doc comment to `generate_branch` function

## Test plan
- [ ] `cargo doc --no-deps --all-features` builds without warnings
- [ ] Existing tests continue to pass: `cargo test`
- [ ] Doc comment renders correctly in generated docs

Closes #256