### PR TITLE
fix(deps): add version to forza-core workspace dependency for crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ toml = "0.8"
 tokio = { version = "1", features = ["process", "fs"] }
 tempfile = "3"
 # forza
-forza-core = { path = "crates/forza-core" }
+forza-core = { version = "0.3.0", path = "crates/forza-core" }
 tower-mcp = { version = "0.9", features = ["http"] }
 schemars = "1"
 claude-wrapper = "0.4"


### PR DESCRIPTION
## Summary

- Adds `version = "0.3.0"` to the `forza-core` workspace dependency entry in the root `Cargo.toml`
- crates.io requires a `version` field alongside `path` for workspace-internal dependencies when publishing
- The version matches the current `forza-core` package version declared in `crates/forza-core/Cargo.toml`
- No logic changes; the `forza` binary crate inherits this via `workspace = true`

## Files changed

- `Cargo.toml` — added `version = "0.3.0"` to the `forza-core` workspace dependency entry

## Test plan

- No tests required — this is a metadata-only change to fix crates.io publishing
- Verified `forza-core` version in `crates/forza-core/Cargo.toml` matches the added version field (`0.3.0`)
- `cargo publish --dry-run` should succeed after this change

Closes #388