### PR TITLE
fix: replace absolute symlink in test-helpers with relative symlink

### DIFF
--- a/crates/forza/tests/orchestrator.rs
+++ b/crates/forza/tests/orchestrator.rs
@@ -104,7 +104,7 @@ fn env_with_fake_gh() -> Vec<(String, String)> {
     let gh_link = fake_dir.join("gh");
     if !gh_link.exists() {
         #[cfg(unix)]
-        std::os::unix::fs::symlink(fake_gh_path(), &gh_link).ok();
+        std::os::unix::fs::symlink("fake-gh.sh", &gh_link).ok();
     }
 
     let original_path = std::env::var("PATH").unwrap_or_default();

--- a/test-helpers/gh
+++ b/test-helpers/gh
@@ -1,1 +1,1 @@
-/Users/joshrotenberg/Code/active/forza/test-helpers/fake-gh.sh
+fake-gh.sh


### PR DESCRIPTION
## Summary

- Replace absolute symlink `test-helpers/gh` (pointing to `/Users/.../fake-gh.sh`) with a relative symlink (`fake-gh.sh`), making the repo portable across machines and CI
- Update runtime symlink creation in `orchestrator.rs` to use a relative target instead of `fake_gh_path()` which resolves to an absolute path
- Fix unrelated doc comment fence in `runner.rs` (code fence to `text` fence)

## Files changed

- `test-helpers/gh` — symlink target changed from absolute path to relative `fake-gh.sh`
- `crates/forza/tests/orchestrator.rs` — line 107: `symlink(fake_gh_path(), ...)` replaced with `symlink("fake-gh.sh", ...)`
- `crates/forza/src/runner.rs` — line 653: doc comment fence changed from bare to `text`

## Test plan

- [ ] Verify `test-helpers/gh` symlink resolves correctly with `ls -la test-helpers/gh`
- [ ] Run `cargo test -p forza --test orchestrator` to confirm test helper works
- [ ] Run `cargo test --all` to ensure no regressions

Closes #365