### PR TITLE
fix(cli): update --repo-dir doc comment on RunArgs to match issue/pr commands

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -139,7 +139,7 @@ struct PrArgs {
 #[derive(Debug, Parser)]
 #[command(after_long_help = "Examples:\n  forza run\n  forza run --repo-dir . --no-gate")]
 struct RunArgs {
-    /// Repository directory.
+    /// Repository directory (default: current directory).
     #[arg(long)]
     repo_dir: Option<PathBuf>,
     /// Bypass the gate_label requirement and process all matching issues immediately.


### PR DESCRIPTION
## Summary

- Updates the `--repo-dir` doc comment on `RunArgs` to be consistent with the identical field on `IssueArgs` and `PrArgs`
- Confirmed that `--repo-dir` was already fully functional in the `run` command with the correct priority chain: per-repo config dir > CLI `--repo-dir` > global config `repo_dir`
- No behavioral changes; this is a doc comment fix only

## Files changed

- `crates/forza/src/main.rs` — updated `RunArgs.repo_dir` doc comment from `"Repository directory."` to `"Repository directory (default: current directory)."`

## Test plan

- [x] Existing tests pass (`cargo test --all`)
- [x] Doc comment is consistent with `IssueArgs` and `PrArgs`
- [x] No logic changes to verify

Closes #300