### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "forza"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/forza-core/CHANGELOG.md
+++ b/crates/forza-core/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/joshrotenberg/forza/releases/tag/forza-core-v0.1.0) - 2026-03-23
+
+### Added
+
+- *(pipeline)* post failure reason as comment on issue closes #335 ([#338](https://github.com/joshrotenberg/forza/pull/338))
+- *(cli)* add open subcommand for agent-driven issue creation closes #327 ([#337](https://github.com/joshrotenberg/forza/pull/337))
+- *(github)* add create_issue to GitHubClient trait and all implementations closes #325 ([#329](https://github.com/joshrotenberg/forza/pull/329))
+- *(planner)* add open_issue.md prompt template ([#328](https://github.com/joshrotenberg/forza/pull/328))
+- *(planner)* agent-specific prompt directory overrides ([#320](https://github.com/joshrotenberg/forza/pull/320))
+- *(logging)* log agent backend and model at info level for every run ([#313](https://github.com/joshrotenberg/forza/pull/313))
+- add mock-based integration test framework ([#285](https://github.com/joshrotenberg/forza/pull/285))
+- add DraftPr stage for early draft PR visibility ([#271](https://github.com/joshrotenberg/forza/pull/271))
+
+### Fixed
+
+- *(pipeline)* truncate failure comment from beginning, not end closes #345 ([#346](https://github.com/joshrotenberg/forza/pull/346))
+- add [skip ci] to draft PR empty commit ([#339](https://github.com/joshrotenberg/forza/pull/339))
+- create empty commit in draft_pr.sh so branch has diff from main ([#298](https://github.com/joshrotenberg/forza/pull/298))
+- chain merge.sh commands with && so CI failure prevents merge ([#297](https://github.com/joshrotenberg/forza/pull/297))
+- *(forza-core)* add Display impl for Scope enum closes #290 ([#291](https://github.com/joshrotenberg/forza/pull/291))
+- *(draft-pr)* stop committing breadcrumb files to branch closes #282 ([#284](https://github.com/joshrotenberg/forza/pull/284))
+- *(adapters)* pass actual StageKind through AgentExecutor::execute closes #257 ([#281](https://github.com/joshrotenberg/forza/pull/281))
+- *(merge)* remove --delete-branch flag to avoid worktree conflict closes #277 ([#279](https://github.com/joshrotenberg/forza/pull/279))
+- *(stage)* wait for CI checks before merging closes #275 ([#276](https://github.com/joshrotenberg/forza/pull/276))
+- split git add in draft_pr.sh to handle missing .forza/ directory ([#274](https://github.com/joshrotenberg/forza/pull/274))
+- *(forza-core)* add Display impl for Execution enum closes #272 ([#273](https://github.com/joshrotenberg/forza/pull/273))
+- *(pipeline)* detect pr after open_pr stage to set correct run outcome closes #260 ([#262](https://github.com/joshrotenberg/forza/pull/262))
+- *(forza-core)* add Display impl for StageStatus closes #253 ([#259](https://github.com/joshrotenberg/forza/pull/259))
+
+### Other
+
+- add integration test for condition route discovery ([#308](https://github.com/joshrotenberg/forza/pull/308))
+- add [workspace.dependencies] to deduplicate shared dep versions ([#267](https://github.com/joshrotenberg/forza/pull/267))
+- add [workspace.package] to deduplicate crate metadata ([#266](https://github.com/joshrotenberg/forza/pull/266))
+- *(forza-core)* add module-level export table to lib.rs docs ([#261](https://github.com/joshrotenberg/forza/pull/261))
+- forza-core crate and unified pipeline ([#252](https://github.com/joshrotenberg/forza/pull/252))

--- a/crates/forza/CHANGELOG.md
+++ b/crates/forza/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0](https://github.com/joshrotenberg/forza/compare/forza-v0.2.0...forza-v0.3.0) - 2026-03-23
+
+### Added
+
+- *(cli)* add open subcommand for agent-driven issue creation closes #327 ([#337](https://github.com/joshrotenberg/forza/pull/337))
+- *(runner)* multi-prefix forza_owned scope matching ([#334](https://github.com/joshrotenberg/forza/pull/334))
+- *(github)* add create_issue to GitHubClient trait and all implementations closes #325 ([#329](https://github.com/joshrotenberg/forza/pull/329))
+- *(runner)* add {route} and {label} placeholders to branch_pattern ([#324](https://github.com/joshrotenberg/forza/pull/324))
+- *(planner)* agent-specific prompt directory overrides ([#320](https://github.com/joshrotenberg/forza/pull/320))
+- *(config)* add per-route branch_pattern override ([#319](https://github.com/joshrotenberg/forza/pull/319))
+- *(logging)* log agent backend and model at info level for every run ([#313](https://github.com/joshrotenberg/forza/pull/313))
+- *(run)* add --route filter to forza run command ([#307](https://github.com/joshrotenberg/forza/pull/307))
+- add Codex agent backend support ([#293](https://github.com/joshrotenberg/forza/pull/293))
+- enhance forza explain with filters, grouping, and verbose mode ([#286](https://github.com/joshrotenberg/forza/pull/286))
+- add DraftPr stage for early draft PR visibility ([#271](https://github.com/joshrotenberg/forza/pull/271))
+
+### Fixed
+
+- replace absolute symlink in test-helpers with relative symlink ([#366](https://github.com/joshrotenberg/forza/pull/366))
+- *(runner)* change empty code fence to text to silence rustdoc warning ([#354](https://github.com/joshrotenberg/forza/pull/354))
+- *(executor)* read skill files and prepend to prompt instead of using --file ([#331](https://github.com/joshrotenberg/forza/pull/331))
+- *(cli)* update --repo-dir doc comment on RunArgs to match issue/pr commands ([#309](https://github.com/joshrotenberg/forza/pull/309))
+- *(explain)* show agent backend in global header and verbose route output closes #302 ([#305](https://github.com/joshrotenberg/forza/pull/305))
+- update init guided prompt with correct workflow names and next steps ([#296](https://github.com/joshrotenberg/forza/pull/296))
+- *(adapters)* pass actual StageKind through AgentExecutor::execute closes #257 ([#281](https://github.com/joshrotenberg/forza/pull/281))
+- suppress noisy HTTP/TLS debug logs with smarter default filter ([#280](https://github.com/joshrotenberg/forza/pull/280))
+- *(github)* improve error messages for failed API calls and missing issues closes #265 ([#270](https://github.com/joshrotenberg/forza/pull/270))
+
+### Other
+
+- add [workspace.dependencies] to deduplicate shared dep versions ([#267](https://github.com/joshrotenberg/forza/pull/267))
+- *(runner)* add doc comment to generate_branch ([#268](https://github.com/joshrotenberg/forza/pull/268))
+- add [workspace.package] to deduplicate crate metadata ([#266](https://github.com/joshrotenberg/forza/pull/266))
+- forza-core crate and unified pipeline ([#252](https://github.com/joshrotenberg/forza/pull/252))

--- a/crates/forza/Cargo.toml
+++ b/crates/forza/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forza"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `forza-core`: 0.1.0
* `forza`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `forza` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type AppState is no longer UnwindSafe, in /tmp/.tmppJZZMU/forza/crates/forza/src/api.rs:25
  type AppState is no longer RefUnwindSafe, in /tmp/.tmppJZZMU/forza/crates/forza/src/api.rs:25
  type AppState is no longer UnwindSafe, in /tmp/.tmppJZZMU/forza/crates/forza/src/mcp.rs:31
  type AppState is no longer RefUnwindSafe, in /tmp/.tmppJZZMU/forza/crates/forza/src/mcp.rs:31

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GlobalConfig.stale_worktree_days in /tmp/.tmppJZZMU/forza/crates/forza/src/config.rs:125
  field GlobalConfig.draft_pr in /tmp/.tmppJZZMU/forza/crates/forza/src/config.rs:136
  field GlobalConfig.github_backend in /tmp/.tmppJZZMU/forza/crates/forza/src/config.rs:143
  field GlobalConfig.git_backend in /tmp/.tmppJZZMU/forza/crates/forza/src/config.rs:147
  field Route.condition in /tmp/.tmppJZZMU/forza/crates/forza/src/config.rs:372
  field Route.scope in /tmp/.tmppJZZMU/forza/crates/forza/src/config.rs:404
  field Route.max_retries in /tmp/.tmppJZZMU/forza/crates/forza/src/config.rs:408
  field Route.draft_pr in /tmp/.tmppJZZMU/forza/crates/forza/src/config.rs:411
  field Route.branch_pattern in /tmp/.tmppJZZMU/forza/crates/forza/src/config.rs:414
  field RunRecord.outcome in /tmp/.tmppJZZMU/forza/crates/forza/src/state.rs:109
  field PrCandidate.checks_passing in /tmp/.tmppJZZMU/forza/crates/forza/src/github/mod.rs:137
  field AppState.gh in /tmp/.tmppJZZMU/forza/crates/forza/src/api.rs:28
  field AppState.git in /tmp/.tmppJZZMU/forza/crates/forza/src/api.rs:29

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum forza::triage::TriageDecision, previously in file /tmp/.tmphuNEwl/forza/src/triage.rs:10

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:Git in /tmp/.tmppJZZMU/forza/crates/forza/src/error.rs:23

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function forza::orchestrator::process_reactive_pr, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:897
  function forza::workflow::select_workflow, previously in file /tmp/.tmphuNEwl/forza/src/workflow.rs:154
  function forza::orchestrator::process_batch, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:2108
  function forza::process_batch, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:2108
  function forza::orchestrator::process_batch_with_config, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:1457
  function forza::orchestrator::process_pr_with_config, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:481
  function forza::process_pr_with_config, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:481
  function forza::triage::triage, previously in file /tmp/.tmphuNEwl/forza/src/triage.rs:26
  function forza::orchestrator::process_batch_for_repo, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:1125
  function forza::orchestrator::process_issue, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:1481
  function forza::process_issue, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:1481
  function forza::planner::create_plan, previously in file /tmp/.tmphuNEwl/forza/src/planner.rs:78
  function forza::orchestrator::process_issue_with_config, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:29

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  forza::deps::validate_dependencies now takes 2 parameters instead of 1, in /tmp/.tmppJZZMU/forza/crates/forza/src/deps.rs:12
  forza::planner::create_plan_with_config now takes 5 parameters instead of 6, in /tmp/.tmppJZZMU/forza/crates/forza/src/planner.rs:82
  forza::isolation::remove_worktree now takes 4 parameters instead of 3, in /tmp/.tmppJZZMU/forza/crates/forza/src/isolation.rs:60
  forza::isolation::find_or_clone_repo now takes 3 parameters instead of 2, in /tmp/.tmppJZZMU/forza/crates/forza/src/isolation.rs:164
  forza::mcp::serve now takes 4 parameters instead of 2, in /tmp/.tmppJZZMU/forza/crates/forza/src/mcp.rs:478
  forza::github::push_branch now takes 3 parameters instead of 2, in /tmp/.tmppJZZMU/forza/crates/forza/src/github/mod.rs:449
  forza::github::push_branch_force now takes 3 parameters instead of 2, in /tmp/.tmppJZZMU/forza/crates/forza/src/github/mod.rs:458
  forza::isolation::create_worktree now takes 4 parameters instead of 3, in /tmp/.tmppJZZMU/forza/crates/forza/src/isolation.rs:42
  forza::isolation::validate_repo_dir now takes 3 parameters instead of 2, in /tmp/.tmppJZZMU/forza/crates/forza/src/isolation.rs:132
  forza::github::create_pull_request now takes 6 parameters instead of 5, in /tmp/.tmppJZZMU/forza/crates/forza/src/github/mod.rs:467

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  forza::mcp::AppState::new now takes 4 parameters instead of 2, in /tmp/.tmppJZZMU/forza/crates/forza/src/mcp.rs:40

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/module_missing.ron

Failed in:
  mod forza::orchestrator, previously in file /tmp/.tmphuNEwl/forza/src/orchestrator.rs:1
  mod forza::triage, previously in file /tmp/.tmphuNEwl/forza/src/triage.rs:1
  mod forza::policy, previously in file /tmp/.tmphuNEwl/forza/src/policy.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct forza::policy::RepoPolicy, previously in file /tmp/.tmphuNEwl/forza/src/policy.rs:11
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `forza-core`

<blockquote>

## [0.1.0](https://github.com/joshrotenberg/forza/releases/tag/forza-core-v0.1.0) - 2026-03-23

### Added

- *(pipeline)* post failure reason as comment on issue closes #335 ([#338](https://github.com/joshrotenberg/forza/pull/338))
- *(cli)* add open subcommand for agent-driven issue creation closes #327 ([#337](https://github.com/joshrotenberg/forza/pull/337))
- *(github)* add create_issue to GitHubClient trait and all implementations closes #325 ([#329](https://github.com/joshrotenberg/forza/pull/329))
- *(planner)* add open_issue.md prompt template ([#328](https://github.com/joshrotenberg/forza/pull/328))
- *(planner)* agent-specific prompt directory overrides ([#320](https://github.com/joshrotenberg/forza/pull/320))
- *(logging)* log agent backend and model at info level for every run ([#313](https://github.com/joshrotenberg/forza/pull/313))
- add mock-based integration test framework ([#285](https://github.com/joshrotenberg/forza/pull/285))
- add DraftPr stage for early draft PR visibility ([#271](https://github.com/joshrotenberg/forza/pull/271))

### Fixed

- *(pipeline)* truncate failure comment from beginning, not end closes #345 ([#346](https://github.com/joshrotenberg/forza/pull/346))
- add [skip ci] to draft PR empty commit ([#339](https://github.com/joshrotenberg/forza/pull/339))
- create empty commit in draft_pr.sh so branch has diff from main ([#298](https://github.com/joshrotenberg/forza/pull/298))
- chain merge.sh commands with && so CI failure prevents merge ([#297](https://github.com/joshrotenberg/forza/pull/297))
- *(forza-core)* add Display impl for Scope enum closes #290 ([#291](https://github.com/joshrotenberg/forza/pull/291))
- *(draft-pr)* stop committing breadcrumb files to branch closes #282 ([#284](https://github.com/joshrotenberg/forza/pull/284))
- *(adapters)* pass actual StageKind through AgentExecutor::execute closes #257 ([#281](https://github.com/joshrotenberg/forza/pull/281))
- *(merge)* remove --delete-branch flag to avoid worktree conflict closes #277 ([#279](https://github.com/joshrotenberg/forza/pull/279))
- *(stage)* wait for CI checks before merging closes #275 ([#276](https://github.com/joshrotenberg/forza/pull/276))
- split git add in draft_pr.sh to handle missing .forza/ directory ([#274](https://github.com/joshrotenberg/forza/pull/274))
- *(forza-core)* add Display impl for Execution enum closes #272 ([#273](https://github.com/joshrotenberg/forza/pull/273))
- *(pipeline)* detect pr after open_pr stage to set correct run outcome closes #260 ([#262](https://github.com/joshrotenberg/forza/pull/262))
- *(forza-core)* add Display impl for StageStatus closes #253 ([#259](https://github.com/joshrotenberg/forza/pull/259))

### Other

- add integration test for condition route discovery ([#308](https://github.com/joshrotenberg/forza/pull/308))
- add [workspace.dependencies] to deduplicate shared dep versions ([#267](https://github.com/joshrotenberg/forza/pull/267))
- add [workspace.package] to deduplicate crate metadata ([#266](https://github.com/joshrotenberg/forza/pull/266))
- *(forza-core)* add module-level export table to lib.rs docs ([#261](https://github.com/joshrotenberg/forza/pull/261))
- forza-core crate and unified pipeline ([#252](https://github.com/joshrotenberg/forza/pull/252))
</blockquote>

## `forza`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/forza/compare/forza-v0.2.0...forza-v0.3.0) - 2026-03-23

### Added

- *(cli)* add open subcommand for agent-driven issue creation closes #327 ([#337](https://github.com/joshrotenberg/forza/pull/337))
- *(runner)* multi-prefix forza_owned scope matching ([#334](https://github.com/joshrotenberg/forza/pull/334))
- *(github)* add create_issue to GitHubClient trait and all implementations closes #325 ([#329](https://github.com/joshrotenberg/forza/pull/329))
- *(runner)* add {route} and {label} placeholders to branch_pattern ([#324](https://github.com/joshrotenberg/forza/pull/324))
- *(planner)* agent-specific prompt directory overrides ([#320](https://github.com/joshrotenberg/forza/pull/320))
- *(config)* add per-route branch_pattern override ([#319](https://github.com/joshrotenberg/forza/pull/319))
- *(logging)* log agent backend and model at info level for every run ([#313](https://github.com/joshrotenberg/forza/pull/313))
- *(run)* add --route filter to forza run command ([#307](https://github.com/joshrotenberg/forza/pull/307))
- add Codex agent backend support ([#293](https://github.com/joshrotenberg/forza/pull/293))
- enhance forza explain with filters, grouping, and verbose mode ([#286](https://github.com/joshrotenberg/forza/pull/286))
- add DraftPr stage for early draft PR visibility ([#271](https://github.com/joshrotenberg/forza/pull/271))

### Fixed

- replace absolute symlink in test-helpers with relative symlink ([#366](https://github.com/joshrotenberg/forza/pull/366))
- *(runner)* change empty code fence to text to silence rustdoc warning ([#354](https://github.com/joshrotenberg/forza/pull/354))
- *(executor)* read skill files and prepend to prompt instead of using --file ([#331](https://github.com/joshrotenberg/forza/pull/331))
- *(cli)* update --repo-dir doc comment on RunArgs to match issue/pr commands ([#309](https://github.com/joshrotenberg/forza/pull/309))
- *(explain)* show agent backend in global header and verbose route output closes #302 ([#305](https://github.com/joshrotenberg/forza/pull/305))
- update init guided prompt with correct workflow names and next steps ([#296](https://github.com/joshrotenberg/forza/pull/296))
- *(adapters)* pass actual StageKind through AgentExecutor::execute closes #257 ([#281](https://github.com/joshrotenberg/forza/pull/281))
- suppress noisy HTTP/TLS debug logs with smarter default filter ([#280](https://github.com/joshrotenberg/forza/pull/280))
- *(github)* improve error messages for failed API calls and missing issues closes #265 ([#270](https://github.com/joshrotenberg/forza/pull/270))

### Other

- add [workspace.dependencies] to deduplicate shared dep versions ([#267](https://github.com/joshrotenberg/forza/pull/267))
- *(runner)* add doc comment to generate_branch ([#268](https://github.com/joshrotenberg/forza/pull/268))
- add [workspace.package] to deduplicate crate metadata ([#266](https://github.com/joshrotenberg/forza/pull/266))
- forza-core crate and unified pipeline ([#252](https://github.com/joshrotenberg/forza/pull/252))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).