### PR TITLE
feat(pipeline): include issue title in draft PR title closes #449

### DIFF
--- a/crates/forza-core/src/commands/draft_pr.sh
+++ b/crates/forza-core/src/commands/draft_pr.sh
@@ -5,7 +5,7 @@
 # If draft creation fails, exits 0 so the optional stage doesn't block.
 
 # Create an empty commit to establish a diff from main.
-git commit --allow-empty -m "wip: issue #$FORZA_SUBJECT_NUMBER [skip ci]" 2>/dev/null
+git commit --allow-empty -m "wip: $FORZA_SUBJECT_TITLE (#$FORZA_SUBJECT_NUMBER) [skip ci]" 2>/dev/null
 
 # Push the branch.
 git push origin HEAD 2>/dev/null || true
@@ -14,11 +14,11 @@ git push origin HEAD 2>/dev/null || true
 if [ -f .plan_breadcrumb.md ]; then
     BODY=$(cat .plan_breadcrumb.md)
 else
-    BODY="Work in progress for issue #$FORZA_SUBJECT_NUMBER"
+    BODY="Work in progress for $FORZA_SUBJECT_TITLE (#$FORZA_SUBJECT_NUMBER)"
 fi
 
 # Create the draft PR. If it fails (PR already exists, etc.), that's OK.
 gh pr create --draft \
-    --title "[WIP] issue #$FORZA_SUBJECT_NUMBER" \
+    --title "[WIP] $FORZA_SUBJECT_TITLE (#$FORZA_SUBJECT_NUMBER)" \
     --body "$BODY" \
     2>/dev/null || true

--- a/crates/forza-core/src/subject.rs
+++ b/crates/forza-core/src/subject.rs
@@ -96,6 +96,7 @@ impl Subject {
             ("FORZA_REPO", self.repo.clone()),
             ("FORZA_SUBJECT_TYPE", self.kind.as_str().to_string()),
             ("FORZA_SUBJECT_NUMBER", self.number.to_string()),
+            ("FORZA_SUBJECT_TITLE", self.title.clone()),
             ("FORZA_BRANCH", self.branch.clone()),
             ("FORZA_RUN_ID", run_id.to_string()),
             ("FORZA_ROUTE", route.to_string()),
@@ -182,6 +183,7 @@ mod tests {
         assert_eq!(map["FORZA_REPO"], "owner/repo");
         assert_eq!(map["FORZA_SUBJECT_TYPE"], "issue");
         assert_eq!(map["FORZA_SUBJECT_NUMBER"], "42");
+        assert_eq!(map["FORZA_SUBJECT_TITLE"], "Fix the bug");
         assert_eq!(map["FORZA_ISSUE_NUMBER"], "42");
         assert_eq!(map["FORZA_BRANCH"], "automation/42-fix-the-bug");
         assert_eq!(map["FORZA_RUN_ID"], "run-123");


### PR DESCRIPTION
## Summary
- Added `FORZA_SUBJECT_TITLE` to the environment variables emitted by `Subject::env_vars()`, exposing the issue/PR title to shell stages
- Updated `draft_pr.sh` to use `$FORZA_SUBJECT_TITLE` in the PR `--title` flag, producing `[WIP] <title> (#N)` instead of the generic `[WIP] issue #N`
- Updated the empty commit message and fallback PR body in `draft_pr.sh` to also include the subject title for consistency
- Updated the `env_vars_include_all_standard_vars` test to assert `FORZA_SUBJECT_TITLE` is present and correct

## Files changed
- `crates/forza-core/src/subject.rs` — Added `FORZA_SUBJECT_TITLE` to the `env_vars()` return vec; updated test assertion
- `crates/forza-core/src/commands/draft_pr.sh` — Updated PR title, empty commit message, and fallback body to use `$FORZA_SUBJECT_TITLE`

## Test plan
- All 135 unit tests pass (`cargo test --all`)
- `env_vars_include_all_standard_vars` test asserts `FORZA_SUBJECT_TITLE == "Fix the bug"`
- No shell injection risk: `FORZA_SUBJECT_TITLE` is interpolated inside double quotes, consistent with surrounding variable usage

Closes #449