### PR TITLE
feat(tools): externalize allowed_tools per stage closes #380

### DIFF
--- a/crates/forza-core/src/lib.rs
+++ b/crates/forza-core/src/lib.rs
@@ -59,6 +59,7 @@ pub mod run;
 pub mod shell;
 pub mod stage;
 pub mod subject;
+pub mod tools;
 pub mod traits;
 
 // ── Re-exports ──────────────────────────────────────────────────────────

--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -8,6 +8,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::tools;
+
 use tracing::{error, info, warn};
 
 use crate::error::Result;
@@ -41,6 +43,10 @@ pub struct PipelineConfig {
     pub append_system_prompt: Option<String>,
     /// Per-stage hooks.
     pub stage_hooks: std::collections::HashMap<String, StageHooks>,
+    /// Directory containing tool list overrides (parallel to `prompts/`).
+    pub tools_dir: Option<PathBuf>,
+    /// Agent name used for agent-specific tool list lookup.
+    pub agent: String,
 }
 
 /// Pre/post/finally hooks for a stage kind.
@@ -254,6 +260,8 @@ pub async fn execute(
                     .cloned()
                     .collect();
                 let mcp = stage.mcp_config.as_deref().or(config.mcp_config.as_deref());
+                let allowed_tools =
+                    tools::select_tools(stage.kind, &config.agent, config.tools_dir.as_deref());
 
                 info!(
                     number = work.subject.number,
@@ -271,6 +279,7 @@ pub async fn execute(
                         &effective_skills,
                         mcp,
                         config.append_system_prompt.as_deref(),
+                        &allowed_tools,
                     )
                     .await
                 {
@@ -744,6 +753,7 @@ mod tests {
             _skills: &[String],
             _mcp_config: Option<&str>,
             _append_system_prompt: Option<&str>,
+            _allowed_tools: &[String],
         ) -> Result<StageResult> {
             Ok(StageResult {
                 stage: "test".into(),
@@ -802,6 +812,8 @@ mod tests {
             validation: vec![],
             append_system_prompt: None,
             stage_hooks: std::collections::HashMap::new(),
+            tools_dir: None,
+            agent: "claude".into(),
         }
     }
 
@@ -1004,6 +1016,8 @@ mod tests {
             validation: vec![],
             append_system_prompt: None,
             stage_hooks: std::collections::HashMap::new(),
+            tools_dir: None,
+            agent: "claude".into(),
         };
         assert!(config.stage_hooks.is_empty());
         assert!(config.validation.is_empty());

--- a/crates/forza-core/src/testing.rs
+++ b/crates/forza-core/src/testing.rs
@@ -505,6 +505,7 @@ impl crate::traits::AgentExecutor for MockAgent {
         _skills: &[String],
         _mcp_config: Option<&str>,
         _append_system_prompt: Option<&str>,
+        _allowed_tools: &[String],
     ) -> Result<StageResult> {
         let truncated = if prompt.len() > 100 {
             format!("{}...", &prompt[..100])
@@ -619,6 +620,7 @@ mod tests {
                 &[],
                 None,
                 None,
+                &[],
             )
             .await
             .unwrap();
@@ -641,6 +643,7 @@ mod tests {
                 &[],
                 None,
                 None,
+                &[],
             )
             .await
             .unwrap();
@@ -655,6 +658,7 @@ mod tests {
                 &[],
                 None,
                 None,
+                &[],
             )
             .await
             .unwrap();
@@ -666,7 +670,16 @@ mod tests {
     async fn mock_agent_always_fail() {
         let agent = MockAgent::new().always_fail("nope");
         let result = agent
-            .execute("test", "anything", Path::new("/tmp"), None, &[], None, None)
+            .execute(
+                "test",
+                "anything",
+                Path::new("/tmp"),
+                None,
+                &[],
+                None,
+                None,
+                &[],
+            )
             .await
             .unwrap();
         assert!(!result.success);

--- a/crates/forza-core/src/tools.rs
+++ b/crates/forza-core/src/tools.rs
@@ -1,0 +1,158 @@
+//! Tool list selection for agent stages.
+//!
+//! Mirrors the same three-tier resolution as `planner::select_template`:
+//! 1. `{tools_dir}/{agent}/{stage}.txt` — agent-specific override
+//! 2. `{tools_dir}/{stage}.txt` — generic override
+//! 3. compiled-in builtin
+//!
+//! Each `.txt` file contains one tool name per line. Empty lines and lines
+//! starting with `#` are ignored. Example:
+//!
+//! ```text
+//! Read
+//! Edit
+//! Write
+//! Bash(cargo *)
+//! ```
+//!
+//! To override tools for a specific stage, place a `.txt` file in the
+//! `tools/` directory of the repo (parallel to `prompts/`).
+
+use crate::stage::StageKind;
+
+// ── Embedded builtin tool lists ──────────────────────────────────────────
+
+const TOOLS_PLAN: &str = include_str!("tools/plan.txt");
+const TOOLS_IMPLEMENT: &str = include_str!("tools/implement.txt");
+const TOOLS_TEST: &str = include_str!("tools/test.txt");
+const TOOLS_REVIEW: &str = include_str!("tools/review.txt");
+const TOOLS_OPEN_PR: &str = include_str!("tools/open_pr.txt");
+const TOOLS_CLARIFY: &str = include_str!("tools/clarify.txt");
+const TOOLS_RESEARCH: &str = include_str!("tools/research.txt");
+const TOOLS_COMMENT: &str = include_str!("tools/comment.txt");
+const TOOLS_FIX_CI: &str = include_str!("tools/fix_ci.txt");
+const TOOLS_REVISE_PR: &str = include_str!("tools/revise_pr.txt");
+
+/// Return the compiled-in builtin tool list for a stage kind.
+fn builtin_tools(kind: StageKind) -> &'static str {
+    match kind {
+        StageKind::Plan => TOOLS_PLAN,
+        StageKind::Implement => TOOLS_IMPLEMENT,
+        StageKind::Test => TOOLS_TEST,
+        StageKind::Review => TOOLS_REVIEW,
+        StageKind::OpenPr => TOOLS_OPEN_PR,
+        StageKind::Clarify => TOOLS_CLARIFY,
+        StageKind::Research => TOOLS_RESEARCH,
+        StageKind::Comment => TOOLS_COMMENT,
+        StageKind::FixCi => TOOLS_FIX_CI,
+        StageKind::RevisePr => TOOLS_REVISE_PR,
+        // Agentless or no-restriction stages return empty — no tool scoping applied.
+        StageKind::Merge | StageKind::Triage | StageKind::DraftPr => "",
+    }
+}
+
+/// Parse a newline-separated tool list, ignoring empty lines and `#` comments.
+fn parse_tools(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(String::from)
+        .collect()
+}
+
+/// Select the allowed tools for a stage.
+///
+/// Resolution order:
+/// 1. `{tools_dir}/{agent}/{stage}.txt` — agent-specific override
+/// 2. `{tools_dir}/{stage}.txt` — generic override
+/// 3. compiled-in builtin
+///
+/// Returns an empty `Vec` for agentless stages (Merge, Triage, DraftPr).
+pub fn select_tools(
+    kind: StageKind,
+    agent: &str,
+    tools_dir: Option<&std::path::Path>,
+) -> Vec<String> {
+    let filename = kind.name();
+
+    if let Some(dir) = tools_dir {
+        let agent_path = dir.join(agent).join(format!("{filename}.txt"));
+        if let Ok(content) = std::fs::read_to_string(&agent_path) {
+            return parse_tools(&content);
+        }
+        let generic_path = dir.join(format!("{filename}.txt"));
+        if let Ok(content) = std::fs::read_to_string(&generic_path) {
+            return parse_tools(&content);
+        }
+    }
+
+    parse_tools(builtin_tools(kind))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_plan_includes_read_and_write() {
+        let tools = select_tools(StageKind::Plan, "claude", None);
+        assert!(tools.contains(&"Read".to_string()));
+        assert!(tools.contains(&"Write".to_string()));
+    }
+
+    #[test]
+    fn builtin_review_is_read_only() {
+        let tools = select_tools(StageKind::Review, "claude", None);
+        assert!(tools.contains(&"Read".to_string()));
+        assert!(!tools.contains(&"Edit".to_string()));
+        assert!(!tools.contains(&"Write".to_string()));
+    }
+
+    #[test]
+    fn builtin_implement_includes_bash() {
+        let tools = select_tools(StageKind::Implement, "claude", None);
+        assert!(tools.iter().any(|t| t.starts_with("Bash")));
+    }
+
+    #[test]
+    fn agentless_stages_return_empty() {
+        assert!(select_tools(StageKind::Merge, "claude", None).is_empty());
+        assert!(select_tools(StageKind::DraftPr, "claude", None).is_empty());
+        assert!(select_tools(StageKind::Triage, "claude", None).is_empty());
+    }
+
+    #[test]
+    fn parse_tools_ignores_empty_lines_and_comments() {
+        let content = "Read\n# a comment\n\nWrite\n";
+        let tools = parse_tools(content);
+        assert_eq!(tools, vec!["Read", "Write"]);
+    }
+
+    #[test]
+    fn override_from_generic_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("plan.txt"), "CustomTool\n").unwrap();
+        let tools = select_tools(StageKind::Plan, "claude", Some(dir.path()));
+        assert_eq!(tools, vec!["CustomTool"]);
+    }
+
+    #[test]
+    fn agent_override_takes_precedence_over_generic() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join("claude");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("plan.txt"), "AgentTool\n").unwrap();
+        std::fs::write(dir.path().join("plan.txt"), "GenericTool\n").unwrap();
+        let tools = select_tools(StageKind::Plan, "claude", Some(dir.path()));
+        assert_eq!(tools, vec!["AgentTool"]);
+    }
+
+    #[test]
+    fn falls_back_to_builtin_when_dir_has_no_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = select_tools(StageKind::Plan, "claude", Some(dir.path()));
+        assert!(!tools.is_empty());
+        assert!(tools.contains(&"Read".to_string()));
+    }
+}

--- a/crates/forza-core/src/tools/clarify.txt
+++ b/crates/forza-core/src/tools/clarify.txt
@@ -1,0 +1,4 @@
+Read
+Glob
+Grep
+Bash(gh *)

--- a/crates/forza-core/src/tools/comment.txt
+++ b/crates/forza-core/src/tools/comment.txt
@@ -1,0 +1,4 @@
+Read
+Glob
+Grep
+Bash(gh *)

--- a/crates/forza-core/src/tools/fix_ci.txt
+++ b/crates/forza-core/src/tools/fix_ci.txt
@@ -1,0 +1,9 @@
+Read
+Edit
+Write
+Glob
+Grep
+Bash(cargo *)
+Bash(npm *)
+Bash(git *)
+Bash(gh *)

--- a/crates/forza-core/src/tools/implement.txt
+++ b/crates/forza-core/src/tools/implement.txt
@@ -1,0 +1,8 @@
+Read
+Edit
+Write
+Glob
+Grep
+Bash(cargo *)
+Bash(npm *)
+Bash(git *)

--- a/crates/forza-core/src/tools/open_pr.txt
+++ b/crates/forza-core/src/tools/open_pr.txt
@@ -1,0 +1,5 @@
+Read
+Glob
+Grep
+Bash(gh *)
+Bash(git *)

--- a/crates/forza-core/src/tools/plan.txt
+++ b/crates/forza-core/src/tools/plan.txt
@@ -1,0 +1,6 @@
+Read
+Glob
+Grep
+Write
+WebSearch
+WebFetch

--- a/crates/forza-core/src/tools/research.txt
+++ b/crates/forza-core/src/tools/research.txt
@@ -1,0 +1,6 @@
+Read
+Glob
+Grep
+Write
+WebSearch
+WebFetch

--- a/crates/forza-core/src/tools/review.txt
+++ b/crates/forza-core/src/tools/review.txt
@@ -1,0 +1,3 @@
+Read
+Glob
+Grep

--- a/crates/forza-core/src/tools/revise_pr.txt
+++ b/crates/forza-core/src/tools/revise_pr.txt
@@ -1,0 +1,9 @@
+Read
+Edit
+Write
+Glob
+Grep
+Bash(cargo *)
+Bash(npm *)
+Bash(git *)
+Bash(gh *)

--- a/crates/forza-core/src/tools/test.txt
+++ b/crates/forza-core/src/tools/test.txt
@@ -1,0 +1,7 @@
+Read
+Edit
+Glob
+Grep
+Bash(cargo *)
+Bash(npm *)
+Bash(make *)

--- a/crates/forza-core/src/traits.rs
+++ b/crates/forza-core/src/traits.rs
@@ -151,6 +151,7 @@ pub trait AgentExecutor: Send + Sync {
         skills: &[String],
         mcp_config: Option<&str>,
         append_system_prompt: Option<&str>,
+        allowed_tools: &[String],
     ) -> Result<StageResult>;
 }
 

--- a/crates/forza-core/tests/pipeline_integration.rs
+++ b/crates/forza-core/tests/pipeline_integration.rs
@@ -23,6 +23,8 @@ fn default_config() -> PipelineConfig {
         validation: vec![],
         append_system_prompt: None,
         stage_hooks: HashMap::new(),
+        tools_dir: None,
+        agent: "claude".into(),
     }
 }
 

--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -309,6 +309,7 @@ impl forza_core::AgentExecutor for ClaudeAgentAdapter {
         skills: &[String],
         mcp_config: Option<&str>,
         append_system_prompt: Option<&str>,
+        allowed_tools: &[String],
     ) -> CoreResult<CoreStageResult> {
         let mut adapter = crate::executor::ClaudeAdapter::new();
         if let Some(m) = model {
@@ -338,6 +339,7 @@ impl forza_core::AgentExecutor for ClaudeAgentAdapter {
             model: None,
             skills: None,
             mcp_config: None,
+            allowed_tools: allowed_tools.to_vec(),
         };
 
         let result = crate::executor::AgentAdapter::execute_stage(&adapter, &planned, work_dir)
@@ -374,6 +376,7 @@ impl forza_core::AgentExecutor for CodexAgentAdapter {
         _skills: &[String],
         _mcp_config: Option<&str>,
         _append_system_prompt: Option<&str>,
+        _allowed_tools: &[String],
     ) -> CoreResult<CoreStageResult> {
         let codex = codex_wrapper::Codex::builder()
             .working_dir(work_dir)

--- a/crates/forza/src/executor.rs
+++ b/crates/forza/src/executor.rs
@@ -10,7 +10,6 @@ use tracing::{debug, info, warn};
 
 use crate::error::{Error, Result};
 use crate::planner::PlannedStage;
-use crate::workflow::StageKind;
 
 /// Result of executing a single stage.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -152,55 +151,10 @@ impl AgentAdapter for ClaudeAdapter {
             cmd = cmd.append_system_prompt(s);
         }
 
-        // Scope tools based on stage kind.
-        match stage.kind {
-            StageKind::Plan | StageKind::Research => {
-                cmd = cmd.allowed_tools(["Read", "Glob", "Grep", "Write", "WebSearch", "WebFetch"]);
-            }
-            StageKind::Implement => {
-                cmd = cmd.allowed_tools([
-                    "Read",
-                    "Edit",
-                    "Write",
-                    "Glob",
-                    "Grep",
-                    "Bash(cargo *)",
-                    "Bash(npm *)",
-                    "Bash(yarn *)",
-                    "Bash(pnpm *)",
-                    "Bash(python *)",
-                    "Bash(pip *)",
-                    "Bash(go *)",
-                    "Bash(make *)",
-                    "Bash(git *)",
-                    "Bash(gh *)",
-                ]);
-            }
-            StageKind::Test => {
-                cmd = cmd.allowed_tools([
-                    "Read",
-                    "Edit",
-                    "Glob",
-                    "Grep",
-                    "Bash(cargo *)",
-                    "Bash(npm *)",
-                    "Bash(yarn *)",
-                    "Bash(pnpm *)",
-                    "Bash(python *)",
-                    "Bash(pytest *)",
-                    "Bash(go *)",
-                    "Bash(make *)",
-                    "Bash(git *)",
-                ]);
-            }
-            StageKind::Review => {
-                cmd = cmd.allowed_tools(["Read", "Glob", "Grep"]);
-                cmd = cmd.disallowed_tools(["Edit", "Write"]);
-            }
-            StageKind::Comment | StageKind::Clarify => {
-                cmd = cmd.allowed_tools(["Read", "Glob", "Grep", "Bash(gh *)"]);
-            }
-            _ => {}
+        // Scope tools based on the passed allowed_tools list.
+        if !stage.allowed_tools.is_empty() {
+            let tools: Vec<&str> = stage.allowed_tools.iter().map(String::as_str).collect();
+            cmd = cmd.allowed_tools(tools);
         }
 
         info!(

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -461,7 +461,7 @@ async fn cmd_open(
     let model = args.model.as_deref().or(config.global.model.as_deref());
 
     match agent
-        .execute("open", &prompt, &rd, model, &[], None, None)
+        .execute("open", &prompt, &rd, model, &[], None, None, &[])
         .await
     {
         Ok(result) => {

--- a/crates/forza/src/planner.rs
+++ b/crates/forza/src/planner.rs
@@ -52,6 +52,8 @@ pub struct PlannedStage {
     pub skills: Option<Vec<String>>,
     /// Override MCP config file path for this stage.
     pub mcp_config: Option<String>,
+    /// Allowed tools for this stage (passed to the agent executor).
+    pub allowed_tools: Vec<String>,
 }
 
 impl PlannedStage {
@@ -125,6 +127,7 @@ pub fn create_plan_with_config(
                 model: stage.model.clone(),
                 skills: stage.skills.clone(),
                 mcp_config: stage.mcp_config.clone(),
+                allowed_tools: vec![],
             }
         })
         .collect();
@@ -194,6 +197,7 @@ pub fn create_pr_plan_with_config(
                 model: stage.model.clone(),
                 skills: stage.skills.clone(),
                 mcp_config: stage.mcp_config.clone(),
+                allowed_tools: vec![],
             }
         })
         .collect();

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -415,7 +415,12 @@ async fn execute_work(
     };
 
     // Build pipeline config from global + route overrides.
-    let pipeline_config = build_pipeline_config(config, &work);
+    let mut pipeline_config = build_pipeline_config(config, &work);
+    pipeline_config.agent = config.global.agent.clone();
+    let tools_dir = repo_dir.join("tools");
+    if tools_dir.exists() {
+        pipeline_config.tools_dir = Some(tools_dir);
+    }
 
     // Generate prompts.
     let preamble = planner::make_preamble(&work.subject.repo);
@@ -555,6 +560,8 @@ fn build_pipeline_config(config: &RunnerConfig, work: &MatchedWork) -> PipelineC
         validation,
         append_system_prompt,
         stage_hooks,
+        tools_dir: None,
+        agent: String::new(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Externalizes per-stage `allowed_tools` from a hardcoded `match` block in the executor into composable `.txt` files embedded at compile time via `include_str!`
- Follows the same three-tier resolution pattern as prompt templates: agent-specific override → generic override → builtin default
- Adds `tools_dir` and `agent` fields to `PipelineConfig`; pipeline calls `tools::select_tools()` per agent stage and passes the result through `AgentExecutor::execute`
- Agentless stages (`Merge`, `Triage`, `DraftPr`) return empty tool lists; new stages (`OpenPr`, `FixCi`, `RevisePr`, `Research`) now have explicit tool scoping

## Files changed
- `crates/forza-core/src/tools/*.txt` — new builtin tool list files (one per stage, one tool per line)
- `crates/forza-core/src/tools.rs` — new `select_tools()` function with three-tier resolution logic and 8 unit tests
- `crates/forza-core/src/lib.rs` — expose `tools` module
- `crates/forza-core/src/traits.rs` — add `allowed_tools: &[String]` parameter to `AgentExecutor::execute`
- `crates/forza-core/src/pipeline.rs` — call `tools::select_tools()` per stage and pass result to executor
- `crates/forza-core/src/testing.rs` — update `MockAgent` to match new trait signature
- `crates/forza/src/executor.rs` — remove hardcoded tool match block; use passed `allowed_tools` instead
- `crates/forza/src/adapters.rs` — update `ClaudeAgentAdapter` and `CodexAgentAdapter` to forward `allowed_tools`
- `crates/forza/src/planner.rs` — update `PlannedStage` to carry tool list
- `crates/forza/src/runner.rs` — set `tools_dir` from `repo_dir.join("tools")` in `PipelineConfig`

## Test plan
- `cargo test -p forza-core` — all 135+ unit tests pass including 8 new `tools::tests`
- `cargo test -p forza-core --test pipeline_integration` — all 12 pipeline integration tests pass
- `cargo test --all` — full test suite passes
- `cargo clippy --all --all-targets -- -D warnings` — no warnings
- `cargo doc --no-deps --all-features` — docs build cleanly

Closes #380