### PR TITLE
fix(prompts): remove Rust-specific language from core prompt templates

### DIFF
--- a/crates/forza-core/src/prompts/implement.md
+++ b/crates/forza-core/src/prompts/implement.md
@@ -12,7 +12,7 @@ Read the plan breadcrumb at `.plan_breadcrumb.md` for the list of files to modif
 
 1. Only modify the files listed in the breadcrumb. Do NOT touch any other files.
 2. Follow the existing code patterns and style.
-3. For Rust code: use Rust 2024 if-let chains — write `if let Some(x) = y && condition {` instead of nested if-let/if blocks.
+3. Follow the project's existing language idioms and conventions.
 {validation_step}{commit_num}. Commit using the exact commit message from the breadcrumb.
 
 Do NOT create a PR in this stage.

--- a/crates/forza-core/src/prompts/pr_review.md
+++ b/crates/forza-core/src/prompts/pr_review.md
@@ -13,7 +13,7 @@ Branch: `{head_branch}` -> `{base_branch}`
 
 - Correctness: does the implementation look correct?
 - Tests: are there tests for new behavior?
-- Code quality: any obvious bugs, panics, or unsafe patterns?
+- Code quality: any obvious bugs, crashes, or unsafe operations?
 - Consistency: does the style match the surrounding code?
 
 ## Output format

--- a/crates/forza-core/src/prompts/review.md
+++ b/crates/forza-core/src/prompts/review.md
@@ -6,7 +6,7 @@ Review the changes for issue #{issue_number}. This is a read-only verification s
 
 - Correctness: does the implementation match the plan?
 - Tests: are there tests for new behavior?
-- Code quality: any obvious bugs, panics, or unsafe patterns?
+- Code quality: any obvious bugs, crashes, or unsafe operations?
 - Consistency: does the style match the surrounding code?
 
 ## Output format

--- a/crates/forza-core/src/prompts/test.md
+++ b/crates/forza-core/src/prompts/test.md
@@ -6,4 +6,4 @@ Run each of the following and confirm they pass:
 {validation_commands}
 
 If any command fails, fix the issue and re-run until all pass.
-Do NOT modify implementation logic — only fix formatting, clippy warnings, or test failures caused by missing test coverage.
+Do NOT modify implementation logic — only fix formatting, linter warnings, or test failures caused by missing test coverage.


### PR DESCRIPTION
## Summary
- Replaced Rust 2024 if-let chains instruction in `implement.md` with generic "follow project's existing language idioms"
- Replaced "clippy warnings" in `test.md` with "linter warnings"
- Replaced "panics" and "unsafe patterns" in `review.md` and `pr_review.md` with "crashes" and "unsafe operations"
- Core workflow prompt templates are now language-agnostic, consistent with forza's agent-agnostic design

## Files changed
- `crates/forza-core/src/prompts/implement.md` - Removed Rust 2024 if-let chains reference; replaced with generic idioms instruction
- `crates/forza-core/src/prompts/test.md` - "clippy warnings" → "linter warnings"
- `crates/forza-core/src/prompts/review.md` - "panics" → "crashes", "unsafe patterns" → "unsafe operations"
- `crates/forza-core/src/prompts/pr_review.md` - Same as review.md

## Test plan
- Build passes: prompt templates are compiled in via `include_str!` and verified at build time
- No unit tests required for prompt content changes
- Review verdict: PASS — no issues found

Closes #374