### PR TITLE
feat(cli): include git commit hash in version output

### DIFF
--- a/crates/forza/build.rs
+++ b/crates/forza/build.rs
@@ -1,0 +1,19 @@
+fn main() {
+    let hash = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs/heads");
+}

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -8,7 +8,7 @@ use tracing::info;
 #[derive(Debug, Parser)]
 #[command(
     name = "forza",
-    version,
+    version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")"),
     about,
     long_about = "Autonomous GitHub issue runner that processes issues through\n\
         configurable workflow templates (plan -> implement -> test -> PR).\n\n\
@@ -1619,7 +1619,10 @@ fn print_status_dashboard(sd: &std::path::Path, workflow_filter: Option<&str>) -
         return ExitCode::FAILURE;
     }
 
-    println!("forza {}", env!("CARGO_PKG_VERSION"));
+    println!(
+        "forza {}",
+        concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")")
+    );
     let sep = "─".repeat(53);
     println!(
         "{:<20}  {:>6}  {:>6}  {:>6}  {:>9}",
@@ -1717,7 +1720,10 @@ fn cmd_status(args: StatusArgs) -> ExitCode {
             eprintln!("no runs found");
             return ExitCode::FAILURE;
         }
-        println!("forza {}", env!("CARGO_PKG_VERSION"));
+        println!(
+            "forza {}",
+            concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")")
+        );
         println!(
             "{:<30}  {:>6}  {:<20}  {:<10}  {:>8}  {:<25}  started_at",
             "run_id", "issue#", "workflow", "status", "cost", "outcome"
@@ -2081,7 +2087,7 @@ fn print_core_run(run: &forza_core::Run) -> ExitCode {
     println!();
     println!(
         "forza {} — Run {} — {} ({subject})",
-        env!("CARGO_PKG_VERSION"),
+        concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")"),
         run.run_id,
         run.status,
     );
@@ -2127,7 +2133,7 @@ fn print_run_result(record: &forza::state::RunRecord) -> ExitCode {
     println!();
     println!(
         "forza {} — Run {} — {} ({})",
-        env!("CARGO_PKG_VERSION"),
+        concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")"),
         record.run_id,
         record.status_text(),
         subject


### PR DESCRIPTION
## Summary
- Adds a `build.rs` to the `forza` binary crate that captures the short git commit hash at compile time via `git rev-parse --short HEAD`
- Updates the clap `Parser` derive and all version display sites in `main.rs` to show `<version> (<hash>)` (e.g. `0.3.0 (abc1234)`)
- Falls back to `"unknown"` if the git command fails (e.g. in clean CI environments)
- No new dependencies required

## Files changed
- `crates/forza/build.rs` (new) — build script that sets `GIT_HASH` env var via `cargo:rustc-env`; re-runs on `.git/HEAD` and `.git/refs/heads` changes
- `crates/forza/src/main.rs` — updates `#[command(version = ...)]` attribute and four additional version-display sites to include the git hash

## Test plan
- [ ] `cargo build -p forza` succeeds
- [ ] `forza --version` outputs `forza <version> (<short-hash>)`
- [ ] `forza --version` output does not duplicate the hash
- [ ] `cargo test --all` passes

Closes #411