### PR TITLE
fix(github): improve error messages for failed API calls and missing issues closes #265

### DIFF
--- a/crates/forza/src/github/mod.rs
+++ b/crates/forza/src/github/mod.rs
@@ -258,7 +258,15 @@ pub async fn fetch_issue(repo: &str, number: u64) -> Result<IssueCandidate> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::GitHub(format!("gh issue view failed: {stderr}")));
+        let lower = stderr.to_lowercase();
+        if lower.contains("not found") || lower.contains("could not resolve") {
+            return Err(Error::GitHub(format!(
+                "issue #{number} not found in {repo}"
+            )));
+        }
+        return Err(Error::GitHub(format!(
+            "fetch issue #{number} in {repo}: {stderr}"
+        )));
     }
 
     let raw: GhIssue = serde_json::from_slice(&output.stdout)
@@ -659,7 +667,13 @@ pub async fn fetch_pr(repo: &str, number: u64) -> Result<PrCandidate> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Error::GitHub(format!("gh pr view failed: {stderr}")));
+        let lower = stderr.to_lowercase();
+        if lower.contains("not found") || lower.contains("could not resolve") {
+            return Err(Error::GitHub(format!("PR #{number} not found in {repo}")));
+        }
+        return Err(Error::GitHub(format!(
+            "fetch PR #{number} in {repo}: {stderr}"
+        )));
     }
 
     let raw: GhPrFull = serde_json::from_slice(&output.stdout)

--- a/crates/forza/src/github/octocrab_client.rs
+++ b/crates/forza/src/github/octocrab_client.rs
@@ -99,7 +99,13 @@ impl GitHubClient for OctocrabClient {
             .issues(owner, name)
             .get(number)
             .await
-            .map_err(|e| Error::GitHub(format!("fetch issue #{number}: {e}")))?;
+            .map_err(|e| {
+                if matches!(&e, octocrab::Error::GitHub { source, .. } if source.status_code == StatusCode::NOT_FOUND) {
+                    Error::GitHub(format!("issue #{number} not found in {repo}"))
+                } else {
+                    Error::GitHub(format!("fetch issue #{number} in {repo}: {e}"))
+                }
+            })?;
 
         let comments = self
             .client
@@ -266,7 +272,13 @@ impl GitHubClient for OctocrabClient {
             .pulls(owner, name)
             .get(number)
             .await
-            .map_err(|e| Error::GitHub(format!("fetch PR #{number}: {e}")))?;
+            .map_err(|e| {
+                if matches!(&e, octocrab::Error::GitHub { source, .. } if source.status_code == StatusCode::NOT_FOUND) {
+                    Error::GitHub(format!("PR #{number} not found in {repo}"))
+                } else {
+                    Error::GitHub(format!("fetch PR #{number} in {repo}: {e}"))
+                }
+            })?;
 
         let checks_passing = fetch_checks_passing(&self.client, owner, name, &pr.head.sha).await;
 

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -734,6 +734,10 @@ async fn cmd_issue(
     .await
     {
         Ok(run) => print_core_run(&run),
+        Err(forza_core::Error::GitHub(msg)) => {
+            eprintln!("error: {msg}");
+            ExitCode::FAILURE
+        }
         Err(e) => {
             eprintln!("error: {e}");
             ExitCode::FAILURE
@@ -823,6 +827,10 @@ async fn cmd_pr(
     .await
     {
         Ok(run) => print_core_run(&run),
+        Err(forza_core::Error::GitHub(msg)) => {
+            eprintln!("error: {msg}");
+            ExitCode::FAILURE
+        }
         Err(e) => {
             eprintln!("error: {e}");
             ExitCode::FAILURE

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -671,10 +671,11 @@ pub async fn process_issue(
     model_override: Option<String>,
     skill_overrides: Vec<String>,
 ) -> forza_core::Result<Run> {
-    let issue = gh
-        .fetch_issue(repo, number)
-        .await
-        .map_err(|e| forza_core::Error::GitHub(e.to_string()))?;
+    tracing::info!(number, repo, "processing issue");
+    let issue = gh.fetch_issue(repo, number).await.map_err(|e| match e {
+        crate::error::Error::GitHub(msg) => forza_core::Error::GitHub(msg),
+        _ => forza_core::Error::GitHub(e.to_string()),
+    })?;
 
     let (route_name, route) = RunnerConfig::match_route_in(routes, &issue).ok_or_else(|| {
         forza_core::Error::NoMatchingRoute(format!(
@@ -733,10 +734,11 @@ pub async fn process_pr(
     skill_overrides: Vec<String>,
     route_override: Option<String>,
 ) -> forza_core::Result<Run> {
-    let pr = gh
-        .fetch_pr(repo, number)
-        .await
-        .map_err(|e| forza_core::Error::GitHub(e.to_string()))?;
+    tracing::info!(number, repo, "processing PR");
+    let pr = gh.fetch_pr(repo, number).await.map_err(|e| match e {
+        crate::error::Error::GitHub(msg) => forza_core::Error::GitHub(msg),
+        _ => forza_core::Error::GitHub(e.to_string()),
+    })?;
 
     // Use route override if provided (from condition routes), otherwise match by labels.
     let (route_name, route) = if let Some(ref rn) = route_override


### PR DESCRIPTION
## Summary
- Fix double-prefix error messages (e.g., `"github: github error: fetch issue #N: GitHub"`) by unwrapping the inner message directly instead of calling `e.to_string()`
- Detect missing issues/PRs via `gh` CLI stderr keywords and return human-readable `"issue #N not found in repo"` messages
- Map octocrab HTTP 404 responses to the same styled "not found" message
- Add structured `tracing::info!` logging before each `fetch_issue`/`fetch_pr` call

## Files changed
- `crates/forza/src/github/mod.rs` — `fetch_issue` and `fetch_pr` detect "not found"/"could not resolve" in stderr and return contextual error messages
- `crates/forza/src/github/octocrab_client.rs` — `get_issue` and `get_pr` map `octocrab::Error::GitHub` with HTTP 404 to "not found in {repo}" message
- `crates/forza/src/runner.rs` — pattern-match on `crate::error::Error::GitHub(msg)` to pass message directly, eliminating redundant `e.to_string()` wrapping; add structured tracing
- `crates/forza/src/main.rs` — match `forza_core::Error::GitHub(msg)` before catch-all arm to print `"error: {msg}"` without the "github:" prefix

## Test plan
- Run `cargo test` — all 112 tests pass
- Run `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- Manually invoke `forza issue` with a non-existent issue number and verify the output is `"error: issue #N not found in owner/repo"` without double prefixes

Closes #265