### PR TITLE
feat(config): add per-route branch_pattern override

### DIFF
--- a/crates/forza/src/config.rs
+++ b/crates/forza/src/config.rs
@@ -409,6 +409,9 @@ pub struct Route {
 
     /// Override draft_pr setting for this route.
     pub draft_pr: Option<bool>,
+
+    /// Override branch_pattern for this route.
+    pub branch_pattern: Option<String>,
 }
 
 impl Route {
@@ -716,6 +719,14 @@ impl RunnerConfig {
     /// Get the effective draft_pr setting (route override > global default).
     pub fn effective_draft_pr(&self, route: &Route) -> bool {
         route.draft_pr.unwrap_or(self.global.draft_pr)
+    }
+
+    /// Get the effective branch pattern for a route (route override > global default).
+    pub fn effective_branch_pattern<'a>(&'a self, route: &'a Route) -> &'a str {
+        route
+            .branch_pattern
+            .as_deref()
+            .unwrap_or(&self.global.branch_pattern)
     }
 
     /// Generate a branch name for an issue.
@@ -1402,6 +1413,7 @@ workflow = "bug"
                 scope: ConditionScope::default(),
                 max_retries: None,
                 draft_pr: None,
+                branch_pattern: None,
             },
         );
 
@@ -1557,6 +1569,7 @@ repo = "owner/repo"
             scope: ConditionScope::default(),
             max_retries: None,
             draft_pr: None,
+            branch_pattern: None,
         };
         assert!(route.validate("test").is_err()); // no trigger
 

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -41,12 +41,6 @@ async fn discover(
     gh: &dyn crate::github::GitHubClient,
 ) -> Vec<MatchedWork> {
     let mut work = Vec::new();
-    let branch_prefix = config
-        .global
-        .branch_pattern
-        .split('{')
-        .next()
-        .unwrap_or("automation/");
 
     // 1. Discover issues with gate label.
     let labels = config
@@ -64,7 +58,7 @@ async fn discover(
                     let wf_name = route.workflow.as_deref().unwrap_or("");
                     if config.resolve_workflow(wf_name).is_some() {
                         let branch = generate_branch(
-                            &config.global.branch_pattern,
+                            config.effective_branch_pattern(route),
                             issue.number,
                             &issue.title,
                         );
@@ -176,15 +170,20 @@ async fn discover(
                 }
 
                 // Scope filter.
-                if route.scope == config::ConditionScope::ForzaOwned
-                    && !pr.head_branch.starts_with(branch_prefix)
-                {
-                    debug!(
-                        pr = pr.number,
-                        route = route_name,
-                        "skipping: outside forza_owned scope"
-                    );
-                    continue;
+                if route.scope == config::ConditionScope::ForzaOwned {
+                    let branch_prefix = config
+                        .effective_branch_pattern(route)
+                        .split('{')
+                        .next()
+                        .unwrap_or("automation/");
+                    if !pr.head_branch.starts_with(branch_prefix) {
+                        debug!(
+                            pr = pr.number,
+                            route = route_name,
+                            "skipping: outside forza_owned scope"
+                        );
+                        continue;
+                    }
                 }
 
                 // Condition check (uses forza-core's RouteCondition via the old type).
@@ -733,7 +732,7 @@ pub async fn process_issue(
     })?;
 
     let wf_name = route.workflow.as_deref().unwrap_or("");
-    let branch = generate_branch(&config.global.branch_pattern, number, &issue.title);
+    let branch = generate_branch(config.effective_branch_pattern(route), number, &issue.title);
     let subject = adapters::issue_to_subject(&issue, &branch);
 
     let mut matched = MatchedWork {


### PR DESCRIPTION
## Summary

- Adds `branch_pattern: Option<String>` to the `Route` struct in `config.rs`, allowing each route to override the global `branch_pattern`
- Adds `effective_branch_pattern()` helper to `RunnerConfig` that returns the route-level pattern when set, falling back to `global.branch_pattern`
- Updates all three `generate_branch()` call sites in `runner.rs` (discovery issue routes, `forza_owned` scope filtering, and `process_issue()`) to use the per-route effective pattern
- Follows the same override pattern already used by `effective_draft_pr()` and `effective_model()`

## Files changed

- `crates/forza/src/config.rs` — added `branch_pattern: Option<String>` field to `Route` and `effective_branch_pattern()` method to `RunnerConfig`
- `crates/forza/src/runner.rs` — updated three call sites to use `effective_branch_pattern(route)` instead of `global.branch_pattern` directly

## Test plan

- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all --all-targets -- -D warnings` passes
- [ ] Existing configs with no route-level `branch_pattern` continue to work (field is `Option<String>`, backward compatible)
- [ ] Route with `branch_pattern` set uses the override; route without it falls back to global default
- [ ] `forza explain --route <name> -v` shows the effective branch pattern

Closes #315