### PR TITLE
fix: remove CLAUDE.md from .gitignore closes #368

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 .forza/
 .claudes/
 .claude/
-CLAUDE.md
 *.breadcrumb.md


### PR DESCRIPTION
## Summary

- Removed `CLAUDE.md` from `.gitignore` so the project's agent context file can be properly version-controlled
- Fixes release-plz detecting uncommitted changes due to the gitignore/tracked file conflict
- `CLAUDE.md` is already tracked by git and intentionally committed as project context

## Files changed

- `.gitignore` — removed the `CLAUDE.md` entry

## Test plan

- [x] Verified `CLAUDE.md` is tracked in git (`git ls-files` confirms)
- [x] Verified no other gitignore files or CI workflows reference `CLAUDE.md`
- [x] Remaining `.gitignore` entries are consistent and correct

Closes #368