### PR TITLE
docs: add "What forza isn't" section to design principles and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ Full documentation at **[joshrotenberg.github.io/forza](https://joshrotenberg.gi
 - [Writing Issues](https://joshrotenberg.github.io/forza/usage/writing-issues.html)
 - [Security](https://joshrotenberg.github.io/forza/usage/security.html)
 
+## What forza isn't
+
+forza will fail, and that's by design. When a run fails, forza stops, labels the issue, and tells you what happened. It doesn't retry, work around, or guess.
+
+- Not fully autonomous — humans decide what to work on and when
+- Not self-healing — failures are reported, not automatically resolved
+- Not a replacement for good issue writing — vague issues produce vague results
+- Not an agent — forza is infrastructure that agents run inside
+- Not trying to handle every edge case — simplicity and determinism over cleverness
+
+See [design/principles.md](design/principles.md) for the full rationale.
+
 ## Design
 
 See [design/principles.md](design/principles.md) for the design principles and feature evaluation guidelines.

--- a/design/principles.md
+++ b/design/principles.md
@@ -86,6 +86,23 @@ These follow directly from the three-actor model.
    Differences are data, not control flow. A unified pipeline is easier to reason about,
    test, and extend.
 
+## What forza isn't
+
+**forza will fail, and that's by design.** When a run fails, forza stops, labels the
+issue, and tells you what happened. It doesn't retry, work around, or guess. The right
+response is usually to read the failure, improve the issue description, and run again.
+
+- **Not fully autonomous** — humans decide what to work on and when.
+- **Not self-healing** — failures are reported, not automatically resolved.
+- **Not a replacement for good issue writing** — vague issues produce vague results.
+- **Not an agent** — forza is infrastructure that agents run inside.
+- **Not trying to handle every edge case** — simplicity and determinism over cleverness.
+
+The temptation is to make forza handle more. Resist it. Every conditional path added to
+the pipeline is complexity that makes the system harder to reason about. If something
+fails, the answer is usually a better issue, a better prompt, or a human decision — not
+more framework logic.
+
 ## What this rules out
 
 - **Adaptive prompting**: forza does not modify prompts based on prior failures. The

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -10,6 +10,7 @@
   - [Stage Kinds](concepts/stage-kinds.md)
   - [Lifecycle](concepts/lifecycle.md)
   - [Breadcrumbs](concepts/breadcrumbs.md)
+  - [What forza isn't](concepts/what-forza-isnt.md)
 
 - [Configuration](configuration/overview.md)
   - [Reference](configuration/reference.md)

--- a/docs/src/concepts/what-forza-isnt.md
+++ b/docs/src/concepts/what-forza-isnt.md
@@ -1,0 +1,19 @@
+# What forza isn't
+
+**forza will fail, and that's by design.** When a run fails, forza stops, labels the issue, and tells you what happened. It doesn't retry, work around, or guess. The right response is usually to read the failure, improve the issue description, and run again.
+
+## What forza is not
+
+- **Not fully autonomous** — humans decide what to work on and when. Labeling an issue `forza:ready` is a human decision.
+- **Not self-healing** — failures are reported, not automatically resolved. A failed stage means a labeled issue and a failure comment, not a retry loop.
+- **Not a replacement for good issue writing** — vague issues produce vague results. The quality of forza's output is bounded by the quality of the issue.
+- **Not an agent** — forza is infrastructure that agents run inside. The agent implements; forza orchestrates.
+- **Not trying to handle every edge case** — simplicity and determinism over cleverness. If an edge case isn't covered, the answer is usually a better issue or a human decision.
+
+## Why this matters
+
+The temptation is to make forza handle more. Resist it. Every conditional path added to the pipeline is complexity that makes the system harder to reason about. If something fails, the answer is usually a better issue, a better prompt, or a human decision — not more framework logic.
+
+This follows directly from the three-actor model: forza controls process, humans control direction, agents control implementation. Blurring those lanes adds unpredictability without adding value.
+
+See [design/principles.md](https://github.com/joshrotenberg/forza/blob/main/design/principles.md) in the repository for the full design rationale.


### PR DESCRIPTION
## Summary
- Adds a new \"What forza isn't\" section to the design principles document clarifying forza's scope
- Creates a new `docs/src/concepts/what-forza-isnt.md` page for the mdbook documentation site
- Updates `docs/src/SUMMARY.md` to include the new page in the table of contents
- Updates `README.md` to reference the new section

## Files changed
- `README.md` - Added reference to the "What forza isn't" section
- `design/principles.md` - Added "What forza isn't" section explaining scope boundaries
- `docs/src/SUMMARY.md` - Added entry for the new concepts page
- `docs/src/concepts/what-forza-isnt.md` - New page with full "What forza isn't" content

## Test plan
- [ ] Verify mdbook builds without errors: `cd docs && mdbook build`
- [ ] Confirm new page appears in the generated site navigation
- [ ] Review content for accuracy and consistency with existing design principles

Closes #341