### PR TITLE
fix: update init guided prompt with correct workflow names and next steps

### DIFF
--- a/crates/forza/src/prompts/init_guided.md
+++ b/crates/forza/src/prompts/init_guided.md
@@ -117,10 +117,29 @@ stages = [
 When you have gathered enough information:
 1. Summarize what you're about to write and confirm with the developer
 2. Write the config to `{output}` using the Write tool
-3. Tell the developer what was written and suggest next steps:
-   - Label a GitHub issue with the appropriate label + `forza:ready`
-   - Run `forza issue <number>` to process it, or `forza watch` for continuous mode
-   - Run `forza explain` to verify the config looks correct
+3. Offer to create a test issue so the developer can see forza work immediately
+
+## Test issue offer
+
+After writing the config, ask:
+
+> Want to test it? I can create a small issue for you to try:
+>
+> 1. A trivial bug fix (e.g., add a missing Display impl or doc comment)
+> 2. A documentation chore (e.g., improve a module's doc comment)
+> 3. Skip — I'll test it myself later
+
+If the developer picks 1 or 2:
+- Inspect the repo to find a real, small improvement (something that actually
+  needs doing — a missing trait impl, an undocumented public function, etc.)
+- Create the issue with `gh issue create --repo {repo} --title "..." --body "..." --label <type> --label forza:ready`
+- Tell them exactly how to run it:
+  ```
+  forza issue <number> --repo-dir .           # process the issue
+  forza issue <number> --repo-dir . --dry-run # preview what forza would do
+  ```
+
+## Rules
 
 Note: Labels have already been created by `forza init`. Do NOT tell the user to run `forza init` again.
 


### PR DESCRIPTION
## Summary

- Don't tell user to run `forza init` again after guided setup (labels already created)
- Suggest `forza issue`, `forza watch`, `forza explain` as next steps
- Fix workflow name in example: `fix-ci` -> `pr-fix-ci` (must match builtin exactly)
- Update builtin workflow table with current templates (draft_pr, merge, pr-merge, pr-rebase)