### PR TITLE
fix: split git add in draft_pr.sh to handle missing .forza/ directory

### DIFF
--- a/crates/forza-core/src/commands/draft_pr.sh
+++ b/crates/forza-core/src/commands/draft_pr.sh
@@ -4,8 +4,10 @@
 # If draft creation fails (e.g., no diff from main), exits 0 so the
 # optional stage doesn't block the workflow.
 
-# Stage breadcrumb files if they exist.
-git add -A .forza/ .plan_breadcrumb.md 2>/dev/null
+# Stage breadcrumb files if they exist (add separately so one missing path
+# doesn't prevent the other from being staged).
+git add .plan_breadcrumb.md 2>/dev/null
+git add -A .forza/ 2>/dev/null
 
 # Commit only if there are staged changes.
 git diff --cached --quiet || git commit -m "plan: issue #$FORZA_SUBJECT_NUMBER"


### PR DESCRIPTION
## Summary

`git add -A .forza/ .plan_breadcrumb.md` fails with exit 128 when `.forza/` doesn't exist, preventing `.plan_breadcrumb.md` from being staged too. Split into separate `git add` calls so each path is handled independently.

## Context

The draft PR stage silently succeeded (due to `|| true`) but never created a PR because no files were committed or pushed.