### PR TITLE
fix(runner): change empty code fence to text to silence rustdoc warning

### DIFF
--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -650,7 +650,7 @@ fn create_agent(config: &RunnerConfig) -> Arc<dyn forza_core::AgentExecutor> {
 ///
 /// # Examples
 ///
-/// ```
+/// ```text
 /// // "automation/{issue}-{slug}" with number=42, title="Fix the bug"
 /// // → "automation/42-fix-the-bug"
 /// ```


### PR DESCRIPTION
## Summary

- The `generate_branch` doc comment in `runner.rs` had a bare code fence (` ``` `) containing only comments, which rustdoc treated as Rust code and emitted a warning
- Changed the fence to ` ```text ` so rustdoc skips compilation of that block
- Verified `cargo doc --no-deps -p forza` produces zero warnings after the fix

## Files changed

- `crates/forza/src/runner.rs` — annotate doc comment code fence with `text` language tag

## Test plan

- [x] `cargo doc --no-deps -p forza` produces no warnings
- [x] `cargo clippy --all --all-targets -- -D warnings` passes
- [x] `cargo test --all` passes

Closes #353