### PR TITLE
fix(git): detect default branch instead of hardcoding origin/main

### DIFF
--- a/crates/forza/src/api.rs
+++ b/crates/forza/src/api.rs
@@ -1022,6 +1022,9 @@ mod tests {
         async fn create_branch_from(&self, _: &Path, _: &str, _: &str) -> crate::error::Result<()> {
             unimplemented!()
         }
+        async fn default_branch(&self, _: &Path) -> crate::error::Result<String> {
+            unimplemented!()
+        }
         async fn version(&self) -> crate::error::Result<String> {
             unimplemented!()
         }

--- a/crates/forza/src/git/cli.rs
+++ b/crates/forza/src/git/cli.rs
@@ -81,7 +81,8 @@ impl GitClient for GitCliClient {
             )
             .await?
         } else {
-            // New branch — create from origin/main.
+            // New branch — create from the repo's default branch.
+            let base = self.default_branch(repo_dir).await?;
             git(
                 &[
                     "worktree",
@@ -89,7 +90,7 @@ impl GitClient for GitCliClient {
                     "-b",
                     branch,
                     &worktree_dir.to_string_lossy(),
-                    "origin/main",
+                    &base,
                 ],
                 repo_dir,
             )
@@ -196,6 +197,19 @@ impl GitClient for GitCliClient {
         }
         git_ok(&["branch", branch, base], repo_dir).await?;
         Ok(())
+    }
+
+    async fn default_branch(&self, repo_dir: &Path) -> Result<String> {
+        let output = git(&["symbolic-ref", "refs/remotes/origin/HEAD"], repo_dir).await?;
+        if output.status.success() {
+            let sym = String::from_utf8_lossy(&output.stdout);
+            // "refs/remotes/origin/main\n" -> strip "refs/remotes/" prefix
+            let branch = sym.trim().trim_start_matches("refs/remotes/");
+            if !branch.is_empty() {
+                return Ok(branch.to_string());
+            }
+        }
+        Ok("origin/main".to_string())
     }
 
     async fn version(&self) -> Result<String> {

--- a/crates/forza/src/git/gix_client.rs
+++ b/crates/forza/src/git/gix_client.rs
@@ -73,8 +73,9 @@ impl GitClient for GixClient {
         let output = if remote_exists || local_exists {
             git_cli(&["worktree", "add", &dir_str, branch], repo_dir).await?
         } else {
+            let base = self.default_branch(repo_dir).await?;
             git_cli(
-                &["worktree", "add", "-b", branch, &dir_str, "origin/main"],
+                &["worktree", "add", "-b", branch, &dir_str, &base],
                 repo_dir,
             )
             .await?
@@ -205,6 +206,18 @@ impl GitClient for GixClient {
             return Err(Error::Git(format!("git branch failed: {stderr}")));
         }
         Ok(())
+    }
+
+    async fn default_branch(&self, repo_dir: &Path) -> Result<String> {
+        let output = git_cli(&["symbolic-ref", "refs/remotes/origin/HEAD"], repo_dir).await?;
+        if output.status.success() {
+            let sym = String::from_utf8_lossy(&output.stdout);
+            let branch = sym.trim().trim_start_matches("refs/remotes/");
+            if !branch.is_empty() {
+                return Ok(branch.to_string());
+            }
+        }
+        Ok("origin/main".to_string())
     }
 
     async fn version(&self) -> Result<String> {

--- a/crates/forza/src/git/mod.rs
+++ b/crates/forza/src/git/mod.rs
@@ -82,6 +82,12 @@ pub trait GitClient: Send + Sync {
     /// Fetches from origin first, then creates the branch if it does not exist.
     async fn create_branch_from(&self, repo_dir: &Path, branch: &str, base: &str) -> Result<()>;
 
+    /// Detect the default remote branch (e.g. `origin/main` or `origin/master`).
+    ///
+    /// Resolves `refs/remotes/origin/HEAD` via `git symbolic-ref`. Falls back
+    /// to `"origin/main"` if the ref is unset or the command fails.
+    async fn default_branch(&self, repo_dir: &Path) -> Result<String>;
+
     /// Check if git is available and return version string.
     async fn version(&self) -> Result<String>;
 }


### PR DESCRIPTION
## Summary

- Both `GitCliClient` and `GixClient` hardcoded `"origin/main"` as the base ref when creating worktree branches, causing failures on repos with non-`main` default branches
- Adds a `default_branch()` method to the `GitClient` trait that resolves `refs/remotes/origin/HEAD` via `git symbolic-ref`, falling back to `"origin/main"` if unresolvable
- Both `cli.rs` and `gix_client.rs` implement `default_branch()` and update `worktree_add` to call it instead of using the hardcoded string

## Files changed

- `crates/forza/src/git/mod.rs` — adds `default_branch()` to `GitClient` trait
- `crates/forza/src/git/cli.rs` — implements `default_branch()` in `GitCliClient`, updates `worktree_add`
- `crates/forza/src/git/gix_client.rs` — implements `default_branch()` in `GixClient`, updates `worktree_add`

## Test plan

- [ ] Verify existing tests pass: `cargo test --all`
- [ ] Manually test `forza issue` or `forza pr` on a repo whose default branch is not `main` (e.g. named `master` or `develop`)
- [ ] Verify worktree creation succeeds and branches from the correct upstream ref

Closes #454