### PR TITLE
feat(plan): add --close flag to close plan issue after exec closes #421

### DIFF
--- a/crates/forza/src/github/gh_cli.rs
+++ b/crates/forza/src/github/gh_cli.rs
@@ -70,6 +70,10 @@ impl GitHubClient for GhCliClient {
         super::comment_on_issue(repo, number, body).await
     }
 
+    async fn close_issue(&self, repo: &str, number: u64) -> Result<()> {
+        super::close_issue(repo, number).await
+    }
+
     async fn create_issue(&self, repo: &str, title: &str, body: &str) -> Result<u64> {
         super::create_issue(repo, title, body).await
     }

--- a/crates/forza/src/github/mod.rs
+++ b/crates/forza/src/github/mod.rs
@@ -46,6 +46,7 @@ pub trait GitHubClient: Send + Sync {
         description: &str,
     ) -> Result<()>;
     async fn comment_on_issue(&self, repo: &str, number: u64, body: &str) -> Result<()>;
+    async fn close_issue(&self, repo: &str, number: u64) -> Result<()>;
     async fn create_issue(&self, repo: &str, title: &str, body: &str) -> Result<u64>;
 
     // ── Pull Requests ───────────────────────────────────────────────
@@ -977,6 +978,22 @@ pub async fn comment_on_issue(repo: &str, number: u64, body: &str) -> Result<()>
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(Error::GitHub(format!("gh issue comment failed: {stderr}")));
+    }
+
+    Ok(())
+}
+
+/// Close an issue via gh CLI.
+pub async fn close_issue(repo: &str, number: u64) -> Result<()> {
+    let output = tokio::process::Command::new("gh")
+        .args(["issue", "close", "--repo", repo, &number.to_string()])
+        .output()
+        .await
+        .map_err(|e| Error::GitHub(format!("gh issue close failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::GitHub(format!("gh issue close failed: {stderr}")));
     }
 
     Ok(())

--- a/crates/forza/src/github/octocrab_client.rs
+++ b/crates/forza/src/github/octocrab_client.rs
@@ -265,6 +265,18 @@ impl GitHubClient for OctocrabClient {
         Ok(())
     }
 
+    async fn close_issue(&self, repo: &str, number: u64) -> Result<()> {
+        let (owner, name) = parse_repo(repo)?;
+        self.client
+            .issues(owner, name)
+            .update(number)
+            .state(octocrab::models::IssueState::Closed)
+            .send()
+            .await
+            .map_err(|e| Error::GitHub(format!("close issue #{number}: {e}")))?;
+        Ok(())
+    }
+
     async fn create_issue(&self, repo: &str, title: &str, body: &str) -> Result<u64> {
         let (owner, name) = parse_repo(repo)?;
         let issue = self

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -313,7 +313,7 @@ struct OpenArgs {
 
 #[derive(Debug, Parser)]
 #[command(
-    after_long_help = "Examples:\n  forza plan\n  forza plan 42\n  forza plan 10 20 30\n  forza plan 10..20\n  forza plan --label backlog\n  forza plan --revise 99\n  forza plan --exec 99\n  forza plan --exec 99 --dry-run"
+    after_long_help = "Examples:\n  forza plan\n  forza plan 42\n  forza plan 10 20 30\n  forza plan 10..20\n  forza plan --label backlog\n  forza plan --revise 99\n  forza plan --exec 99\n  forza plan --exec 99 --dry-run\n  forza plan --exec 99 --close"
 )]
 struct PlanArgs {
     /// Issue numbers to plan. Supports single (42), multiple (10 20 30), range (10..20).
@@ -335,6 +335,9 @@ struct PlanArgs {
     /// Preview execution order without processing (use with --exec).
     #[arg(long)]
     dry_run: bool,
+    /// Close the plan issue after all items are executed (use with --exec).
+    #[arg(long)]
+    close: bool,
     /// Override the model (e.g. claude-opus-4-6).
     #[arg(long)]
     model: Option<String>,
@@ -529,7 +532,17 @@ async fn cmd_plan(
 
     // Exec mode: execute an existing plan issue.
     if let Some(plan_number) = args.exec {
-        return cmd_plan_exec(plan_number, &repo, &rd, config, gh, git, args.dry_run).await;
+        return cmd_plan_exec(
+            plan_number,
+            &repo,
+            &rd,
+            config,
+            gh,
+            git,
+            args.dry_run,
+            args.close,
+        )
+        .await;
     }
 
     // Revise mode: update an existing plan issue.
@@ -603,6 +616,7 @@ async fn cmd_plan(
 }
 
 /// Execute an existing plan issue: process actionable items in dependency order.
+#[allow(clippy::too_many_arguments)]
 async fn cmd_plan_exec(
     plan_number: u64,
     repo: &str,
@@ -611,6 +625,7 @@ async fn cmd_plan_exec(
     gh: &std::sync::Arc<dyn forza::github::GitHubClient>,
     git: &std::sync::Arc<dyn forza::git::GitClient>,
     dry_run: bool,
+    close: bool,
 ) -> ExitCode {
     let plan_issue = match gh.fetch_issue(repo, plan_number).await {
         Ok(i) => i,
@@ -789,6 +804,21 @@ async fn cmd_plan_exec(
         "\nPlan #{plan_number} complete: {succeeded} succeeded, {failed} failed, {} skipped",
         skipped.len().saturating_sub(failed)
     );
+
+    if close {
+        let summary = format!(
+            "Plan execution complete: {succeeded} succeeded, {failed} failed, {} skipped.",
+            skipped.len().saturating_sub(failed)
+        );
+        if let Err(e) = gh.comment_on_issue(repo, plan_number, &summary).await {
+            eprintln!("warning: failed to post summary comment on #{plan_number}: {e}");
+        }
+        if let Err(e) = gh.close_issue(repo, plan_number).await {
+            eprintln!("warning: failed to close plan issue #{plan_number}: {e}");
+        } else {
+            println!("Closed plan issue #{plan_number}.");
+        }
+    }
 
     if failed > 0 {
         ExitCode::FAILURE


### PR DESCRIPTION
## Summary

- Adds a `--close` boolean flag to `forza plan --exec` that closes the plan issue after execution completes
- Posts a summary comment on the plan issue (total/succeeded/failed/skipped counts) before closing
- Adds `close_issue` method to the `GitHubClient` trait with implementations in both `GhCliClient` and `OctocrabClient`
- `--dry-run --close` is safe: the close is skipped when dry-run is active

## Files changed

- `crates/forza/src/main.rs` — adds `--close` CLI flag to `PlanArgs`, threads it through `cmd_plan_exec`, posts summary comment and closes issue when flag is set
- `crates/forza/src/github/mod.rs` — adds `close_issue` trait method and default `gh CLI` implementation
- `crates/forza/src/github/gh_cli.rs` — `GhCliClient` impl delegates to `super::close_issue`
- `crates/forza/src/github/octocrab_client.rs` — `OctocrabClient` impl via `.update().state(Closed)`

## Test plan

- [ ] Run `forza plan --exec <N>` without `--close` — plan issue should remain open
- [ ] Run `forza plan --exec <N> --close` — plan issue should receive a summary comment and be closed after all items execute
- [ ] Run `forza plan --exec <N> --close --dry-run` — issue should not be closed (dry-run guard)
- [ ] Run with partial failures — verify summary comment includes correct failed/skipped counts and issue is still closed

Closes #421