### PR TITLE
chore: release v0.3.0

### DIFF
--- a/crates/forza-core/CHANGELOG.md
+++ b/crates/forza-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.1.0...forza-core-v0.3.0) - 2026-03-23
+
+### Added
+
+- *(init)* ship built-in language context templates closes #375 ([#378](https://github.com/joshrotenberg/forza/pull/378))
+
+### Fixed
+
+- *(prompts)* remove Rust-specific language from core prompt templates ([#377](https://github.com/joshrotenberg/forza/pull/377))
+- bump forza-core version to 0.3.0 to resolve release tag conflict ([#373](https://github.com/joshrotenberg/forza/pull/373))
+
 ## [0.1.0](https://github.com/joshrotenberg/forza/releases/tag/forza-core-v0.1.0) - 2026-03-23
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `forza-core`: 0.1.0 -> 0.3.0
* `forza`: 0.2.0 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `forza-core`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.1.0...forza-core-v0.3.0) - 2026-03-23

### Added

- *(init)* ship built-in language context templates closes #375 ([#378](https://github.com/joshrotenberg/forza/pull/378))

### Fixed

- *(prompts)* remove Rust-specific language from core prompt templates ([#377](https://github.com/joshrotenberg/forza/pull/377))
- bump forza-core version to 0.3.0 to resolve release tag conflict ([#373](https://github.com/joshrotenberg/forza/pull/373))
</blockquote>

## `forza`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/forza/compare/forza-v0.2.0...forza-v0.3.0) - 2026-03-23

### Added

- *(cli)* add open subcommand for agent-driven issue creation closes #327 ([#337](https://github.com/joshrotenberg/forza/pull/337))
- *(runner)* multi-prefix forza_owned scope matching ([#334](https://github.com/joshrotenberg/forza/pull/334))
- *(github)* add create_issue to GitHubClient trait and all implementations closes #325 ([#329](https://github.com/joshrotenberg/forza/pull/329))
- *(runner)* add {route} and {label} placeholders to branch_pattern ([#324](https://github.com/joshrotenberg/forza/pull/324))
- *(planner)* agent-specific prompt directory overrides ([#320](https://github.com/joshrotenberg/forza/pull/320))
- *(config)* add per-route branch_pattern override ([#319](https://github.com/joshrotenberg/forza/pull/319))
- *(logging)* log agent backend and model at info level for every run ([#313](https://github.com/joshrotenberg/forza/pull/313))
- *(run)* add --route filter to forza run command ([#307](https://github.com/joshrotenberg/forza/pull/307))
- add Codex agent backend support ([#293](https://github.com/joshrotenberg/forza/pull/293))
- enhance forza explain with filters, grouping, and verbose mode ([#286](https://github.com/joshrotenberg/forza/pull/286))
- add DraftPr stage for early draft PR visibility ([#271](https://github.com/joshrotenberg/forza/pull/271))

### Fixed

- replace absolute symlink in test-helpers with relative symlink ([#366](https://github.com/joshrotenberg/forza/pull/366))
- *(runner)* change empty code fence to text to silence rustdoc warning ([#354](https://github.com/joshrotenberg/forza/pull/354))
- *(executor)* read skill files and prepend to prompt instead of using --file ([#331](https://github.com/joshrotenberg/forza/pull/331))
- *(cli)* update --repo-dir doc comment on RunArgs to match issue/pr commands ([#309](https://github.com/joshrotenberg/forza/pull/309))
- *(explain)* show agent backend in global header and verbose route output closes #302 ([#305](https://github.com/joshrotenberg/forza/pull/305))
- update init guided prompt with correct workflow names and next steps ([#296](https://github.com/joshrotenberg/forza/pull/296))
- *(adapters)* pass actual StageKind through AgentExecutor::execute closes #257 ([#281](https://github.com/joshrotenberg/forza/pull/281))
- suppress noisy HTTP/TLS debug logs with smarter default filter ([#280](https://github.com/joshrotenberg/forza/pull/280))
- *(github)* improve error messages for failed API calls and missing issues closes #265 ([#270](https://github.com/joshrotenberg/forza/pull/270))

### Other

- add [workspace.dependencies] to deduplicate shared dep versions ([#267](https://github.com/joshrotenberg/forza/pull/267))
- *(runner)* add doc comment to generate_branch ([#268](https://github.com/joshrotenberg/forza/pull/268))
- add [workspace.package] to deduplicate crate metadata ([#266](https://github.com/joshrotenberg/forza/pull/266))
- forza-core crate and unified pipeline ([#252](https://github.com/joshrotenberg/forza/pull/252))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).