### PR TITLE
fix: bump forza-core version to 0.3.0 to resolve release tag conflict

### DIFF
--- a/crates/forza-core/Cargo.toml
+++ b/crates/forza-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forza-core"
-version = "0.1.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary
- Bumps `forza-core` version from `0.1.0` to `0.3.0` in `crates/forza-core/Cargo.toml`
- Resolves a release-plz tag conflict where `forza-core-v0.1.0` already existed, blocking new releases
- Aligns `forza-core` versioning with the `forza` binary crate so both crates are versioned together going forward
- Metadata-only change: no source files modified, no logic changes, no new tests needed

## Files changed
- `crates/forza-core/Cargo.toml` — version bumped from `0.1.0` to `0.3.0`
- `Cargo.lock` — updated to reflect `forza-core v0.3.0`

## Test plan
- [ ] `cargo check` passes cleanly for both crates
- [ ] `Cargo.lock` reflects `forza-core v0.3.0`
- [ ] Release tooling (release-plz) can proceed without tag collision

Closes #372