### PR TITLE
fix: create empty commit in draft_pr.sh so branch has diff from main

### DIFF
--- a/crates/forza-core/src/commands/draft_pr.sh
+++ b/crates/forza-core/src/commands/draft_pr.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 # Create an early draft PR after the plan stage for visibility.
-# Pushes the branch and creates a draft PR using the plan breadcrumb as the body.
-# If draft creation fails (e.g., no diff from main), exits 0 so the
-# optional stage doesn't block the workflow.
+# Creates an empty commit so the branch has a diff from main, pushes,
+# and creates a draft PR with the plan breadcrumb as the body.
+# If draft creation fails, exits 0 so the optional stage doesn't block.
+
+# Create an empty commit to establish a diff from main.
+git commit --allow-empty -m "wip: issue #$FORZA_SUBJECT_NUMBER" 2>/dev/null
 
 # Push the branch.
-git push origin HEAD 2>/dev/null
+git push origin HEAD 2>/dev/null || true
 
 # Read the plan breadcrumb for the PR body.
 if [ -f .plan_breadcrumb.md ]; then
@@ -14,7 +17,7 @@ else
     BODY="Work in progress for issue #$FORZA_SUBJECT_NUMBER"
 fi
 
-# Create the draft PR. If it fails (no diff, PR already exists), that's OK.
+# Create the draft PR. If it fails (PR already exists, etc.), that's OK.
 gh pr create --draft \
     --title "[WIP] issue #$FORZA_SUBJECT_NUMBER" \
     --body "$BODY" \


### PR DESCRIPTION
## Summary

After the plan stage, the branch has no commits different from main (breadcrumbs are written but not committed per #284). `gh pr create --draft` fails silently because there's no diff.

Fix: create an empty commit (`git commit --allow-empty`) before pushing so the branch has a diff and GitHub allows PR creation. The implement stage's real commits will follow on top.