### PR TITLE
feat(status): plan execution tracking in forza status

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -711,6 +711,13 @@ async fn cmd_plan_exec(
     // Track PR numbers created by each issue for merge-gating.
     let mut prs: std::collections::HashMap<u64, u64> = std::collections::HashMap::new();
 
+    let mut plan_exec = forza::state::PlanExecRecord {
+        plan_number,
+        repo: repo.to_string(),
+        started_at: chrono::Utc::now(),
+        issues: Vec::new(),
+    };
+
     let max_concurrency = config.global.max_concurrency;
 
     'levels: for (level_idx, level) in levels.iter().enumerate() {
@@ -734,8 +741,16 @@ async fn cmd_plan_exec(
         for issue_number in level {
             if !runnable.contains(issue_number) {
                 skipped.insert(*issue_number);
+                plan_exec.issues.push(forza::state::PlanIssueEntry {
+                    issue_number: *issue_number,
+                    status: forza::state::PlanIssueStatus::Skipped,
+                    pr_number: None,
+                    pr_merged: false,
+                    failed_stage: None,
+                });
             }
         }
+        let _ = forza::state::save_plan_exec(&plan_exec, &sd);
 
         if runnable.is_empty() {
             continue;
@@ -795,6 +810,14 @@ async fn cmd_plan_exec(
                     Ok(issue) if issue.labels.iter().any(|l| l == "forza:complete") => {
                         println!("    #{issue_number}: already complete, skipping");
                         succeeded += 1;
+                        plan_exec.issues.push(forza::state::PlanIssueEntry {
+                            issue_number,
+                            status: forza::state::PlanIssueStatus::Succeeded,
+                            pr_number: None,
+                            pr_merged: false,
+                            failed_stage: None,
+                        });
+                        let _ = forza::state::save_plan_exec(&plan_exec, &sd);
                         continue;
                     }
                     _ => {}
@@ -831,16 +854,43 @@ async fn cmd_plan_exec(
                     Ok((issue_number, Ok(run))) => match run.status {
                         forza_core::RunStatus::Succeeded => {
                             succeeded += 1;
+                            let (pr_number, pr_merged) = match run.outcome.as_ref() {
+                                Some(forza_core::Outcome::PrCreated { number }) => {
+                                    (Some(*number), false)
+                                }
+                                Some(forza_core::Outcome::PrMerged { number }) => {
+                                    (Some(*number), true)
+                                }
+                                _ => (None, false),
+                            };
                             if let Some(forza_core::Outcome::PrCreated { number })
                             | Some(forza_core::Outcome::PrMerged { number }) = run.outcome
                             {
                                 prs.insert(issue_number, number);
                             }
+                            plan_exec.issues.push(forza::state::PlanIssueEntry {
+                                issue_number,
+                                status: forza::state::PlanIssueStatus::Succeeded,
+                                pr_number,
+                                pr_merged,
+                                failed_stage: None,
+                            });
+                            let _ = forza::state::save_plan_exec(&plan_exec, &sd);
                             println!("    #{issue_number}: succeeded");
                         }
                         _ => {
                             failed += 1;
                             skipped.insert(issue_number);
+                            let failed_stage =
+                                run.failed_stage().map(|s| s.kind_name().to_string());
+                            plan_exec.issues.push(forza::state::PlanIssueEntry {
+                                issue_number,
+                                status: forza::state::PlanIssueStatus::Failed,
+                                pr_number: None,
+                                pr_merged: false,
+                                failed_stage,
+                            });
+                            let _ = forza::state::save_plan_exec(&plan_exec, &sd);
                             println!("    #{issue_number}: failed");
                         }
                     },
@@ -848,6 +898,14 @@ async fn cmd_plan_exec(
                         eprintln!("    #{issue_number}: error: {e}");
                         failed += 1;
                         skipped.insert(issue_number);
+                        plan_exec.issues.push(forza::state::PlanIssueEntry {
+                            issue_number,
+                            status: forza::state::PlanIssueStatus::Failed,
+                            pr_number: None,
+                            pr_merged: false,
+                            failed_stage: None,
+                        });
+                        let _ = forza::state::save_plan_exec(&plan_exec, &sd);
                     }
                     Err(e) => {
                         eprintln!("    task join error: {e}");
@@ -2403,6 +2461,63 @@ fn print_status_dashboard(sd: &std::path::Path, workflow_filter: Option<&str>) -
                 "  {prefix} #{} {} → {}     {ago}",
                 r.issue_number, r.workflow, outcome
             );
+        }
+    }
+
+    // Plan Executions
+    let plan_execs = forza::state::load_all_plan_execs(sd);
+    if !plan_execs.is_empty() {
+        use forza::state::PlanIssueStatus;
+        println!();
+        println!("Plan Executions:");
+        for plan in &plan_execs {
+            let n_succeeded = plan
+                .issues
+                .iter()
+                .filter(|i| i.status == PlanIssueStatus::Succeeded)
+                .count();
+            let n_failed = plan
+                .issues
+                .iter()
+                .filter(|i| i.status == PlanIssueStatus::Failed)
+                .count();
+            let n_skipped = plan
+                .issues
+                .iter()
+                .filter(|i| i.status == PlanIssueStatus::Skipped)
+                .count();
+            let ago = format_time_ago(plan.started_at);
+            println!(
+                "  Plan #{} ({}) — {} issue(s): {}✓ {}✗ {}- ({ago})",
+                plan.plan_number,
+                plan.repo,
+                plan.issues.len(),
+                n_succeeded,
+                n_failed,
+                n_skipped,
+            );
+            for entry in &plan.issues {
+                let (prefix, detail) = match entry.status {
+                    PlanIssueStatus::Succeeded => {
+                        let pr_info = match (entry.pr_number, entry.pr_merged) {
+                            (Some(n), true) => format!("  PR #{n} (merged)"),
+                            (Some(n), false) => format!("  PR #{n}"),
+                            (None, _) => String::new(),
+                        };
+                        ("✓", format!("succeeded{pr_info}"))
+                    }
+                    PlanIssueStatus::Failed => {
+                        let stage_info = entry
+                            .failed_stage
+                            .as_deref()
+                            .map(|s| format!("  stage: {s}"))
+                            .unwrap_or_default();
+                        ("✗", format!("failed{stage_info}"))
+                    }
+                    PlanIssueStatus::Skipped => ("-", "skipped".to_string()),
+                };
+                println!("    {prefix} #{:<6}  {detail}", entry.issue_number);
+            }
         }
     }
 

--- a/crates/forza/src/state.rs
+++ b/crates/forza/src/state.rs
@@ -527,6 +527,81 @@ pub fn generate_run_id() -> String {
     format!("run-{timestamp}-{suffix:08x}")
 }
 
+/// Execution status of a single issue within a plan execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanIssueStatus {
+    Succeeded,
+    Failed,
+    Skipped,
+}
+
+/// Per-issue record within a plan execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanIssueEntry {
+    /// Issue number.
+    pub issue_number: u64,
+    /// Final status of this issue.
+    pub status: PlanIssueStatus,
+    /// PR number if created or merged.
+    pub pr_number: Option<u64>,
+    /// Whether the PR was merged.
+    pub pr_merged: bool,
+    /// Name of the stage that failed, if any.
+    pub failed_stage: Option<String>,
+}
+
+/// A persisted record of a plan execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanExecRecord {
+    /// The plan issue number.
+    pub plan_number: u64,
+    /// Repository.
+    pub repo: String,
+    /// When execution started.
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    /// Per-issue results.
+    pub issues: Vec<PlanIssueEntry>,
+}
+
+/// Save a plan execution record to disk.
+pub fn save_plan_exec(
+    record: &PlanExecRecord,
+    state_dir: &std::path::Path,
+) -> crate::error::Result<()> {
+    std::fs::create_dir_all(state_dir)?;
+    let final_path = state_dir.join(format!("plan_{}.json", record.plan_number));
+    let tmp_path = state_dir.join(format!("plan_{}.json.tmp", record.plan_number));
+    let json = serde_json::to_string_pretty(record)?;
+    std::fs::write(&tmp_path, &json)?;
+    std::fs::rename(&tmp_path, &final_path)?;
+    Ok(())
+}
+
+/// Load all plan execution records from the state directory, sorted by `started_at` descending.
+pub fn load_all_plan_execs(state_dir: &std::path::Path) -> Vec<PlanExecRecord> {
+    let entries = match std::fs::read_dir(state_dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    let mut records: Vec<PlanExecRecord> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.starts_with("plan_") && n.ends_with(".json"))
+                .unwrap_or(false)
+        })
+        .filter_map(|e| {
+            let content = std::fs::read_to_string(e.path()).ok()?;
+            serde_json::from_str(&content).ok()
+        })
+        .collect();
+    records.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+    records
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Adds `PlanExecRecord`, `PlanIssueEntry`, and `PlanIssueStatus` types to `state.rs` for persisting plan execution outcomes per-issue to disk
- Adds `save_plan_exec()` and `load_all_plan_execs()` functions using atomic writes (`plan_N.json` files) so partial progress survives interruption
- Updates `cmd_plan_exec()` in `main.rs` to initialize and update a `PlanExecRecord` at each decision point (skipped, already-complete, succeeded, failed), capturing PR number, merge status, and failed stage
- Adds a "Plan Execution" section to `print_status_dashboard()` that renders per-plan/per-issue history with status symbols and metadata — fully local, no GitHub API access required

## Files changed

- `crates/forza/src/state.rs` — new `PlanIssueStatus` enum, `PlanIssueEntry` and `PlanExecRecord` structs, `save_plan_exec` and `load_all_plan_execs` functions
- `crates/forza/src/main.rs` — `cmd_plan_exec` updated to track and persist plan execution state; `print_status_dashboard` updated to display plan history

## Test plan

- [ ] Run `forza plan --exec <N>` and verify `plan_N.json` files are written to the state directory after each issue completes
- [ ] Run `forza status` and verify the "Plan Execution" section appears with correct per-issue status symbols
- [ ] Interrupt a plan execution mid-run and verify the partial state is preserved and displayed correctly
- [ ] Run `cargo test --all` to confirm no regressions

Closes #425