### PR TITLE
refactor(cli): remove --route from forza pr, consolidate to --fix/--workflow

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -131,7 +131,7 @@ struct IssueArgs {
 
 #[derive(Debug, Parser)]
 #[command(
-    after_long_help = "Examples:\n  forza pr 123\n  forza pr 123 --route fix-pr\n  forza pr 123 --dry-run\n  forza pr 123 --workflow pr-fix\n  forza pr 123 --fix"
+    after_long_help = "Examples:\n  forza pr 123\n  forza pr 123 --dry-run\n  forza pr 123 --workflow pr-fix\n  forza pr 123 --fix"
 )]
 struct PrArgs {
     /// PR number to process.
@@ -151,9 +151,6 @@ struct PrArgs {
     /// Add a skill file for every stage in this run (repeatable).
     #[arg(long, action = clap::ArgAction::Append)]
     skill: Vec<String>,
-    /// Force a specific route by name, bypassing label-based matching.
-    #[arg(long)]
-    route: Option<String>,
     /// Override the workflow template, skipping route matching (e.g. pr-fix, pr-rebase).
     #[arg(long)]
     workflow: Option<String>,
@@ -1791,20 +1788,14 @@ async fn cmd_pr(
             }
         };
 
-        let (route_name, route) = if let Some(ref rn) = args.route
-            && let Some(r) = routes.get(rn)
-        {
-            (rn.as_str(), r)
-        } else {
-            match forza::RunnerConfig::match_pr_route_in(routes, &pr) {
-                Some(r) => r,
-                None => {
-                    eprintln!(
-                        "no route matches PR #{} (labels: {:?})",
-                        pr.number, pr.labels
-                    );
-                    return ExitCode::FAILURE;
-                }
+        let (route_name, route) = match forza::RunnerConfig::match_pr_route_in(routes, &pr) {
+            Some(r) => r,
+            None => {
+                eprintln!(
+                    "no route matches PR #{} (labels: {:?})",
+                    pr.number, pr.labels
+                );
+                return ExitCode::FAILURE;
             }
         };
 
@@ -1866,7 +1857,7 @@ async fn cmd_pr(
             git.clone(),
             args.model,
             args.skill,
-            args.route,
+            None,
             args.workflow,
         )
         .await
@@ -1890,7 +1881,7 @@ async fn cmd_pr(
         git.clone(),
         args.model,
         args.skill,
-        args.route,
+        None,
         args.workflow,
     )
     .await


### PR DESCRIPTION
## Summary

- Removes `--route` flag from `forza pr` CLI; routes are a discovery/batch concept (`run`/`watch`) and not meaningful for direct single-PR invocation
- Consolidates PR intent flags to `--fix` (shorthand) and `--workflow` (power-user override), reducing CLI surface area
- Adds `FORZA_SUBJECT_TITLE` env var to `Subject::env_vars()` and uses it in `draft_pr.sh` for more descriptive commit/PR messages
- Adds `default_branch` trait method to `GitClient`, replacing hardcoded `origin/main` fallback

## Files changed

- `crates/forza/src/main.rs` — removed `PrArgs.route` field, updated help text and `after_long_help` examples, both `process_pr` call sites now pass `None` for `route_override`
- `crates/forza-core/src/subject.rs` — added `FORZA_SUBJECT_TITLE` to `env_vars()` with test assertion
- `crates/forza-core/src/commands/draft_pr.sh` — uses `$FORZA_SUBJECT_TITLE` in commit message and `gh pr create` title/body
- `crates/forza-core/src/traits.rs` — added `default_branch` method to `GitClient` trait
- `crates/forza/src/github/` — implemented `default_branch` on `GitCliClient` and `GixClient` via `git symbolic-ref`
- `crates/forza/src/api.rs` — added `unimplemented!()` stub for `default_branch` on mock

## Test plan

- [ ] `cargo test --all` passes
- [ ] `cargo clippy --all --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean
- [ ] `forza pr <N>` no longer accepts `--route`; `--fix` and `--workflow` work as before
- [ ] `FORZA_SUBJECT_TITLE` is set in shell env during `draft_pr` stage execution

Closes #453