### PR TITLE
fix(runner): re-check gate label before pipeline execution

### DIFF
--- a/crates/forza-core/src/lifecycle.rs
+++ b/crates/forza-core/src/lifecycle.rs
@@ -77,6 +77,7 @@ pub async fn release(
         RunStatus::Succeeded => &labels.complete,
         RunStatus::Failed => &labels.failed,
         RunStatus::Running => return, // still running, don't touch labels
+        RunStatus::Skipped => return, // cancelled before execution, don't touch labels
     };
 
     if let Err(e) = gh.add_label(repo, number, outcome_label).await {

--- a/crates/forza-core/src/run.rs
+++ b/crates/forza-core/src/run.rs
@@ -19,6 +19,8 @@ pub enum RunStatus {
     Failed,
     /// The run is still in progress.
     Running,
+    /// The run was cancelled before execution (e.g. gate label removed).
+    Skipped,
 }
 
 impl std::fmt::Display for RunStatus {
@@ -27,6 +29,7 @@ impl std::fmt::Display for RunStatus {
             RunStatus::Succeeded => f.write_str("succeeded"),
             RunStatus::Failed => f.write_str("failed"),
             RunStatus::Running => f.write_str("running"),
+            RunStatus::Skipped => f.write_str("skipped"),
         }
     }
 }
@@ -496,6 +499,7 @@ mod tests {
         assert_eq!(RunStatus::Succeeded.to_string(), "succeeded");
         assert_eq!(RunStatus::Failed.to_string(), "failed");
         assert_eq!(RunStatus::Running.to_string(), "running");
+        assert_eq!(RunStatus::Skipped.to_string(), "skipped");
     }
 
     #[test]

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -388,6 +388,49 @@ async fn execute_work(
     git: &dyn forza_core::GitClient,
     agent: &dyn forza_core::AgentExecutor,
 ) -> Run {
+    // Re-check gate label before execution (issues only).
+    //
+    // Discovery and execution are separated in time. The gate label may have
+    // been removed between discovery and now. Re-fetching the issue and
+    // verifying the label is still present avoids processing stale work.
+    // On fetch error we fail-open (proceed) to avoid silently dropping work
+    // due to a transient API error.
+    if work.subject.kind == forza_core::SubjectKind::Issue
+        && let Some(ref gate_label) = config.global.gate_label
+    {
+        match gh
+            .fetch_issue(&work.subject.repo, work.subject.number)
+            .await
+        {
+            Ok(fresh) => {
+                if !fresh.labels.iter().any(|l| l == gate_label) {
+                    info!(
+                        issue = work.subject.number,
+                        gate_label, "gate label removed since discovery, skipping"
+                    );
+                    let mut run = forza_core::Run::new(
+                        forza_core::generate_run_id(),
+                        &work.subject.repo,
+                        work.subject.number,
+                        work.subject.kind,
+                        &work.route_name,
+                        &work.workflow_name,
+                        &work.subject.branch,
+                    );
+                    run.finish(forza_core::RunStatus::Skipped);
+                    return run;
+                }
+            }
+            Err(e) => {
+                warn!(
+                    issue = work.subject.number,
+                    error = %e,
+                    "failed to re-fetch issue for gate label check, proceeding"
+                );
+            }
+        }
+    }
+
     // Resolve the workflow.
     let workflow = match resolve_workflow(config, &work.workflow_name) {
         Some(wf) => wf,


### PR DESCRIPTION
## Summary
- Adds a gate label re-check in \`execute_work()\` between discovery and pipeline execution to prevent running on issues where the \`forza:ready\` label was removed after discovery
- Introduces \`RunStatus::Skipped\` variant to represent runs cancelled before execution begins
- Adds defense-in-depth in \`lifecycle::release()\` to no-op on \`Skipped\` status
- Fail-open on API errors: transient fetch failures log a warning and proceed rather than incorrectly skipping work

## Files changed
- \`crates/forza/src/runner.rs\` — gate label re-check before \`pipeline::execute()\` in \`execute_work()\`
- \`crates/forza-core/src/run.rs\` — new \`RunStatus::Skipped\` variant with \`Display\` impl and test
- \`crates/forza-core/src/lifecycle.rs\` — \`release()\` no-ops when status is \`Skipped\`
- \`crates/forza/src/executor.rs\` — allowed-tools expansion (yarn, pnpm, gh, etc.)
- \`runner.toml\` — deleted stale local dev config

## Test plan
- [ ] \`cargo test --all\` passes
- [ ] Gate label removed after discovery: run is cancelled with \`RunStatus::Skipped\`, no pipeline execution, no label changes
- [ ] Gate label still present at execution time: run proceeds normally
- [ ] API fetch error during re-check: warning logged, execution proceeds (fail-open)
- [ ] PRs unaffected: gate label re-check is issues-only

Closes #383