### PR TITLE
chore: add workflow_dispatch trigger to release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release-plz:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to the `release-plz.yml` GitHub Actions workflow
- Allows manually triggering the release-plz workflow from the Actions tab, useful for re-running releases without pushing to main

## Files changed
- `.github/workflows/release-plz.yml` — added `workflow_dispatch:` trigger alongside existing `push` trigger

## Test plan
- [ ] Verify the workflow file is valid YAML
- [ ] Confirm the workflow appears with a "Run workflow" button in the GitHub Actions tab after merge

Closes #361