### PR TITLE
feat(explain): show builtin defaults when no config file exists closes #445

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -421,7 +421,7 @@ fn load_config(path: &std::path::Path) -> Result<forza::RunnerConfig, ExitCode> 
 ///
 /// - Explicit `--config PATH`: load it (error if missing).
 /// - No flag, `forza.toml` exists: load it.
-/// - No flag, `forza.toml` absent, command is `issue`/`pr`: return a default config.
+/// - No flag, `forza.toml` absent, command is `issue`/`pr`/`explain`: return a default config.
 /// - No flag, `forza.toml` absent, other commands: error with a hint.
 fn resolve_config(
     config_flag: &Option<PathBuf>,
@@ -434,7 +434,10 @@ fn resolve_config(
     if default_path.exists() {
         return load_config(&default_path);
     }
-    if matches!(command, Command::Issue(_) | Command::Pr(_)) {
+    if matches!(
+        command,
+        Command::Issue(_) | Command::Pr(_) | Command::Explain(_)
+    ) {
         return Ok(forza::RunnerConfig::default());
     }
     eprintln!("error: forza.toml not found");
@@ -2190,6 +2193,34 @@ async fn cmd_explain(
                 return ExitCode::FAILURE;
             }
         }
+    }
+
+    // No config file: show builtin defaults and return early.
+    if config.repos.is_empty() && config.global.repo.is_none() {
+        println!("No forza.toml found. Showing builtin defaults.");
+        println!("{}", "=".repeat(60));
+        println!();
+        println!("Agents:  claude, codex");
+        println!();
+        println!("Default labels:");
+        println!("  in-progress: forza:in-progress");
+        println!("  complete:    forza:complete");
+        println!("  failed:      forza:failed");
+        println!();
+        println!("Builtin Workflows");
+        println!("{}", "-".repeat(60));
+        for wf in forza_core::Workflow::builtins() {
+            let stages: Vec<&str> = wf.stages.iter().map(|s| s.kind.name()).collect();
+            let wt = if wf.needs_worktree {
+                ""
+            } else {
+                " (no worktree)"
+            };
+            println!("  {:<16} {}{wt}", wf.name, stages.join(" -> "));
+        }
+        println!();
+        println!("No routes configured.");
+        return ExitCode::SUCCESS;
     }
 
     // --workflows: list all workflow templates.


### PR DESCRIPTION
## Summary
- Adds `Command::Explain(_)` to the `resolve_config` fallback arm so `forza explain` no longer errors when no `forza.toml` exists
- When no config is found, `cmd_explain` detects the default state (`config.repos.is_empty() && config.global.repo.is_none()`) and prints a builtin-defaults banner instead of the per-repo loop
- Displays builtin workflows (via `Workflow::builtins()`), supported agents, default labels, and a "No routes configured" footer, then exits successfully
- Existing behavior for users with a config file is unchanged

## Files changed
- `crates/forza/src/main.rs` — added `Command::Explain(_)` to the no-config fallback in `resolve_config`; added early-return no-config block at the top of `cmd_explain`

## Test plan
- [ ] Run `forza explain` with no `forza.toml` present — should print builtin defaults and exit 0
- [ ] Run `forza explain` with a valid `forza.toml` — should behave exactly as before
- [ ] Run `forza explain --json` with no config — should serialize empty default config (consistent existing behavior)
- [ ] `cargo build -p forza` and `cargo clippy` pass with no warnings
- [ ] `cargo test --all` passes

Closes #445