### PR TITLE
fix(forza-core): add Display impl for Scope enum closes #290

### DIFF
--- a/crates/forza-core/src/route.rs
+++ b/crates/forza-core/src/route.rs
@@ -39,6 +39,15 @@ pub enum Scope {
     All,
 }
 
+impl std::fmt::Display for Scope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Scope::ForzaOwned => write!(f, "forza_owned"),
+            Scope::All => write!(f, "all"),
+        }
+    }
+}
+
 /// A named rule that maps a trigger to a workflow.
 ///
 /// All fields are public for observability. Routes are loaded from config
@@ -345,6 +354,12 @@ mod tests {
             Trigger::Condition(RouteCondition::CiFailing).to_string(),
             "condition:ci_failing"
         );
+    }
+
+    #[test]
+    fn scope_display() {
+        assert_eq!(Scope::ForzaOwned.to_string(), "forza_owned");
+        assert_eq!(Scope::All.to_string(), "all");
     }
 
     // ── Serialization ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `std::fmt::Display` impl for the `Scope` enum in `forza-core`
- Outputs `"forza_owned"` and `"all"` to match the TOML config string values
- Follows the existing `Display` impl pattern already used for `Trigger` in the same file
- Adds unit test `scope_display` verifying both variant display strings

## Files changed
- `crates/forza-core/src/route.rs` - Added `Display` impl for `Scope` enum and `scope_display` unit test

## Test plan
- `cargo test -p forza-core` passes
- `scope_display` test asserts `Scope::ForzaOwned` displays as `"forza_owned"` and `Scope::All` displays as `"all"`

Closes #290