### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "forza-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/forza-core/CHANGELOG.md
+++ b/crates/forza-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.3.0...forza-core-v0.4.0) - 2026-03-24
+
+### Added
+
+- *(tools)* externalize allowed_tools per stage closes #380 ([#381](https://github.com/joshrotenberg/forza/pull/381))
+
+### Other
+
+- release v0.3.0 ([#382](https://github.com/joshrotenberg/forza/pull/382))
+
 ## [0.3.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.1.0...forza-core-v0.3.0) - 2026-03-23
 
 ### Added

--- a/crates/forza-core/Cargo.toml
+++ b/crates/forza-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forza-core"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `forza-core`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `forza`: 0.2.0 -> 0.3.0

### ⚠ `forza-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PipelineConfig.tools_dir in /tmp/.tmp8kWFo0/forza/crates/forza-core/src/pipeline.rs:47
  field PipelineConfig.agent in /tmp/.tmp8kWFo0/forza/crates/forza-core/src/pipeline.rs:49

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  AgentExecutor::execute now takes 8 instead of 7 parameters, in file /tmp/.tmp8kWFo0/forza/crates/forza-core/src/traits.rs:145
  AgentExecutor::execute now takes 8 instead of 7 parameters, in file /tmp/.tmp8kWFo0/forza/crates/forza-core/src/traits.rs:145
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `forza-core`

<blockquote>

## [0.4.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.3.0...forza-core-v0.4.0) - 2026-03-24

### Added

- *(tools)* externalize allowed_tools per stage closes #380 ([#381](https://github.com/joshrotenberg/forza/pull/381))

### Other

- release v0.3.0 ([#382](https://github.com/joshrotenberg/forza/pull/382))
</blockquote>

## `forza`

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/forza/compare/forza-v0.2.0...forza-v0.3.0) - 2026-03-23

### Added

- *(cli)* add open subcommand for agent-driven issue creation closes #327 ([#337](https://github.com/joshrotenberg/forza/pull/337))
- *(runner)* multi-prefix forza_owned scope matching ([#334](https://github.com/joshrotenberg/forza/pull/334))
- *(github)* add create_issue to GitHubClient trait and all implementations closes #325 ([#329](https://github.com/joshrotenberg/forza/pull/329))
- *(runner)* add {route} and {label} placeholders to branch_pattern ([#324](https://github.com/joshrotenberg/forza/pull/324))
- *(planner)* agent-specific prompt directory overrides ([#320](https://github.com/joshrotenberg/forza/pull/320))
- *(config)* add per-route branch_pattern override ([#319](https://github.com/joshrotenberg/forza/pull/319))
- *(logging)* log agent backend and model at info level for every run ([#313](https://github.com/joshrotenberg/forza/pull/313))
- *(run)* add --route filter to forza run command ([#307](https://github.com/joshrotenberg/forza/pull/307))
- add Codex agent backend support ([#293](https://github.com/joshrotenberg/forza/pull/293))
- enhance forza explain with filters, grouping, and verbose mode ([#286](https://github.com/joshrotenberg/forza/pull/286))
- add DraftPr stage for early draft PR visibility ([#271](https://github.com/joshrotenberg/forza/pull/271))

### Fixed

- replace absolute symlink in test-helpers with relative symlink ([#366](https://github.com/joshrotenberg/forza/pull/366))
- *(runner)* change empty code fence to text to silence rustdoc warning ([#354](https://github.com/joshrotenberg/forza/pull/354))
- *(executor)* read skill files and prepend to prompt instead of using --file ([#331](https://github.com/joshrotenberg/forza/pull/331))
- *(cli)* update --repo-dir doc comment on RunArgs to match issue/pr commands ([#309](https://github.com/joshrotenberg/forza/pull/309))
- *(explain)* show agent backend in global header and verbose route output closes #302 ([#305](https://github.com/joshrotenberg/forza/pull/305))
- update init guided prompt with correct workflow names and next steps ([#296](https://github.com/joshrotenberg/forza/pull/296))
- *(adapters)* pass actual StageKind through AgentExecutor::execute closes #257 ([#281](https://github.com/joshrotenberg/forza/pull/281))
- suppress noisy HTTP/TLS debug logs with smarter default filter ([#280](https://github.com/joshrotenberg/forza/pull/280))
- *(github)* improve error messages for failed API calls and missing issues closes #265 ([#270](https://github.com/joshrotenberg/forza/pull/270))

### Other

- add [workspace.dependencies] to deduplicate shared dep versions ([#267](https://github.com/joshrotenberg/forza/pull/267))
- *(runner)* add doc comment to generate_branch ([#268](https://github.com/joshrotenberg/forza/pull/268))
- add [workspace.package] to deduplicate crate metadata ([#266](https://github.com/joshrotenberg/forza/pull/266))
- forza-core crate and unified pipeline ([#252](https://github.com/joshrotenberg/forza/pull/252))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).