### PR TITLE
fix(cli): add --route flag to forza pr subcommand closes #437

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -142,6 +142,9 @@ struct PrArgs {
     /// Add a skill file for every stage in this run (repeatable).
     #[arg(long, action = clap::ArgAction::Append)]
     skill: Vec<String>,
+    /// Force a specific route by name, bypassing label-based matching.
+    #[arg(long)]
+    route: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -1629,14 +1632,20 @@ async fn cmd_pr(
             }
         };
 
-        let (route_name, route) = match forza::RunnerConfig::match_pr_route_in(routes, &pr) {
-            Some(r) => r,
-            None => {
-                eprintln!(
-                    "no route matches PR #{} (labels: {:?})",
-                    pr.number, pr.labels
-                );
-                return ExitCode::FAILURE;
+        let (route_name, route) = if let Some(ref rn) = args.route
+            && let Some(r) = routes.get(rn)
+        {
+            (rn.as_str(), r)
+        } else {
+            match forza::RunnerConfig::match_pr_route_in(routes, &pr) {
+                Some(r) => r,
+                None => {
+                    eprintln!(
+                        "no route matches PR #{} (labels: {:?})",
+                        pr.number, pr.labels
+                    );
+                    return ExitCode::FAILURE;
+                }
             }
         };
 
@@ -1683,7 +1692,7 @@ async fn cmd_pr(
         git.clone(),
         args.model,
         args.skill,
-        None,
+        args.route,
     )
     .await
     {


### PR DESCRIPTION
## Summary

- `PrArgs` was missing a `--route` field, causing `forza pr` to always ignore route overrides
- Added `--route <name>` flag to the `forza pr` subcommand, wired through to `process_pr`
- Updated the dry-run path in `cmd_pr` to use the override when resolving the route
- Added `--route fix-pr` usage example to `after_long_help`

## Files changed

- `crates/forza/src/main.rs` — added `route: Option<String>` to `PrArgs`, updated `cmd_pr` dry-run path and `process_pr` call to pass `args.route`

## Test plan

- [ ] `forza pr <N> --route <route-name>` selects the named route without label matching
- [ ] `forza pr <N> --dry-run --route <route-name>` displays the correct route in dry-run output
- [ ] `forza pr <N>` (no `--route`) continues to use label-based route matching as before
- [ ] `cargo test --all` passes

Closes #437