### PR TITLE
fix(dist): update workspace member path for crate restructure

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["cargo:forza"]
+members = ["cargo:crates/forza"]
 
 # Config for 'dist'
 [dist]


### PR DESCRIPTION
## Summary

After the workspace restructure (binary moved to `crates/forza/`), the `dist-workspace.toml` still pointed to `cargo:.` (the root). Updated to `cargo:forza` so cargo-dist can find the binary crate.

This should fix the brew formula and release asset generation for the next release (v0.3.0, PR #105).