### PR TITLE
docs: add design principles document formalizing responsibility boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ For PRs, condition routes automatically detect CI failures and merge conflicts, 
 | Worktree isolation | Each run gets a clean git worktree | Working directory |
 | PR lifecycle | Automated open, update, merge | Manual |
 
+## Responsibility boundaries
+
+Forza is infrastructure, not an autonomous agent. Three actors share responsibility:
+
+| Actor | Decides |
+|-------|---------|
+| **You (human)** | What to work on, when to start, what "done" means |
+| **Forza (process)** | Which stages run, where work happens, when to stop, label lifecycle |
+| **Agent (Claude/Codex)** | How to implement, what files to change, how to fix failures |
+
+Adding decision-making to the framework — adaptive prompting, automatic workflow
+selection, intelligent retries — blurs these lanes and adds unpredictability. When
+evaluating a new feature, ask: does this belong with the human, the agent, or the
+framework? If it belongs with the human or agent, it does not belong in forza.
+
+See [design/principles.md](design/principles.md) for the full design principles and
+feature evaluation guidelines.
+
 ## Quick start
 
 ```bash

--- a/design/principles.md
+++ b/design/principles.md
@@ -1,0 +1,100 @@
+# forza — Design Principles
+
+This document formalizes what forza is and is not responsible for. It is the reference
+point when evaluating new features. If a proposal crosses a boundary, it needs strong
+justification.
+
+## Three actors, clear lanes
+
+### Forza decides (the process)
+
+- Which stages run and in what order
+- When to stop (validation failure, retry budget)
+- Where work happens (worktrees, branches)
+- What labels to apply and when
+- How to recover (condition routes, retry with backoff)
+
+### Humans decide (the direction)
+
+- What to work on (labeling issues `forza:ready`)
+- When to start (manual run, watch mode, or action trigger)
+- What "done" looks like (acceptance criteria in the issue)
+- Whether to merge (or let auto-merge handle it)
+- Sequencing and prioritization of work
+
+### The agent decides (the implementation)
+
+- How to implement the plan
+- What files to change
+- How to fix failures
+- What to write in the PR
+
+## Key principle
+
+Forza is infrastructure, not an autonomous agent. It provides deterministic guardrails —
+stages, validation, lifecycle labels, retry budgets — and the human decides what to work
+on and when. The agent decides how. Adding intelligence to the framework adds
+unpredictability.
+
+## Evaluating features
+
+When a feature is proposed, ask:
+
+- Does this add decision-making to forza that belongs with the human or the agent?
+- Does this make the pipeline less deterministic?
+- Can this be achieved by a better issue, a better prompt, or a better config instead
+  of new framework logic?
+
+If the answer to any of these is "yes," the feature probably does not belong in forza.
+
+### Examples
+
+**Belongs in forza:** A `max_retries` field that stops a route after N failures. This
+is process control — a guardrail the human configures.
+
+**Does not belong in forza:** Automatically adjusting the prompt when a stage fails
+repeatedly. That is intelligence in the framework. The human should update the issue;
+the agent should handle variation.
+
+**Belongs in forza:** A `condition` field on a stage that gates execution on a shell
+command exit code. The human writes the condition; forza enforces it.
+
+**Does not belong in forza:** Automatically deciding which workflow to use based on
+issue content analysis. Route matching is the human's job; it must be explicit in config.
+
+## Design principles
+
+These follow directly from the three-actor model.
+
+1. **One route, one action, one cycle.** A route does exactly one thing. If a PR needs
+   rebasing and CI fixing and merging, that is three routes across three poll cycles.
+   Multi-step behavior is achieved through configuration, not framework complexity.
+
+2. **GitHub is the state machine.** PR state on GitHub is authoritative. Routes are
+   transition functions. The poll loop is the event loop. Forza does not maintain an
+   internal state machine that duplicates or diverges from GitHub state.
+
+3. **Match once, carry through.** Once a subject is matched to a route, that binding is
+   immutable for the duration of the run. No re-matching mid-execution. The human's
+   intent, expressed as a label or PR state, is locked in at discovery time.
+
+4. **Config is behavior.** Everything a route does is visible in `forza.toml`. No global
+   flags that secretly modify stage behavior. If you want auto-merge, include the merge
+   stage. If you do not want it, leave it out.
+
+5. **One path through the code.** Issues and PRs follow the same execution pipeline.
+   Differences are data, not control flow. A unified pipeline is easier to reason about,
+   test, and extend.
+
+## What this rules out
+
+- **Adaptive prompting**: forza does not modify prompts based on prior failures. The
+  agent adapts; forza does not.
+- **Automatic workflow selection**: the human picks the workflow via route config. Forza
+  does not infer it from issue content.
+- **In-process decisions between stages**: forza does not inspect stage output to decide
+  what to do next. The stage sequence is fixed in config.
+- **Autonomous issue triage**: forza does not label, prioritize, or select which issues
+  to work on. It only acts on issues that already have the gate label.
+- **Framework-level retry intelligence**: retries are a counter, not a strategy. Forza
+  retries blindly up to `max_retries`; the agent is responsible for varying its approach.


### PR DESCRIPTION
## Summary
- Add `design/principles.md` that formalizes the three-actor model (human, forza, agent) with clear responsibility boundaries
- Document key design principles guiding forza's architecture and behavior
- Add a feature evaluation rubric for assessing new capabilities against the model
- Update `README.md` with a brief responsibility boundaries table linking to the full document

## Files changed
- `design/principles.md` - New document formalizing the three-actor model, design principles, and feature evaluation rubric
- `README.md` - Added responsibility boundaries table with link to principles document

## Test plan
- [ ] Review `design/principles.md` for accuracy and completeness against current codebase behavior
- [ ] Verify README table renders correctly
- [ ] Confirm links between README and principles document resolve

Closes #321