### PR TITLE
feat(github): add create_issue to GitHubClient trait and all implementations closes #325

### DIFF
--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -619,6 +619,9 @@ mod tests {
         async fn post_comment(&self, _repo: &str, _number: u64, _body: &str) -> Result<()> {
             Ok(())
         }
+        async fn create_issue(&self, _repo: &str, _title: &str, _body: &str) -> Result<u64> {
+            Ok(0)
+        }
         async fn create_pr(
             &self,
             _repo: &str,

--- a/crates/forza-core/src/testing.rs
+++ b/crates/forza-core/src/testing.rs
@@ -119,7 +119,8 @@ pub enum MockCall {
     AddLabel(u64, String),
     RemoveLabel(u64, String),
     PostComment(u64, String),
-    CreatePr(String), // branch
+    CreateIssue(String), // title
+    CreatePr(String),    // branch
     UpdatePrBody(u64),
     MarkPrReady(u64),
     AgentExecute(String),   // prompt (truncated)
@@ -136,6 +137,7 @@ pub struct MockGitHub {
     prs_by_branch: HashMap<String, u64>,
     all_open_prs: Vec<Subject>,
     next_pr_number: Arc<Mutex<u64>>,
+    next_issue_number: Arc<Mutex<u64>>,
     pub calls: Arc<Mutex<Vec<MockCall>>>,
 }
 
@@ -147,6 +149,7 @@ impl MockGitHub {
             prs_by_branch: HashMap::new(),
             all_open_prs: Vec::new(),
             next_pr_number: Arc::new(Mutex::new(100)),
+            next_issue_number: Arc::new(Mutex::new(200)),
             calls: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -195,6 +198,15 @@ impl MockGitHub {
             .unwrap()
             .iter()
             .any(|c| matches!(c, MockCall::RemoveLabel(n, l) if *n == number && l == label))
+    }
+
+    /// Check if an issue was created.
+    pub fn issue_was_created(&self) -> bool {
+        self.calls
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|c| matches!(c, MockCall::CreateIssue(_)))
     }
 
     /// Check if a PR was created.
@@ -283,6 +295,14 @@ impl crate::traits::GitHubClient for MockGitHub {
             .get(branch)
             .and_then(|n| self.prs.get(n))
             .cloned())
+    }
+
+    async fn create_issue(&self, _repo: &str, title: &str, _body: &str) -> Result<u64> {
+        self.record(MockCall::CreateIssue(title.to_string()));
+        let mut next = self.next_issue_number.lock().unwrap();
+        let number = *next;
+        *next += 1;
+        Ok(number)
     }
 
     async fn add_label(&self, _repo: &str, number: u64, label: &str) -> Result<()> {

--- a/crates/forza-core/src/traits.rs
+++ b/crates/forza-core/src/traits.rs
@@ -71,6 +71,9 @@ pub trait GitHubClient: Send + Sync {
     /// Post a comment on an issue or PR.
     async fn post_comment(&self, repo: &str, number: u64, body: &str) -> Result<()>;
 
+    /// Create an issue. Returns the issue number.
+    async fn create_issue(&self, repo: &str, title: &str, body: &str) -> Result<u64>;
+
     /// Create a pull request. Returns the PR number.
     async fn create_pr(
         &self,

--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -169,6 +169,13 @@ impl forza_core::GitHubClient for GitHubAdapter {
             .map_err(|e| CoreError::GitHub(e.to_string()))
     }
 
+    async fn create_issue(&self, repo: &str, title: &str, body: &str) -> CoreResult<u64> {
+        self.inner
+            .create_issue(repo, title, body)
+            .await
+            .map_err(|e| CoreError::GitHub(e.to_string()))
+    }
+
     async fn create_pr(
         &self,
         repo: &str,

--- a/crates/forza/src/github/gh_cli.rs
+++ b/crates/forza/src/github/gh_cli.rs
@@ -70,6 +70,10 @@ impl GitHubClient for GhCliClient {
         super::comment_on_issue(repo, number, body).await
     }
 
+    async fn create_issue(&self, repo: &str, title: &str, body: &str) -> Result<u64> {
+        super::create_issue(repo, title, body).await
+    }
+
     async fn fetch_pr(&self, repo: &str, number: u64) -> Result<PrCandidate> {
         super::fetch_pr(repo, number).await
     }

--- a/crates/forza/src/github/mod.rs
+++ b/crates/forza/src/github/mod.rs
@@ -46,6 +46,7 @@ pub trait GitHubClient: Send + Sync {
         description: &str,
     ) -> Result<()>;
     async fn comment_on_issue(&self, repo: &str, number: u64, body: &str) -> Result<()>;
+    async fn create_issue(&self, repo: &str, title: &str, body: &str) -> Result<u64>;
 
     // ── Pull Requests ───────────────────────────────────────────────
     async fn fetch_pr(&self, repo: &str, number: u64) -> Result<PrCandidate>;
@@ -979,6 +980,31 @@ pub async fn comment_on_issue(repo: &str, number: u64, body: &str) -> Result<()>
     }
 
     Ok(())
+}
+
+/// Create an issue via gh CLI. Returns the issue number.
+pub async fn create_issue(repo: &str, title: &str, body: &str) -> Result<u64> {
+    let output = tokio::process::Command::new("gh")
+        .args([
+            "issue", "create", "--repo", repo, "--title", title, "--body", body,
+        ])
+        .output()
+        .await
+        .map_err(|e| Error::GitHub(format!("gh issue create failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::GitHub(format!("gh issue create failed: {stderr}")));
+    }
+
+    let issue_url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let issue_number = issue_url
+        .rsplit('/')
+        .next()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    Ok(issue_number)
 }
 
 #[cfg(test)]

--- a/crates/forza/src/github/octocrab_client.rs
+++ b/crates/forza/src/github/octocrab_client.rs
@@ -265,6 +265,19 @@ impl GitHubClient for OctocrabClient {
         Ok(())
     }
 
+    async fn create_issue(&self, repo: &str, title: &str, body: &str) -> Result<u64> {
+        let (owner, name) = parse_repo(repo)?;
+        let issue = self
+            .client
+            .issues(owner, name)
+            .create(title)
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| Error::GitHub(format!("create issue: {e}")))?;
+        Ok(issue.number)
+    }
+
     async fn fetch_pr(&self, repo: &str, number: u64) -> Result<PrCandidate> {
         let (owner, name) = parse_repo(repo)?;
         let pr = self


### PR DESCRIPTION
## Summary

- Adds `create_issue(&self, repo: &str, title: &str, body: &str) -> Result<u64>` to the `GitHubClient` trait in `forza-core`
- Implements the method across all four client layers: core trait, `MockGitHub`, `GitHubAdapter`, `GhCliClient`, and `OctocrabClient`
- `MockGitHub` gains a `CreateIssue` variant in `MockCall`, a `next_issue_number` counter mirroring `next_pr_number`, and an `issue_was_created()` verification method
- The `gh` CLI implementation parses the created issue URL to extract and return the issue number

## Files changed

- `crates/forza-core/src/traits.rs` - Added `create_issue` to the `GitHubClient` trait
- `crates/forza-core/src/testing.rs` - Added `MockCall::CreateIssue`, `next_issue_number` counter, and `issue_was_created()` helper
- `crates/forza/src/github/mod.rs` - Added `create_issue` to the internal `GitHubClient` trait and the free function implementation
- `crates/forza/src/github/gh_cli.rs` - Added `create_issue` to `GhCliClient`
- `crates/forza/src/github/octocrab_client.rs` - Added `create_issue` to `OctocrabClient`
- `crates/forza/src/adapters.rs` - Added `create_issue` to `GitHubAdapter` with `CoreError::GitHub` error mapping

## Test plan

- [ ] `cargo test --all` passes with no regressions
- [ ] `cargo clippy --all --all-targets -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `MockGitHub::issue_was_created()` is available for future tests exercising this code path

Closes #325