### PR TITLE
feat(logging): log agent backend and model at info level for every run

### DIFF
--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -247,6 +247,13 @@ pub async fn execute(
                 let skills = stage.skills.as_ref().unwrap_or(&config.skills);
                 let mcp = stage.mcp_config.as_deref().or(config.mcp_config.as_deref());
 
+                info!(
+                    number = work.subject.number,
+                    stage = stage_name,
+                    model = model.unwrap_or("default"),
+                    "running agent stage"
+                );
+
                 match agent
                     .execute(
                         stage_name,

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -620,15 +620,17 @@ fn to_core_stage_kind(kind: crate::workflow::StageKind) -> forza_core::StageKind
 ///
 /// Supported values: `"claude"` (default), `"codex"`.
 fn create_agent(config: &RunnerConfig) -> Arc<dyn forza_core::AgentExecutor> {
+    let model = config.global.model.as_deref().unwrap_or("default");
     match config.global.agent.as_str() {
         "codex" => {
-            info!(agent = "codex", "using Codex agent backend");
+            info!(agent = "codex", model, "using Codex agent backend");
             Arc::new(CodexAgentAdapter)
         }
         other => {
             if other != "claude" {
                 warn!(agent = other, "unknown agent, falling back to Claude");
             }
+            info!(agent = "claude", model, "using Claude agent backend");
             Arc::new(ClaudeAgentAdapter)
         }
     }


### PR DESCRIPTION
## Summary

- Added info-level logging in `create_agent()` (runner.rs) for both Claude and Codex backends, including the configured model name
- Added info-level logging in the `Execution::Agent` arm of the pipeline for each agent stage, including subject number, stage name, and model
- Together these give full operator visibility at two granularity levels: once per run (agent selection) and once per agent stage

## Files changed

- `crates/forza/src/runner.rs` — `create_agent()` now logs `agent` + `model` at info level for both Claude and Codex backends
- `crates/forza-core/src/pipeline.rs` — Each `Execution::Agent` stage logs `number`, `stage`, and `model` at info level before dispatching

## Test plan

- [ ] Run `forza run` or `forza watch` and verify info logs show agent backend and model at startup
- [ ] Verify per-stage logs appear for each agent stage with correct model name
- [ ] When `model` is not configured, verify logs show `"default"` as the model sentinel
- [ ] `cargo clippy --all --all-targets -- -D warnings` passes
- [ ] `cargo test --all` passes

Closes #312