### PR TITLE
feat(planner): add open_issue.md prompt template

### DIFF
--- a/crates/forza-core/src/planner.rs
+++ b/crates/forza-core/src/planner.rs
@@ -34,6 +34,7 @@ const PROMPT_PR_FIX_CI: &str = include_str!("prompts/pr_fix_ci.md");
 const PROMPT_PR_REVISE: &str = include_str!("prompts/pr_revise_pr.md");
 const PROMPT_PR_REVIEW: &str = include_str!("prompts/pr_review.md");
 const _PROMPT_PR_MERGE: &str = include_str!("prompts/pr_merge.md");
+const _PROMPT_OPEN_ISSUE: &str = include_str!("prompts/open_issue.md");
 
 /// Generate prompts for each stage in a workflow.
 ///

--- a/crates/forza-core/src/prompts/open_issue.md
+++ b/crates/forza-core/src/prompts/open_issue.md
@@ -1,0 +1,48 @@
+{preamble}
+
+Create a well-formed GitHub issue in {repo}.
+
+## Steps
+
+1. Read `CLAUDE.md`, `README.md`, and any relevant source files to understand the project context.
+2. Draft the issue using the template below.
+3. Create the issue:
+   ```
+   gh issue create \
+   --repo {repo} \
+   --title "<conventional title>" \
+   --body "$(cat <<'EOF'
+   <issue body>
+   EOF
+   )" \
+   --label <label>
+   ```
+
+## Issue template
+
+### Title
+
+Use a conventional format: `type: short description` (e.g. `feat: add retry backoff`, `fix: handle nil pointer in runner`).
+
+### Body
+
+```
+## Summary
+
+<1-3 sentences describing the problem or feature request>
+
+## Motivation
+
+<Why this matters — what breaks, what is missing, what would improve>
+
+## Acceptance criteria
+
+- [ ] <specific, testable criterion>
+- [ ] <specific, testable criterion>
+
+## Affected files
+
+<List files or modules likely involved, based on your reading of the codebase>
+```
+
+Choose labels that match the issue type (e.g. `bug`, `enhancement`, `documentation`).


### PR DESCRIPTION
## Summary

- Adds `crates/forza-core/src/prompts/open_issue.md`, a new prompt template for the `open_issue` stage
- Template follows the existing structure: `{preamble}` header, numbered steps to read repo context, draft a well-formed issue, and create it via `gh issue create`
- Embeds the template at compile time via `include_str!` in `planner.rs` to validate the file exists at build time
- Consistent with the staged-addition pattern used by `_PROMPT_PR_MERGE` — no live code path yet

## Files changed

- `crates/forza-core/src/prompts/open_issue.md` — new prompt template with `{preamble}` and `{repo}` placeholders
- `crates/forza-core/src/planner.rs` — adds `const _PROMPT_OPEN_ISSUE` using `include_str!` for compile-time validation

## Test plan

- `cargo check` passes (compile-time `include_str!` validates the file)
- `cargo test --all` passes
- `cargo clippy --all --all-targets -- -D warnings` passes
- Review verdict: PASS (two low-severity notes, both acceptable)

Closes #326