### PR TITLE
docs: update README workflow table with draft_pr stage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ max_retries = 3
 | **pr-fix-ci** | fix_ci |
 | **pr-rebase** | revise_pr |
 | **pr-merge** | merge (no worktree) |
+| **pr-review** | review |
 
 `*` = optional stage. Stage kinds: `triage`, `clarify`, `plan`, `implement`, `test`,
 `review`, `open_pr`, `revise_pr`, `fix_ci`, `merge`, `research`, `comment`, `draft_pr`.

--- a/README.md
+++ b/README.md
@@ -276,18 +276,21 @@ A chain of stages for a type of work. Built-in templates:
 
 | Template | Mode | Stages |
 |----------|------|--------|
-| **bug** | Linear | plan -> implement -> test -> review -> open_pr -> merge |
-| **feature** | Linear | plan -> implement -> test -> review -> open_pr -> merge |
-| **chore** | Linear | implement -> test -> open_pr -> merge |
+| **bug** | Linear | plan -> draft_pr* -> implement -> test -> review -> open_pr -> merge* |
+| **feature** | Linear | plan -> draft_pr* -> implement -> test -> review -> open_pr -> merge* |
+| **chore** | Linear | implement -> test -> open_pr -> merge* |
 | **research** | Linear | research -> comment |
-| **pr-fix** | Linear | revise_pr -> fix_ci -> merge |
-| **pr-fix-ci** | Linear | fix_ci -> merge |
+| **pr-fix** | Linear | revise_pr -> fix_ci |
+| **pr-fix-ci** | Linear | fix_ci |
 | **pr-rebase** | Linear | revise_pr |
 | **pr-merge** | Linear | merge (no worktree) |
+| **pr-review** | Linear | review |
+
+`*` = optional stage
 
 ### Stage
 
-A bounded unit of work. 12 stage kinds: `triage`, `clarify`, `plan`, `implement`, `test`, `review`, `open_pr`, `revise_pr`, `fix_ci`, `merge`, `research`, `comment`.
+A bounded unit of work. 13 stage kinds: `triage`, `clarify`, `plan`, `draft_pr`, `implement`, `test`, `review`, `open_pr`, `revise_pr`, `fix_ci`, `merge`, `research`, `comment`.
 
 Stages can be:
 - **Agentless**: run a shell command directly (no agent invocation)


### PR DESCRIPTION
## Summary
- Add `draft_pr*` to bug and feature workflows in the README workflow table
- Mark `merge*` as optional across relevant workflows
- Fix `pr-fix` and `pr-fix-ci` workflows (no merge stage)
- Add missing `pr-review` workflow entry and update stage kinds count from 12 to 13
- Sync CLAUDE.md to match README changes

## Files changed
- `README.md` - Updated workflow table with draft_pr stage, corrected optional stages, added pr-review workflow
- `CLAUDE.md` - Synced workflow table to match README

## Test plan
- Verify workflow table in README accurately reflects all builtin workflows and their stages
- Confirm stage kinds list is complete (13 stages including draft_pr)
- Check that optional stages are correctly marked with `*`

Closes #303