### PR TITLE
fix: chain merge.sh commands with && so CI failure prevents merge

### DIFF
--- a/crates/forza-core/src/commands/merge.sh
+++ b/crates/forza-core/src/commands/merge.sh
@@ -2,6 +2,7 @@
 # Wait for all CI checks to pass, then merge the PR.
 # Uses --watch so the command blocks until checks complete or fail.
 # If any check fails, gh pr checks exits non-zero and the merge is skipped.
+# The && ensures we only merge if checks pass.
 
-gh pr checks "$FORZA_PR_NUMBER" --watch
-gh pr merge "$FORZA_PR_NUMBER" --squash
+set -e
+gh pr checks "$FORZA_PR_NUMBER" --watch && gh pr merge "$FORZA_PR_NUMBER" --squash


### PR DESCRIPTION
## Summary

The merge.sh script had `gh pr checks` and `gh pr merge` on separate lines without `&&`. If CI checks failed, the script continued to merge anyway.

Added `set -e` and chained with `&&` so merge only runs if checks pass.

Found during first run on codex-wrapper — PR merged despite 3 failing test jobs.