### PR TITLE
feat(run): add --route filter to forza run command

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -137,11 +137,16 @@ struct PrArgs {
 }
 
 #[derive(Debug, Parser)]
-#[command(after_long_help = "Examples:\n  forza run\n  forza run --repo-dir . --no-gate")]
+#[command(
+    after_long_help = "Examples:\n  forza run\n  forza run --repo-dir . --no-gate\n  forza run --route bugfix"
+)]
 struct RunArgs {
     /// Repository directory.
     #[arg(long)]
     repo_dir: Option<PathBuf>,
+    /// Only run a specific route.
+    #[arg(long)]
+    route: Option<String>,
     /// Bypass the gate_label requirement and process all matching issues immediately.
     #[arg(long, default_value = "false")]
     no_gate: bool,
@@ -900,7 +905,16 @@ async fn cmd_run(
                 return ExitCode::FAILURE;
             }
         };
-        repos_resolved.push((repo.to_string(), rd, routes.clone()));
+        let routes = if let Some(ref route_filter) = args.route {
+            routes
+                .iter()
+                .filter(|(name, _)| *name == route_filter)
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect()
+        } else {
+            routes.clone()
+        };
+        repos_resolved.push((repo.to_string(), rd, routes));
     }
 
     let (_cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);


### PR DESCRIPTION
## Summary

- Adds `--route <name>` flag to `forza run`, mirroring the existing flag on `forza watch`
- When specified, filters each repo's route map to only the named route before passing to the runner; no changes to runner or discovery logic required
- If the named route does not exist in a repo, the empty route map results in no work discovered (consistent with existing behavior)
- Includes two incidental fixes to `forza explain` output: prints `Agent:` in the global header and verbose route view

## Files changed

- `crates/forza/src/main.rs` — added `route: Option<String>` to `RunArgs`, applied filter in `cmd_run`

## Test plan

- [ ] Run `forza run --route <existing-route>` and verify only that route's work is processed
- [ ] Run `forza run --route <nonexistent-route>` and verify no work is discovered
- [ ] Run `forza run` without `--route` and verify all routes are processed (no regression)
- [ ] Run `cargo test --all` to confirm existing tests pass

Closes #299