### PR TITLE
fix: remove invalid git_cliff_config field from release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,2 @@
 [workspace]
 changelog_update = true
-git_cliff_config = "cliff.toml"


### PR DESCRIPTION
## Summary

- Removed the invalid `git_cliff_config = "cliff.toml"` line from `release-plz.toml`
- This field is not recognized by release-plz v0.5 and causes a parse error
- The `cliff.toml` file is kept in the repo since release-plz/git-cliff may auto-detect it

## Files changed

- `release-plz.toml` — removed unrecognized `git_cliff_config` field

## Test plan

- No source code changes; config-only fix
- Verify `release-plz` no longer errors on parsing `release-plz.toml`

Closes #363