### PR TITLE
fix: remove publish = false from forza-core

### DIFF
--- a/crates/forza-core/Cargo.toml
+++ b/crates/forza-core/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "forza-core"
 version = "0.4.0"
-publish = false
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
forza depends on forza-core with a version requirement. crates.io needs forza-core published to resolve it. Remove publish = false and let both crates publish together.