### PR TITLE
feat(cli): auto-dispatch plan issues from forza issue to plan --exec closes #444

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -1617,13 +1617,14 @@ async fn cmd_issue(
             }
         };
 
-        // Detect plan issues.
+        // Detect plan issues — auto-dispatch to plan --exec.
         if issue.labels.iter().any(|l| l == "forza:plan") {
-            eprintln!(
-                "issue #{} is a plan issue. Use `forza plan --exec {}` to execute it.",
-                issue.number, issue.number
+            tracing::info!(
+                "issue #{} is a plan issue; dispatching to plan --exec",
+                issue.number
             );
-            return ExitCode::FAILURE;
+            return cmd_plan_exec(issue.number, &repo, &rd, config, gh, git, true, false, None)
+                .await;
         }
 
         // Match route.
@@ -1677,15 +1678,15 @@ async fn cmd_issue(
         return ExitCode::SUCCESS;
     }
 
-    // Check for plan issues before processing.
+    // Check for plan issues before processing — auto-dispatch to plan --exec.
     if let Ok(issue) = gh.fetch_issue(&repo, args.number).await
         && issue.labels.iter().any(|l| l == "forza:plan")
     {
-        eprintln!(
-            "issue #{} is a plan issue. Use `forza plan --exec {}` to execute it.",
-            args.number, args.number
+        tracing::info!(
+            "issue #{} is a plan issue; dispatching to plan --exec",
+            args.number
         );
-        return ExitCode::FAILURE;
+        return cmd_plan_exec(args.number, &repo, &rd, config, gh, git, false, false, None).await;
     }
 
     // --fix: find latest failed run and re-process.


### PR DESCRIPTION
## Summary

- Auto-dispatches plan issues detected by `forza issue <N>` to `cmd_plan_exec` instead of returning an error with a manual instruction
- Handles both the dry-run path and the normal execution path in `cmd_issue`
- Replaces `eprintln!` error messages with `tracing::info!` for structured logging consistency
- Reuses the existing, well-tested `cmd_plan_exec` function with `close=false` and `branch_override=None` defaults

## Files changed

- `crates/forza/src/main.rs` — modified two plan-label detection branches in `cmd_issue` to call `cmd_plan_exec` instead of returning an error

## Test plan

- [ ] Run `forza issue <N>` where `<N>` is a plan issue (has the plan label); confirm it dispatches to `plan --exec` automatically
- [ ] Run `forza issue <N> --dry-run` with a plan issue; confirm dry-run is forwarded correctly
- [ ] Run `forza issue <N>` where `<N>` is a regular issue; confirm normal execution path is unaffected
- [ ] Run `cargo test --all` and confirm all existing tests pass

Closes #444