### PR TITLE
chore: release v0.5.0

### DIFF
--- a/crates/forza-core/CHANGELOG.md
+++ b/crates/forza-core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.4.0...forza-core-v0.5.0) - 2026-03-29
+
+### Added
+
+- GitHub Action for event-driven forza execution ([#470](https://github.com/joshrotenberg/forza/pull/470))
+- *(pipeline)* enrich agent context — comments, route/workflow name, configless plan ([#469](https://github.com/joshrotenberg/forza/pull/469))
+- *(pipeline)* include issue title in draft PR title closes #449 ([#450](https://github.com/joshrotenberg/forza/pull/450))
+- *(cli)* add forza plan command ([#417](https://github.com/joshrotenberg/forza/pull/417))
+
 ## [0.4.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.3.0...forza-core-v0.4.0) - 2026-03-24
 
 ### Added

--- a/crates/forza/CHANGELOG.md
+++ b/crates/forza/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/joshrotenberg/forza/compare/forza-v0.3.0...forza-v0.5.0) - 2026-03-29
+
+### Added
+
+- GitHub Action for event-driven forza execution ([#470](https://github.com/joshrotenberg/forza/pull/470))
+- *(pipeline)* enrich agent context — comments, route/workflow name, configless plan ([#469](https://github.com/joshrotenberg/forza/pull/469))
+- *(api,mcp)* add workflow and model overrides to trigger endpoints ([#465](https://github.com/joshrotenberg/forza/pull/465))
+- *(plan)* apply forza:complete/failed label to plan issue after exec closes #451 ([#452](https://github.com/joshrotenberg/forza/pull/452))
+- *(explain)* show builtin defaults when no config file exists closes #445 ([#448](https://github.com/joshrotenberg/forza/pull/448))
+- *(cli)* auto-dispatch plan issues from forza issue to plan --exec closes #444 ([#447](https://github.com/joshrotenberg/forza/pull/447))
+- *(cli)* make forza.toml optional for direct commands ([#443](https://github.com/joshrotenberg/forza/pull/443))
+- *(plan)* add --branch flag to target plan branch for PR merges ([#436](https://github.com/joshrotenberg/forza/pull/436))
+- *(status)* plan execution tracking in forza status ([#435](https://github.com/joshrotenberg/forza/pull/435))
+- *(plan)* concurrent execution of independent issues closes #419 ([#434](https://github.com/joshrotenberg/forza/pull/434))
+- *(mcp)* add plan tools to MCP server closes #428 ([#433](https://github.com/joshrotenberg/forza/pull/433))
+- *(api)* add plan endpoints for REST API closes #427 ([#432](https://github.com/joshrotenberg/forza/pull/432))
+- *(explain)* add --plans flag to show open plan issues and status ([#431](https://github.com/joshrotenberg/forza/pull/431))
+- *(plan)* add --close flag to close plan issue after exec closes #421 ([#430](https://github.com/joshrotenberg/forza/pull/430))
+- *(cli)* add forza plan command ([#417](https://github.com/joshrotenberg/forza/pull/417))
+- *(cli)* include git commit hash in version output ([#412](https://github.com/joshrotenberg/forza/pull/412))
+- *(config)* add issue_order to global config for deterministic issue processing ([#399](https://github.com/joshrotenberg/forza/pull/399))
+
+### Fixed
+
+- *(runner)* remove misleading model log from create_agent in configless mode ([#458](https://github.com/joshrotenberg/forza/pull/458))
+- *(git)* detect default branch instead of hardcoding origin/main ([#457](https://github.com/joshrotenberg/forza/pull/457))
+- *(cli)* add --route flag to forza pr subcommand closes #437 ([#438](https://github.com/joshrotenberg/forza/pull/438))
+- *(plan)* deterministic topo sort + dependency merge gating ([#422](https://github.com/joshrotenberg/forza/pull/422))
+- *(runner)* deduplicate PRs across condition routes to prevent double-processing ([#410](https://github.com/joshrotenberg/forza/pull/410))
+- add homepage, allow-dirty, and homebrew publish job for brew formula ([#397](https://github.com/joshrotenberg/forza/pull/397))
+
+### Other
+
+- *(cli)* remove --route from forza pr, consolidate to --fix/--workflow ([#459](https://github.com/joshrotenberg/forza/pull/459))
+- *(cli)* add --workflow flag, fold watch/fix into run/issue/pr ([#440](https://github.com/joshrotenberg/forza/pull/440))
+
 ## [0.3.0](https://github.com/joshrotenberg/forza/compare/forza-v0.2.0...forza-v0.3.0) - 2026-03-23
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `forza-core`: 0.4.0 -> 0.5.0
* `forza`: 0.3.0 -> 0.5.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `forza-core`

<blockquote>

## [0.5.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.4.0...forza-core-v0.5.0) - 2026-03-29

### Added

- GitHub Action for event-driven forza execution ([#470](https://github.com/joshrotenberg/forza/pull/470))
- *(pipeline)* enrich agent context — comments, route/workflow name, configless plan ([#469](https://github.com/joshrotenberg/forza/pull/469))
- *(pipeline)* include issue title in draft PR title closes #449 ([#450](https://github.com/joshrotenberg/forza/pull/450))
- *(cli)* add forza plan command ([#417](https://github.com/joshrotenberg/forza/pull/417))
</blockquote>

## `forza`

<blockquote>

## [0.5.0](https://github.com/joshrotenberg/forza/compare/forza-v0.3.0...forza-v0.5.0) - 2026-03-29

### Added

- GitHub Action for event-driven forza execution ([#470](https://github.com/joshrotenberg/forza/pull/470))
- *(pipeline)* enrich agent context — comments, route/workflow name, configless plan ([#469](https://github.com/joshrotenberg/forza/pull/469))
- *(api,mcp)* add workflow and model overrides to trigger endpoints ([#465](https://github.com/joshrotenberg/forza/pull/465))
- *(plan)* apply forza:complete/failed label to plan issue after exec closes #451 ([#452](https://github.com/joshrotenberg/forza/pull/452))
- *(explain)* show builtin defaults when no config file exists closes #445 ([#448](https://github.com/joshrotenberg/forza/pull/448))
- *(cli)* auto-dispatch plan issues from forza issue to plan --exec closes #444 ([#447](https://github.com/joshrotenberg/forza/pull/447))
- *(cli)* make forza.toml optional for direct commands ([#443](https://github.com/joshrotenberg/forza/pull/443))
- *(plan)* add --branch flag to target plan branch for PR merges ([#436](https://github.com/joshrotenberg/forza/pull/436))
- *(status)* plan execution tracking in forza status ([#435](https://github.com/joshrotenberg/forza/pull/435))
- *(plan)* concurrent execution of independent issues closes #419 ([#434](https://github.com/joshrotenberg/forza/pull/434))
- *(mcp)* add plan tools to MCP server closes #428 ([#433](https://github.com/joshrotenberg/forza/pull/433))
- *(api)* add plan endpoints for REST API closes #427 ([#432](https://github.com/joshrotenberg/forza/pull/432))
- *(explain)* add --plans flag to show open plan issues and status ([#431](https://github.com/joshrotenberg/forza/pull/431))
- *(plan)* add --close flag to close plan issue after exec closes #421 ([#430](https://github.com/joshrotenberg/forza/pull/430))
- *(cli)* add forza plan command ([#417](https://github.com/joshrotenberg/forza/pull/417))
- *(cli)* include git commit hash in version output ([#412](https://github.com/joshrotenberg/forza/pull/412))
- *(config)* add issue_order to global config for deterministic issue processing ([#399](https://github.com/joshrotenberg/forza/pull/399))

### Fixed

- *(runner)* remove misleading model log from create_agent in configless mode ([#458](https://github.com/joshrotenberg/forza/pull/458))
- *(git)* detect default branch instead of hardcoding origin/main ([#457](https://github.com/joshrotenberg/forza/pull/457))
- *(cli)* add --route flag to forza pr subcommand closes #437 ([#438](https://github.com/joshrotenberg/forza/pull/438))
- *(plan)* deterministic topo sort + dependency merge gating ([#422](https://github.com/joshrotenberg/forza/pull/422))
- *(runner)* deduplicate PRs across condition routes to prevent double-processing ([#410](https://github.com/joshrotenberg/forza/pull/410))
- add homepage, allow-dirty, and homebrew publish job for brew formula ([#397](https://github.com/joshrotenberg/forza/pull/397))

### Other

- *(cli)* remove --route from forza pr, consolidate to --fix/--workflow ([#459](https://github.com/joshrotenberg/forza/pull/459))
- *(cli)* add --workflow flag, fold watch/fix into run/issue/pr ([#440](https://github.com/joshrotenberg/forza/pull/440))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).