### PR TITLE
feat(plan): apply forza:complete/failed label to plan issue after exec closes #451

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -996,6 +996,15 @@ async fn cmd_plan_exec(
         }
     }
 
+    let plan_label = if failed == 0 {
+        "forza:complete"
+    } else {
+        "forza:failed"
+    };
+    if let Err(e) = gh.add_label(repo, plan_number, plan_label).await {
+        eprintln!("warning: failed to apply label {plan_label} to #{plan_number}: {e}");
+    }
+
     println!(
         "\nPlan #{plan_number} complete: {succeeded} succeeded, {failed} failed, {} skipped",
         skipped.len().saturating_sub(failed)


### PR DESCRIPTION
## Summary

- After the `'levels` loop exits normally in `cmd_plan_exec`, applies `forza:complete` to the plan issue if all sub-issues succeeded, or `forza:failed` if any failed
- The early-return `NeedsHumanMerge` path is unaffected — no label applied while paused, matching the spec
- Label application is best-effort (warns on failure, non-fatal), consistent with `lifecycle::release` error-handling patterns

## Files changed

- `crates/forza/src/main.rs` — added 9 lines after the `'levels` loop to apply the appropriate lifecycle label to the plan issue

## Test plan

- [ ] Run `forza plan --exec <N>` against a plan issue where all sub-issues succeed and verify `forza:complete` label is applied
- [ ] Run `forza plan --exec <N>` against a plan issue where at least one sub-issue fails and verify `forza:failed` label is applied
- [ ] Trigger a `NeedsHumanMerge` early-return and verify no label is applied to the plan issue
- [ ] Confirm label-application errors are non-fatal (warn only)

Closes #451