### PR TITLE
fix(forza-core): add Display impl for Execution enum closes #272

### DIFF
--- a/crates/forza-core/src/stage.rs
+++ b/crates/forza-core/src/stage.rs
@@ -104,6 +104,15 @@ pub enum Execution {
     },
 }
 
+impl std::fmt::Display for Execution {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Execution::Agent => f.write_str("agent"),
+            Execution::Shell { .. } => f.write_str("shell"),
+        }
+    }
+}
+
 /// A single stage in a workflow.
 ///
 /// Stages are the atomic units of work in forza. Each stage either invokes
@@ -411,6 +420,18 @@ mod tests {
         assert_eq!(restored.kind, StageKind::Merge);
         assert!(restored.optional);
         assert!(restored.is_agentless());
+    }
+
+    #[test]
+    fn execution_display() {
+        assert_eq!(Execution::Agent.to_string(), "agent");
+        assert_eq!(
+            Execution::Shell {
+                command: "cargo fmt".into()
+            }
+            .to_string(),
+            "shell"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds a `Display` impl for the `Execution` enum in `crates/forza-core/src/stage.rs`
- `Agent` variant renders as `"agent"`, `Shell { .. }` variant renders as `"shell"`
- Follows the same pattern as the existing `Display` impl for `StageKind`
- Adds a unit test `execution_display` covering both variants

## Files changed

- `crates/forza-core/src/stage.rs` — added `Display` impl for `Execution` and corresponding unit test

## Test plan

- `cargo test -p forza-core` passes (new `execution_display` test covers both variants)
- `cargo clippy -p forza-core -- -D warnings` passes with no warnings
- `cargo fmt --all -- --check` passes

Closes #272