### PR TITLE
fix: update CLI reference docs with all commands and flags

### DIFF
--- a/docs/src/usage/cli-reference.md
+++ b/docs/src/usage/cli-reference.md
@@ -7,8 +7,16 @@
 Create the required GitHub labels and generate a starter `forza.toml`:
 
 ```
-forza init [--repo owner/name] [--config path]
+forza init --repo <owner/name> [--output <path>] [--auto] [--guided] [--model <model>] [--config <path>]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--repo <owner/name>` | Repository in owner/name format (required) |
+| `--output <path>` | Output path for the generated config file (default: `forza.toml`) |
+| `--auto` | Use an agent to inspect the repo and generate a tailored config |
+| `--guided` | Launch an interactive Claude session to collaboratively generate a config |
+| `--model <model>` | Model to use for agent-assisted config generation (e.g. `claude-opus-4-6`) |
 
 This is a one-time setup command. It is idempotent — safe to run on a repo that already has some of the labels.
 
@@ -17,8 +25,16 @@ This is a one-time setup command. It is idempotent — safe to run on a repo tha
 Process a single issue by number:
 
 ```
-forza issue <N> [--dry-run] [--config path]
+forza issue <N> [--repo <owner/name>] [--repo-dir <path>] [--dry-run] [--model <model>] [--skill <path>...] [--config <path>]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--repo <owner/name>` | Repository to process (required when multiple repos are configured) |
+| `--repo-dir <path>` | Repository directory (default: current directory) |
+| `--dry-run` | Show the plan without executing |
+| `--model <model>` | Override the model for every stage in this run |
+| `--skill <path>` | Add a skill file for every stage in this run (repeatable) |
 
 Fetches the issue, matches a route, and executes the workflow. Use `--dry-run` to preview the match and planned stages without executing.
 
@@ -27,8 +43,16 @@ Fetches the issue, matches a route, and executes the workflow. Use `--dry-run` t
 Process a single PR by number:
 
 ```
-forza pr <N> [--dry-run] [--config path]
+forza pr <N> [--repo <owner/name>] [--repo-dir <path>] [--dry-run] [--model <model>] [--skill <path>...] [--config <path>]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--repo <owner/name>` | Repository to process (required when multiple repos are configured) |
+| `--repo-dir <path>` | Repository directory (default: current directory) |
+| `--dry-run` | Show the plan without executing |
+| `--model <model>` | Override the model for every stage in this run |
+| `--skill <path>` | Add a skill file for every stage in this run (repeatable) |
 
 Fetches the PR, matches a condition or label route, and executes the workflow.
 
@@ -37,8 +61,14 @@ Fetches the PR, matches a condition or label route, and executes the workflow.
 Discover and process one batch of eligible issues and PRs:
 
 ```
-forza run [--config path]
+forza run [--route <name>] [--repo-dir <path>] [--no-gate] [--config <path>]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--route <name>` | Only run a specific route |
+| `--repo-dir <path>` | Repository directory (default: current directory) |
+| `--no-gate` | Bypass the gate_label requirement and process all matching issues immediately |
 
 Equivalent to one iteration of the watch loop. Useful for running forza from a cron job or CI.
 
@@ -47,8 +77,20 @@ Equivalent to one iteration of the watch loop. Useful for running forza from a c
 Continuous polling loop with auto-fix:
 
 ```
-forza watch [--interval <seconds>] [--config path]
+forza watch [--interval <seconds>] [--route <name>] [--repo-dir <path>]
+            [--serve-api] [--api-host <host>] [--api-port <port>]
+            [--no-gate] [--config <path>]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--interval <seconds>` | Override poll interval in seconds (uses per-route intervals by default) |
+| `--route <name>` | Only run a specific route |
+| `--repo-dir <path>` | Repository directory |
+| `--serve-api` | Also start the REST API server alongside the watch loop |
+| `--api-host <host>` | Host address for the REST API server (default: `127.0.0.1`) |
+| `--api-port <port>` | Port for the REST API server (default: `8080`) |
+| `--no-gate` | Bypass the gate_label requirement and process all matching issues immediately |
 
 Runs `forza run` on the configured `poll_interval` for each route, indefinitely. Use `Ctrl+C` to stop.
 
@@ -57,8 +99,15 @@ Runs `forza run` on the configured `poll_interval` for each route, indefinitely.
 Show run history and outcomes:
 
 ```
-forza status [--limit N] [--config path]
+forza status [--all] [--detailed] [--run-id <id>] [--workflow <name>] [--config <path>]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Show all runs as a history table (sorted newest first) |
+| `--detailed` | Show latest run detail |
+| `--run-id <id>` | Show a specific run by ID |
+| `--workflow <name>` | Filter dashboard to a single workflow |
 
 Displays recent runs with their route, workflow, outcome, and cost.
 
@@ -67,10 +116,22 @@ Displays recent runs with their route, workflow, outcome, and cost.
 Visualize your config, routes, and workflows:
 
 ```
-forza explain [--issues] [--prs] [--conditions]
+forza explain [--repo <owner/name>] [--issues] [--prs] [--conditions]
               [--route <name>] [--workflows] [--workflow <name>]
               [-v] [--json] [--config path]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--repo <owner/name>` | Filter output to a single repository |
+| `--issues` | Show only issue routes |
+| `--prs` | Show only PR routes (label and condition) |
+| `--conditions` | Show only condition routes |
+| `--route <name>` | Show a single route in detail (auto-verbose) |
+| `--workflows` | List all workflow templates |
+| `--workflow <name>` | Show a single workflow's stages |
+| `-v` / `--verbose` | Verbose output — show per-stage detail |
+| `--json` | Output as JSON instead of human-readable text |
 
 Useful for verifying that routes are configured correctly before running.
 
@@ -79,8 +140,13 @@ Useful for verifying that routes are configured correctly before running.
 Re-run failed stages with error context:
 
 ```
-forza fix [--run-id <id>] [--config path]
+forza fix [--run <id>] [--issue <N>] [--config <path>]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--run <id>` | Run ID to fix (default: latest run) |
+| `--issue <N>` | Issue number to fix (finds latest run for this issue) |
 
 Picks up where a failed run left off, passing the failure reason as additional context to the agent.
 
@@ -89,18 +155,32 @@ Picks up where a failed run left off, passing the failure reason as additional c
 Remove worktrees and run state:
 
 ```
-forza clean [--all] [--config path]
+forza clean [--repo-dir <path>] [--runs] [--stale] [--days <N>] [--dry-run] [--config <path>]
 ```
 
-Removes stale git worktrees created by forza and cleans up local run state. Use `--all` to remove all forza-created worktrees, including ones from active runs.
+| Flag | Description |
+|------|-------------|
+| `--repo-dir <path>` | Repository directory (default: current directory) |
+| `--runs` | Remove run state files instead of worktrees |
+| `--stale` | Remove only worktrees older than the configured threshold (see `--days`) |
+| `--days <N>` | Age threshold in days for `--stale` (overrides the configured default) |
+| `--dry-run` | Print what would be removed without acting |
+
+Removes stale git worktrees created by forza and cleans up local run state.
 
 ### forza serve
 
 Start the REST API server:
 
 ```
-forza serve [--port <port>] [--config path]
+forza serve [--host <host>] [--port <port>] [--repo-dir <path>] [--config <path>]
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--host <host>` | Host address to bind to (default: `127.0.0.1`) |
+| `--port <port>` | Port to listen on (default: `8080`) |
+| `--repo-dir <path>` | Repository directory |
 
 Starts an HTTP server exposing the forza API. See [REST API](../advanced/api.md) for endpoint documentation.
 
@@ -109,15 +189,37 @@ Starts an HTTP server exposing the forza API. See [REST API](../advanced/api.md)
 Start the MCP server:
 
 ```
-forza mcp [--config path]
+forza mcp [--http] [--host <host>] [--port <port>] [--config <path>]
 ```
 
+| Flag | Description |
+|------|-------------|
+| `--http` | Use HTTP/SSE transport instead of stdio |
+| `--host <host>` | Host address to bind to, HTTP mode only (default: `127.0.0.1`) |
+| `--port <port>` | Port to listen on, HTTP mode only (default: `8080`) |
+
 Starts an MCP server on stdio. See [MCP Server](../advanced/mcp.md) for tool documentation.
+
+### forza open
+
+Open a new GitHub issue using agent assistance:
+
+```
+forza open [--repo <owner/name>] [--prompt <text>] [--label <label>] [--ready] [--model <model>] [--config <path>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--repo <owner/name>` | Repository to open an issue in (required when multiple repos are configured) |
+| `--prompt <text>` | Prompt describing the issue to open |
+| `--label <label>` | Label to apply to the created issue |
+| `--ready` | Also add the `forza:ready` label to the created issue |
+| `--model <model>` | Override the model (e.g. `claude-opus-4-6`) |
 
 ## Global flags
 
 | Flag | Description |
 |------|-------------|
-| `--config <path>` | Path to `forza.toml` (default: `./forza.toml`) |
+| `--config <path>` / `-c` | Path to `forza.toml` (default: `./forza.toml`) |
+| `--log-file <path>` | Write tracing output to this file instead of stderr |
 | `--dry-run` | Preview actions without executing (supported on `issue`, `pr`) |
-| `--verbose` / `-v` | Increase log verbosity |


### PR DESCRIPTION
## Summary
- Updated CLI reference docs to include all flags and options for every command (`init`, `issue`, `pr`, `run`, `watch`, `status`, `explain`, `fix`, `clean`, `serve`, `mcp`)
- Added the new `forza open` command documentation
- Added flag tables for each command showing all available options with descriptions
- Restructured getting started page with a quickstart section including multiple installation methods and a first-issue walkthrough

## Files changed
- `docs/src/usage/cli-reference.md` — expanded all command sections with complete flag tables, added `forza open` command, updated global flags
- `docs/src/getting-started.md` — reorganized into quickstart flow with install methods (Homebrew, shell, PowerShell, cargo), init, and first issue steps

## Test plan
- [ ] Verify docs build cleanly with `mdbook build`
- [ ] Confirm all documented flags match current CLI (`forza --help`, `forza <cmd> --help`)
- [ ] Review rendered docs for formatting and accuracy

Closes #352