### PR TITLE
fix(explain): show agent backend in global header and verbose route output closes #302

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -1181,6 +1181,7 @@ fn cmd_explain(args: ExplainArgs, config: &forza::RunnerConfig) -> ExitCode {
         if let Some(ref gate) = config.global.gate_label {
             println!("  Gate label:     {gate}");
         }
+        println!("  Agent:          {}", config.global.agent);
         println!("  Max concurrency: {}", config.global.max_concurrency);
         println!("  Security:       {}", config.security.authorization_level);
         let validation = &config.validation.commands;
@@ -1338,6 +1339,7 @@ fn explain_route_verbose(name: &str, route: &forza::config::Route, config: &forz
         .unwrap_or("(default)")
         .to_string();
     println!("  Model:       {model}");
+    println!("  Agent:       {}", config.global.agent);
 
     // Skills.
     let skills = config.effective_skills(route, None);


### PR DESCRIPTION
## Summary

- Added `Agent: {config.global.agent}` to the global header printed by `cmd_explain` so the configured agent backend is visible at a glance
- Added `Agent: {config.global.agent}` to the verbose route output in `explain_route_verbose`, consistent with how `Model` is already shown per route
- No new fields or config changes needed — `GlobalConfig.agent` already existed

## Files changed

- `crates/forza/src/main.rs` — two `println!` lines added: one in the global header block (after gate label), one in the verbose route output (after model line)

## Test plan

- [ ] Run `forza explain` against a real or sample config and confirm `Agent: claude` appears in the global header
- [ ] Run `forza explain -v` and confirm `Agent: claude` appears under each route's verbose output
- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all --all-targets -- -D warnings` produces no warnings

Closes #302