### PR TITLE
refactor(cli): add --workflow flag, fold watch/fix into run/issue/pr

### DIFF
--- a/crates/forza/src/api.rs
+++ b/crates/forza/src/api.rs
@@ -297,6 +297,7 @@ async fn trigger_issue(
             None,
             vec![],
             None,
+            None,
         )
         .await
         {
@@ -381,6 +382,7 @@ async fn trigger_pr(
             git,
             None,
             vec![],
+            None,
             None,
         )
         .await
@@ -848,6 +850,7 @@ async fn exec_plan(
                 git.clone(),
                 None,
                 vec![],
+                None,
                 None,
             )
             .await

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -39,13 +39,15 @@ enum Command {
     Issue(IssueArgs),
     /// Process a single PR by number.
     Pr(PrArgs),
-    /// Run once — poll for eligible issues and process them.
+    /// Run once — poll for eligible issues and process them. Use --watch for continuous mode.
     Run(RunArgs),
-    /// Watch mode — continuously poll and process issues.
+    /// Watch mode — continuously poll and process issues (deprecated: use `run --watch`).
+    #[command(hide = true)]
     Watch(WatchArgs),
     /// Show run history and status.
     Status(StatusArgs),
-    /// Re-run failed stages with error context.
+    /// Re-run failed stages with error context (deprecated: use `issue --fix` or `pr --fix`).
+    #[command(hide = true)]
     Fix(FixArgs),
     /// Remove worktrees or run state.
     Clean(CleanArgs),
@@ -98,7 +100,7 @@ struct FixArgs {
 
 #[derive(Debug, Parser)]
 #[command(
-    after_long_help = "Examples:\n  forza issue 42\n  forza issue 42 --dry-run --model claude-opus-4-6\n  forza issue 42 --skill ./skills/extra.md"
+    after_long_help = "Examples:\n  forza issue 42\n  forza issue 42 --dry-run --model claude-opus-4-6\n  forza issue 42 --skill ./skills/extra.md\n  forza issue 42 --workflow feature\n  forza issue 42 --fix"
 )]
 struct IssueArgs {
     /// Issue number to process.
@@ -118,11 +120,17 @@ struct IssueArgs {
     /// Add a skill file for every stage in this run (repeatable).
     #[arg(long, action = clap::ArgAction::Append)]
     skill: Vec<String>,
+    /// Override the workflow template, skipping route matching (e.g. feature, bug, chore).
+    #[arg(long)]
+    workflow: Option<String>,
+    /// Re-run the latest failed run for this issue.
+    #[arg(long)]
+    fix: bool,
 }
 
 #[derive(Debug, Parser)]
 #[command(
-    after_long_help = "Examples:\n  forza pr 123\n  forza pr 123 --route fix-pr\n  forza pr 123 --dry-run"
+    after_long_help = "Examples:\n  forza pr 123\n  forza pr 123 --route fix-pr\n  forza pr 123 --dry-run\n  forza pr 123 --workflow pr-fix\n  forza pr 123 --fix"
 )]
 struct PrArgs {
     /// PR number to process.
@@ -145,11 +153,17 @@ struct PrArgs {
     /// Force a specific route by name, bypassing label-based matching.
     #[arg(long)]
     route: Option<String>,
+    /// Override the workflow template, skipping route matching (e.g. pr-fix, pr-rebase).
+    #[arg(long)]
+    workflow: Option<String>,
+    /// Re-run the latest failed run for this PR.
+    #[arg(long)]
+    fix: bool,
 }
 
 #[derive(Debug, Parser)]
 #[command(
-    after_long_help = "Examples:\n  forza run\n  forza run --repo-dir . --no-gate\n  forza run --route bugfix"
+    after_long_help = "Examples:\n  forza run\n  forza run --repo-dir . --no-gate\n  forza run --route bugfix\n  forza run --watch\n  forza run --watch --interval 30 --serve-api"
 )]
 struct RunArgs {
     /// Repository directory (default: current directory).
@@ -161,6 +175,21 @@ struct RunArgs {
     /// Bypass the gate_label requirement and process all matching issues immediately.
     #[arg(long, default_value = "false")]
     no_gate: bool,
+    /// Watch mode — continuously poll and process issues.
+    #[arg(long, default_value = "false")]
+    watch: bool,
+    /// Override poll interval in seconds (watch mode only).
+    #[arg(long)]
+    interval: Option<u64>,
+    /// Also start the REST API server alongside the watch loop (watch mode only).
+    #[arg(long, default_value = "false")]
+    serve_api: bool,
+    /// Host address for the REST API server (watch mode only, default: 127.0.0.1).
+    #[arg(long)]
+    api_host: Option<String>,
+    /// Port for the REST API server (watch mode only, default: 8080).
+    #[arg(long)]
+    api_port: Option<u16>,
 }
 
 #[derive(Debug, Parser)]
@@ -863,6 +892,7 @@ async fn cmd_plan_exec(
                         None,
                         vec![],
                         branch_override_clone,
+                        None,
                     )
                     .await;
                     (issue_number, result)
@@ -1582,6 +1612,45 @@ async fn cmd_issue(
         return ExitCode::FAILURE;
     }
 
+    // --fix: find latest failed run and re-process.
+    if args.fix {
+        let record = forza::state::find_latest_run_for_issue(args.number, &sd)
+            .filter(|r| r.status == forza::state::RunStatus::Failed);
+        let record = match record {
+            Some(r) => r,
+            None => {
+                eprintln!("error: no failed run found for issue #{}", args.number);
+                return ExitCode::FAILURE;
+            }
+        };
+        println!(
+            "Fixing run {} (issue #{})",
+            record.run_id, record.issue_number
+        );
+        match forza::runner::process_issue(
+            args.number,
+            &repo,
+            config,
+            routes,
+            &sd,
+            &rd,
+            gh.clone(),
+            git.clone(),
+            args.model,
+            args.skill,
+            None,
+            args.workflow,
+        )
+        .await
+        {
+            Ok(run) => return print_core_run(&run),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
     match forza::runner::process_issue(
         args.number,
         &repo,
@@ -1594,6 +1663,7 @@ async fn cmd_issue(
         args.model,
         args.skill,
         None,
+        args.workflow,
     )
     .await
     {
@@ -1681,6 +1751,45 @@ async fn cmd_pr(
         return ExitCode::SUCCESS;
     }
 
+    // --fix: find latest failed run for this PR and re-process.
+    if args.fix {
+        let record = forza::state::load_all_runs(&sd).into_iter().find(|r| {
+            r.issue_number == args.number
+                && r.subject_kind == forza::state::SubjectKind::Pr
+                && r.status == forza::state::RunStatus::Failed
+        });
+        let record = match record {
+            Some(r) => r,
+            None => {
+                eprintln!("error: no failed run found for PR #{}", args.number);
+                return ExitCode::FAILURE;
+            }
+        };
+        println!("Fixing run {} (PR #{})", record.run_id, record.issue_number);
+        match forza::runner::process_pr(
+            args.number,
+            &repo,
+            config,
+            routes,
+            &sd,
+            &rd,
+            gh.clone(),
+            git.clone(),
+            args.model,
+            args.skill,
+            args.route,
+            args.workflow,
+        )
+        .await
+        {
+            Ok(run) => return print_core_run(&run),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
     match forza::runner::process_pr(
         args.number,
         &repo,
@@ -1693,6 +1802,7 @@ async fn cmd_pr(
         args.model,
         args.skill,
         args.route,
+        args.workflow,
     )
     .await
     {
@@ -1714,6 +1824,20 @@ async fn cmd_run(
     gh: std::sync::Arc<dyn forza::github::GitHubClient>,
     git: std::sync::Arc<dyn forza::git::GitClient>,
 ) -> ExitCode {
+    // Delegate to watch mode when --watch is set.
+    if args.watch {
+        let watch_args = WatchArgs {
+            interval: args.interval,
+            route: args.route,
+            repo_dir: args.repo_dir,
+            serve_api: args.serve_api,
+            api_host: args.api_host,
+            api_port: args.api_port,
+            no_gate: args.no_gate,
+        };
+        return cmd_watch(watch_args, config, gh, git).await;
+    }
+
     let mut config = config.clone();
     if args.no_gate {
         config.global.gate_label = None;
@@ -2708,6 +2832,7 @@ async fn cmd_fix(
         git.clone(),
         None,
         vec![],
+        None,
         None,
     )
     .await

--- a/crates/forza/src/mcp.rs
+++ b/crates/forza/src/mcp.rs
@@ -217,6 +217,7 @@ pub fn build_router(state: AppState) -> McpRouter {
                     None,
                     vec![],
                     None,
+                    None,
                 )
                 .await
                 {
@@ -257,6 +258,7 @@ pub fn build_router(state: AppState) -> McpRouter {
                     app.git.clone(),
                     None,
                     vec![],
+                    None,
                     None,
                 )
                 .await
@@ -821,6 +823,7 @@ pub fn build_router(state: AppState) -> McpRouter {
                         app.git.clone(),
                         None,
                         vec![],
+                        None,
                         None,
                     )
                     .await

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -743,6 +743,7 @@ pub async fn process_issue(
     model_override: Option<String>,
     skill_overrides: Vec<String>,
     base_branch_override: Option<String>,
+    workflow_override: Option<String>,
 ) -> forza_core::Result<Run> {
     tracing::info!(number, repo, "processing issue");
     let issue = gh.fetch_issue(repo, number).await.map_err(|e| match e {
@@ -750,40 +751,80 @@ pub async fn process_issue(
         _ => forza_core::Error::GitHub(e.to_string()),
     })?;
 
-    let (route_name, route) = RunnerConfig::match_route_in(routes, &issue).ok_or_else(|| {
-        forza_core::Error::NoMatchingRoute(format!(
-            "no route matches issue #{number} (labels: {:?})",
-            issue.labels
-        ))
-    })?;
+    let mut matched = if let Some(wf_name) = workflow_override {
+        // Workflow override: skip route matching, build a synthetic route.
+        let branch = generate_branch(
+            &config.global.branch_pattern,
+            number,
+            &issue.title,
+            "direct",
+            None,
+        );
+        let mut subject = adapters::issue_to_subject(&issue, &branch);
+        if let Some(ref base) = base_branch_override {
+            subject.base_branch = Some(base.clone());
+        }
+        MatchedWork {
+            subject,
+            route_name: "direct".to_string(),
+            route: forza_core::Route {
+                subject_type: SubjectKind::Issue,
+                trigger: forza_core::Trigger::Label(String::new()),
+                workflow: wf_name.clone(),
+                scope: forza_core::Scope::All,
+                concurrency: 1,
+                poll_interval: 300,
+                max_retries: None,
+                model: model_override.clone(),
+                skills: if skill_overrides.is_empty() {
+                    None
+                } else {
+                    Some(skill_overrides.clone())
+                },
+                mcp_config: None,
+                validation_commands: None,
+            },
+            workflow_name: wf_name,
+        }
+    } else {
+        let (route_name, route) =
+            RunnerConfig::match_route_in(routes, &issue).ok_or_else(|| {
+                forza_core::Error::NoMatchingRoute(format!(
+                    "no route matches issue #{number} (labels: {:?})",
+                    issue.labels
+                ))
+            })?;
 
-    let wf_name = route.workflow.as_deref().unwrap_or("");
-    let branch = generate_branch(
-        config.effective_branch_pattern(route),
-        number,
-        &issue.title,
-        route_name,
-        route.label.as_deref(),
-    );
-    let mut subject = adapters::issue_to_subject(&issue, &branch);
+        let wf_name = route.workflow.as_deref().unwrap_or("");
+        let branch = generate_branch(
+            config.effective_branch_pattern(route),
+            number,
+            &issue.title,
+            route_name,
+            route.label.as_deref(),
+        );
+        let mut subject = adapters::issue_to_subject(&issue, &branch);
 
-    if let Some(ref base) = base_branch_override {
-        subject.base_branch = Some(base.clone());
-    }
+        if let Some(ref base) = base_branch_override {
+            subject.base_branch = Some(base.clone());
+        }
 
-    let mut matched = MatchedWork {
-        subject,
-        route_name: route_name.to_string(),
-        route: to_core_route(route),
-        workflow_name: wf_name.to_string(),
+        MatchedWork {
+            subject,
+            route_name: route_name.to_string(),
+            route: to_core_route(route),
+            workflow_name: wf_name.to_string(),
+        }
     };
 
-    // Apply CLI overrides.
-    if let Some(m) = model_override {
-        matched.route.model = Some(m);
-    }
-    if !skill_overrides.is_empty() {
-        matched.route.skills = Some(skill_overrides);
+    // Apply CLI overrides (for the route-matched path; workflow override path sets these above).
+    if matched.route_name != "direct" {
+        if let Some(m) = model_override {
+            matched.route.model = Some(m);
+        }
+        if !skill_overrides.is_empty() {
+            matched.route.skills = Some(skill_overrides);
+        }
     }
 
     let gh_adapter = Arc::new(GitHubAdapter::new(gh));
@@ -816,6 +857,7 @@ pub async fn process_pr(
     model_override: Option<String>,
     skill_overrides: Vec<String>,
     route_override: Option<String>,
+    workflow_override: Option<String>,
 ) -> forza_core::Result<Run> {
     tracing::info!(number, repo, "processing PR");
     let pr = gh.fetch_pr(repo, number).await.map_err(|e| match e {
@@ -823,35 +865,65 @@ pub async fn process_pr(
         _ => forza_core::Error::GitHub(e.to_string()),
     })?;
 
-    // Use route override if provided (from condition routes), otherwise match by labels.
-    let (route_name, route) = if let Some(ref rn) = route_override
-        && let Some(r) = routes.get(rn)
-    {
-        (rn.as_str(), r)
+    let mut matched = if let Some(wf_name) = workflow_override {
+        // Workflow override: skip route matching, build a synthetic route.
+        let subject = adapters::pr_to_subject(&pr);
+        MatchedWork {
+            subject,
+            route_name: "direct".to_string(),
+            route: forza_core::Route {
+                subject_type: SubjectKind::Pr,
+                trigger: forza_core::Trigger::Label(String::new()),
+                workflow: wf_name.clone(),
+                scope: forza_core::Scope::All,
+                concurrency: 1,
+                poll_interval: 300,
+                max_retries: None,
+                model: model_override.clone(),
+                skills: if skill_overrides.is_empty() {
+                    None
+                } else {
+                    Some(skill_overrides.clone())
+                },
+                mcp_config: None,
+                validation_commands: None,
+            },
+            workflow_name: wf_name,
+        }
     } else {
-        RunnerConfig::match_pr_route_in(routes, &pr).ok_or_else(|| {
-            forza_core::Error::NoMatchingRoute(format!(
-                "no route matches PR #{number} (labels: {:?})",
-                pr.labels
-            ))
-        })?
+        // Use route override if provided (from condition routes), otherwise match by labels.
+        let (route_name, route) = if let Some(ref rn) = route_override
+            && let Some(r) = routes.get(rn)
+        {
+            (rn.as_str(), r)
+        } else {
+            RunnerConfig::match_pr_route_in(routes, &pr).ok_or_else(|| {
+                forza_core::Error::NoMatchingRoute(format!(
+                    "no route matches PR #{number} (labels: {:?})",
+                    pr.labels
+                ))
+            })?
+        };
+
+        let wf_name = route.workflow.as_deref().unwrap_or("");
+        let subject = adapters::pr_to_subject(&pr);
+
+        MatchedWork {
+            subject,
+            route_name: route_name.to_string(),
+            route: to_core_route(route),
+            workflow_name: wf_name.to_string(),
+        }
     };
 
-    let wf_name = route.workflow.as_deref().unwrap_or("");
-    let subject = adapters::pr_to_subject(&pr);
-
-    let mut matched = MatchedWork {
-        subject,
-        route_name: route_name.to_string(),
-        route: to_core_route(route),
-        workflow_name: wf_name.to_string(),
-    };
-
-    if let Some(m) = model_override {
-        matched.route.model = Some(m);
-    }
-    if !skill_overrides.is_empty() {
-        matched.route.skills = Some(skill_overrides);
+    // Apply CLI overrides (for the route-matched path; workflow override path sets these above).
+    if matched.route_name != "direct" {
+        if let Some(m) = model_override {
+            matched.route.model = Some(m);
+        }
+        if !skill_overrides.is_empty() {
+            matched.route.skills = Some(skill_overrides);
+        }
     }
 
     let gh_adapter = Arc::new(GitHubAdapter::new(gh));

--- a/crates/forza/tests/orchestrator.rs
+++ b/crates/forza/tests/orchestrator.rs
@@ -156,6 +156,7 @@ async fn issue_workflow_creates_run_record() {
         None,
         vec![],
         None,
+        None,
     )
     .await;
 
@@ -210,6 +211,7 @@ async fn worktree_cleaned_up_after_run() {
         git,
         None,
         vec![],
+        None,
         None,
     )
     .await;


### PR DESCRIPTION
## Summary
- Adds `--workflow` flag to `issue` and `pr` subcommands, allowing direct workflow execution without requiring a matching route (makes `[global]` the minimum viable config)
- Folds `watch` into `run --watch` with equivalent flags (`--interval`, `--serve-api`, etc.)
- Folds `fix` into `issue --fix` and `pr --fix` for re-running failed stages inline
- Legacy `watch` and `fix` top-level commands are hidden (`#[command(hide = true)]`) but preserved for backwards compatibility

## Files changed
- `crates/forza/src/main.rs` — Added `--workflow`, `--fix`, and `--watch` flags; hidden legacy commands; synthetic route construction for direct workflow dispatch
- `crates/forza/src/runner.rs` — Added `workflow_override: Option<String>` parameter to `process_issue` and `process_pr`; skip route-matching when override is set

## Test plan
- [ ] `cargo build -p forza` passes cleanly
- [ ] `cargo test --all` passes (10 existing tests, 0 failures)
- [ ] `forza issue <N> --workflow bug` runs without a matching route in config
- [ ] `forza run --watch` behaves identically to `forza watch`
- [ ] `forza issue <N> --fix` re-runs the latest failed stage for that issue
- [ ] `forza watch` and `forza fix` still work (hidden but not removed)

Closes #439