### PR TITLE
fix: correct MCP server documentation with actual tool names

### DIFF
--- a/docs/src/advanced/mcp.md
+++ b/docs/src/advanced/mcp.md
@@ -4,11 +4,21 @@ Forza exposes an MCP (Model Context Protocol) server that allows AI agents and M
 
 ## Starting the MCP server
 
+### Stdio transport (default)
+
 ```bash
 forza mcp [--config path]
 ```
 
 The server communicates over stdio using the MCP protocol. Connect to it from an MCP client or configure it in an `.mcp.json` file.
+
+### HTTP/SSE transport
+
+```bash
+forza mcp --http [--host 127.0.0.1] [--port 8080]
+```
+
+Starts an HTTP server with SSE streaming. Useful for remote clients or when stdio is not available.
 
 ## Configuring in .mcp.json
 
@@ -27,52 +37,104 @@ Add forza as an MCP server in your project's `.mcp.json`:
 
 ## Available tools
 
-### list_routes
+Forza exposes 11 tools organized into three groups.
 
-List all configured routes and their current status.
+### Runner tools
 
-### list_runs
+#### issue_run
 
-List recent runs with outcomes and metadata.
-
-**Parameters:**
-
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `limit` | integer | Maximum number of runs to return |
-| `route` | string | Filter by route name |
-
-### trigger_run
-
-Trigger a run for a specific issue or PR.
+Process a single GitHub issue through the full pipeline.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `repo` | string | yes | `owner/name` |
-| `subject_type` | string | yes | `"issue"` or `"pr"` |
-| `subject_number` | integer | yes | Issue or PR number |
-| `route` | string | no | Route name (inferred from config if omitted) |
+| `number` | integer | yes | Issue number to process |
+| `repo` | string | no | `owner/name` (required when multiple repos are configured) |
 
-### get_run
+#### pr_run
 
-Get detailed information about a specific run by ID.
+Process a single GitHub PR through the full pipeline.
 
 **Parameters:**
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| `run_id` | string | Run identifier |
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `number` | integer | yes | PR number to process |
+| `repo` | string | no | `owner/name` (required when multiple repos are configured) |
 
-### get_status
+#### run_batch
 
-Get the current runner status: active runs, queue depth, and cost.
+Poll for all eligible issues and PRs across configured repos and process them in a single batch. Takes no parameters.
+
+#### dry_run_issue
+
+Show the execution plan for an issue without running it.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `number` | integer | yes | Issue number to show the plan for |
+| `repo` | string | no | `owner/name` (required when multiple repos are configured) |
+
+### Status tools
+
+#### status_latest
+
+Get the most recent run record. Takes no parameters.
+
+#### status_list
+
+List all run records sorted newest-first. Takes no parameters.
+
+#### status_get
+
+Get a specific run record by ID.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `run_id` | string | yes | Run identifier |
+
+#### status_summary
+
+Get per-workflow aggregate statistics across all runs (totals, success/failure counts, cost ranges). Takes no parameters.
+
+#### status_find_issue
+
+Find the most recent run for a given issue number.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `issue_number` | integer | yes | Issue number to look up |
+
+### Config tools
+
+#### config_show
+
+Return the currently loaded runner configuration as JSON. Takes no parameters.
+
+#### config_validate
+
+Parse and validate a forza config file, returning any errors.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `path` | string | yes | Path to the config file to validate |
 
 ## Use cases
 
-- **Agent-driven issue creation**: An agent can use `trigger_run` to start processing an issue it just created
-- **Status monitoring**: Query run outcomes from an automated dashboard
+- **Agent-driven issue processing**: An agent can use `issue_run` to start processing an issue it just created
+- **PR maintenance**: Use `pr_run` to trigger pipeline runs for PRs that need rebasing, CI fixes, or review
+- **Batch processing**: Use `run_batch` to poll and process all eligible work in one call
+- **Dry runs**: Use `dry_run_issue` to preview what forza would do for an issue before committing
+- **Status monitoring**: Query run outcomes with `status_list`, `status_latest`, or `status_summary`
 - **Integration testing**: Drive forza runs from test harnesses without using the CLI
 
 ## Using forza with its own MCP server


### PR DESCRIPTION
## Summary
- Replace incorrect MCP tool names (list_routes, list_runs, trigger_run, get_run, get_status) with the actual 11 tools implemented in mcp.rs
- Document all tool parameters organized by category: Runner (issue_run, pr_run, run_batch, dry_run_issue), Status (status_latest, status_list, status_get, status_summary, status_find_issue), Config (config_show, config_validate)
- Add HTTP/SSE transport mode documentation for the MCP server
- Update cross-references in getting-started.md and api.md to match corrected tool names

## Files changed
- `docs/src/advanced/mcp.md` - Rewrote MCP tool reference with actual tool names, parameters, and transport modes
- `docs/src/advanced/api.md` - Updated cross-references to MCP tools
- `docs/src/getting-started.md` - Updated MCP quick-start section with correct tool names

## Test plan
- [ ] Verify `mdbook build` succeeds without warnings
- [ ] Confirm all documented tool names match implementations in `crates/forza/src/mcp.rs`
- [ ] Check cross-references between docs pages are consistent

Closes #350