### PR TITLE
docs: release readiness — align docs with current CLI surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,24 +148,24 @@ cargo doc --no-deps --all-features
 
 ```
 forza init          Create labels and generate starter config
-forza issue <N>     Process a single issue
-forza pr <N>        Process a single PR
-forza run           Single batch cycle (discover + process)
-forza watch         Continuous polling loop
-forza status        View run history
-forza explain       Visualize config, routes, and workflows
-forza fix           Re-run failed stages
+forza issue <N>     Process a single issue (--workflow for configless, --fix to retry)
+forza pr <N>        Process a single PR (--workflow for configless, --fix to retry)
+forza run           Single batch cycle (--watch for continuous polling)
+forza plan          Create, revise, or execute a plan
+forza open          Open a new issue with agent assistance
+forza status        View run history and plan execution tracking
+forza explain       Visualize config, routes, workflows (--plans for plan issues)
 forza clean         Clean worktrees and state
 forza serve         REST API server
 forza mcp           MCP server (stdio)
-forza plan          Create, revise, or execute a plan
 ```
 
-`forza explain` supports filters: `--issues`, `--prs`, `--conditions`, `--route <name>`,
-`--workflows`, `--workflow <name>`, `-v` (verbose), `--json`.
+`forza issue` and `forza pr` work without `forza.toml` when `--workflow` is provided.
+Config is only required for automated discovery via `forza run`.
 
 `forza plan` modes:
 - `forza plan [issues]` — analyze issues, create a plan issue with mermaid dependency graph
 - `forza plan --revise <N>` — revise plan issue #N based on human comments
 - `forza plan --exec <N>` — execute plan issue #N in dependency order
-- `--label`, `--limit`, `--model` flags for filtering and configuration
+- `forza plan --exec <N> --dry-run` — preview execution order
+- `--branch`, `--close`, `--label`, `--limit`, `--model` for additional control

--- a/README.md
+++ b/README.md
@@ -11,22 +11,18 @@ Autonomous GitHub issue runner. Turns issues into pull requests through configur
 GitHub Issue  ->  Route Match  ->  Workflow  ->  Stages  ->  Pull Request
 ```
 
-Label an issue `forza:ready`, configure a route, and forza plans, implements, tests, reviews, and opens a PR — then merges when CI is green.
-
 ## Quick start
 
 ```bash
 # Install
 cargo install forza
 
-# Initialize a repo (creates labels and starter config)
+# Process a single issue (no config needed)
+forza issue 42 --workflow feature
+
+# With a config file for automated workflows
 forza init --repo owner/name
-
-# Process a single issue
-forza issue 123
-
-# Continuous polling loop
-forza watch --interval 60
+forza run --watch
 ```
 
 ## Planning
@@ -43,19 +39,24 @@ forza plan 42 45 48
 # Revise a plan based on human feedback
 forza plan --revise 99
 
+# Preview execution order
+forza plan --exec 99 --dry-run
+
 # Execute a plan in dependency order
 forza plan --exec 99
 ```
 
 The plan issue includes a mermaid dependency graph (rendered by GitHub), actionable issues in order, blocked issues with reasons, and skipped issues. Blocked issues get `forza:needs-human` labels and explanatory comments.
 
+## Configuration
+
+forza works without configuration for direct commands (`issue`, `pr`). Add a `forza.toml` when you want automated discovery via `forza run`.
+
 Minimal `forza.toml`:
 
 ```toml
 [global]
 model = "claude-sonnet-4-6"
-
-[repos."owner/name"]
 
 [repos."owner/name".routes.bugfix]
 type = "issue"

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -28,22 +28,12 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/joshrotenberg/forz
 cargo install forza
 ```
 
-### 2. Initialize your repository
+### 2. Process your first issue
 
-Run the guided setup in your repository directory:
-
-```bash
-forza init --repo owner/name
-```
-
-This creates the required GitHub labels (`forza:ready`, `forza:in-progress`, `forza:complete`, `forza:failed`, `forza:needs-human`) and writes a starter `forza.toml` to the current directory.
-
-### 3. Process your first issue
-
-Label an issue with `bug` and `forza:ready`, then run:
+No configuration needed. From inside any repo with a GitHub remote:
 
 ```bash
-forza issue 123
+forza issue 42 --workflow feature
 ```
 
 Forza picks up the issue, plans the fix, implements it, runs tests, and opens a PR.
@@ -51,21 +41,34 @@ Forza picks up the issue, plans the fix, implements it, runs tests, and opens a 
 To preview without executing:
 
 ```bash
-forza issue 123 --dry-run
+forza issue 42 --workflow feature --dry-run
+```
+
+### 3. Add configuration (optional)
+
+For automated discovery and continuous processing, initialize your repo:
+
+```bash
+forza init --repo owner/name
+```
+
+This creates the required GitHub labels and writes a starter `forza.toml`. Then:
+
+```bash
+# Run one batch cycle
+forza run
+
+# Continuous polling
+forza run --watch
 ```
 
 ## Minimal configuration
 
-The simplest possible setup — one repo, one bug route, all defaults:
+The simplest setup — one repo, one bug route:
 
 ```toml
 [global]
 model = "claude-sonnet-4-6"
-
-[security]
-authorization_level = "contributor"
-
-[repos."your-org/your-repo"]
 
 [repos."your-org/your-repo".routes.bugfix]
 type = "issue"
@@ -73,27 +76,39 @@ label = "bug"
 workflow = "bug"
 ```
 
-Save this as `forza.toml` in your working directory.
+Save as `forza.toml` in your working directory.
 
 ## Common commands
 
 ```bash
-# Process a single issue
-forza issue 123
+# Process a single issue (configless)
+forza issue 42 --workflow feature
 
-# Fix a PR (rebase + fix CI)
-forza pr 42
+# Process a single issue (with config, route matching)
+forza issue 42
 
-# Run one batch cycle (discover + process all eligible issues)
+# Fix a PR
+forza pr 123 --workflow pr-fix
+
+# Re-run a failed issue with error context
+forza issue 42 --fix
+
+# Plan a batch of issues
+forza plan 10 20 30
+
+# Execute a plan in dependency order
+forza plan --exec 99
+
+# Run one batch cycle (requires config)
 forza run
 
-# Continuous polling loop
-forza watch --interval 60
+# Continuous polling (requires config)
+forza run --watch --interval 60
 
 # View run history
 forza status
 
-# Visualize your config, routes, and workflows
+# Visualize config, routes, and workflows
 forza explain
 ```
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -14,7 +14,7 @@ GitHub Issue  ->  Route Match  ->  Workflow  ->  Stages  ->  Pull Request  ->  A
 
 When an issue is labeled (or a PR enters a matching state), forza:
 
-1. **Picks it up** — the watch loop finds issues with `forza:ready` or PRs matching a condition route
+1. **Picks it up** — the polling loop finds issues with `forza:ready` or PRs matching a condition route
 2. **Matches a route** — compares the label or PR state against your configured routes to select a workflow
 3. **Executes stages** — runs each stage in order (e.g., plan → implement → test → review → open_pr), with validation commands between stages and breadcrumbs carrying context forward
 4. **Opens a PR** — commits the work to an isolated git worktree and opens a PR against your branch
@@ -36,12 +36,14 @@ Adding decision-making to the framework — adaptive prompting, automatic workfl
 
 ## When to use forza
 
-**Solo developer** — label a backlog issue `forza:ready` and let forza open a PR while you work on something else. Good for bug fixes, dependency updates, documentation PRs, and chores that follow a clear pattern.
+**Quick one-off** — process a single issue with no configuration: `forza issue 42 --workflow feature`. Forza plans, implements, tests, reviews, and opens a PR. Good for bug fixes, chores, and anything with a clear spec.
 
-**Team with an issue backlog** — apply `forza:ready` to issues you're comfortable automating. Forza triages, plans, and implements while the team focuses on review. Pair with `gate_label` so nothing runs until you've explicitly opted it in.
+**Solo developer** — add a `forza.toml` with routes, label issues `forza:ready`, and let forza open PRs while you work on something else. Run `forza run --watch` for continuous processing.
 
-**CI maintenance** — configure condition routes (`ci_failing_or_conflicts`, `approved_and_green`) so forza watches your forza-owned PRs and fixes failures, rebases stale branches, and merges when green — without anyone having to manually re-trigger CI or click merge.
+**Team with an issue backlog** — apply `forza:ready` to issues you're comfortable automating. Use `forza plan` to organize a batch, review the plan, then `forza plan --exec` to process them all in dependency order.
 
-**Research and exploration** — use a `research` route with the `research -> comment` workflow. Forza investigates a question (API compatibility, migration path, alternative approaches) and posts findings directly on the issue as a comment. No code changes, no PR.
+**CI maintenance** — configure condition routes (`ci_failing_or_conflicts`, `approved_and_green`) so forza watches your PRs and fixes failures, rebases stale branches, and merges when green — without anyone having to manually re-trigger CI or click merge.
+
+**Research and exploration** — use a `research` route with the `research -> comment` workflow. Forza investigates a question and posts findings directly on the issue as a comment. No code changes, no PR.
 
 **Batch planning** — use `forza plan` to analyze a set of issues at once. The agent reads the codebase, classifies issues, detects dependencies, and creates a plan issue with a mermaid dependency graph and implementation order. Review the plan, comment to adjust, then `forza plan --exec` processes them in dependency order.

--- a/docs/src/usage/cli-reference.md
+++ b/docs/src/usage/cli-reference.md
@@ -7,7 +7,7 @@
 Create the required GitHub labels and generate a starter `forza.toml`:
 
 ```
-forza init --repo <owner/name> [--output <path>] [--auto] [--guided] [--model <model>] [--config <path>]
+forza init --repo <owner/name> [--output <path>] [--auto] [--guided] [--model <model>]
 ```
 
 | Flag | Description |
@@ -16,7 +16,7 @@ forza init --repo <owner/name> [--output <path>] [--auto] [--guided] [--model <m
 | `--output <path>` | Output path for the generated config file (default: `forza.toml`) |
 | `--auto` | Use an agent to inspect the repo and generate a tailored config |
 | `--guided` | Launch an interactive Claude session to collaboratively generate a config |
-| `--model <model>` | Model to use for agent-assisted config generation (e.g. `claude-opus-4-6`) |
+| `--model <model>` | Model to use for agent-assisted config generation |
 
 This is a one-time setup command. It is idempotent — safe to run on a repo that already has some of the labels.
 
@@ -25,81 +25,99 @@ This is a one-time setup command. It is idempotent — safe to run on a repo tha
 Process a single issue by number:
 
 ```
-forza issue <N> [--repo <owner/name>] [--repo-dir <path>] [--dry-run] [--model <model>] [--skill <path>...] [--config <path>]
+forza issue <N> [--workflow <name>] [--model <model>] [--fix] [--dry-run] [--skill <path>...]
 ```
 
 | Flag | Description |
 |------|-------------|
+| `--workflow <name>` | Override the workflow template, skipping route matching (e.g. `feature`, `bug`, `chore`) |
+| `--model <model>` | Override the model for every stage in this run |
+| `--fix` | Re-run the latest failed run for this issue with error context |
+| `--dry-run` | Show the plan without executing |
+| `--skill <path>` | Add a skill file for every stage (repeatable) |
 | `--repo <owner/name>` | Repository to process (required when multiple repos are configured) |
 | `--repo-dir <path>` | Repository directory (default: current directory) |
-| `--dry-run` | Show the plan without executing |
-| `--model <model>` | Override the model for every stage in this run |
-| `--skill <path>` | Add a skill file for every stage in this run (repeatable) |
 
-Fetches the issue, matches a route, and executes the workflow. Use `--dry-run` to preview the match and planned stages without executing.
+When `--workflow` is provided, no `forza.toml` is required — forza infers the repo from the git remote and uses the specified workflow directly. Without `--workflow`, forza matches the issue's labels against configured routes.
+
+If the issue has the `forza:plan` label, forza automatically executes it as a plan instead.
 
 ### forza pr
 
 Process a single PR by number:
 
 ```
-forza pr <N> [--repo <owner/name>] [--repo-dir <path>] [--dry-run] [--model <model>] [--skill <path>...] [--config <path>]
+forza pr <N> [--workflow <name>] [--model <model>] [--fix] [--dry-run] [--skill <path>...]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--repo <owner/name>` | Repository to process (required when multiple repos are configured) |
-| `--repo-dir <path>` | Repository directory (default: current directory) |
-| `--dry-run` | Show the plan without executing |
+| `--workflow <name>` | Override the workflow template, skipping route matching (e.g. `pr-fix`, `pr-rebase`) |
 | `--model <model>` | Override the model for every stage in this run |
-| `--skill <path>` | Add a skill file for every stage in this run (repeatable) |
+| `--fix` | Re-run the latest failed run for this PR with error context |
+| `--dry-run` | Show the plan without executing |
+| `--skill <path>` | Add a skill file for every stage (repeatable) |
+| `--repo <owner/name>` | Repository to process |
+| `--repo-dir <path>` | Repository directory (default: current directory) |
 
-Fetches the PR, matches a condition or label route, and executes the workflow.
+Like `forza issue`, the `--workflow` flag enables configless usage for one-off PR operations.
 
 ### forza run
 
 Discover and process one batch of eligible issues and PRs:
 
 ```
-forza run [--route <name>] [--repo-dir <path>] [--no-gate] [--config <path>]
+forza run [--watch] [--interval <seconds>] [--route <name>] [--no-gate] [--serve-api]
 ```
 
 | Flag | Description |
 |------|-------------|
+| `--watch` | Continuous polling mode — runs repeatedly on the configured poll interval |
+| `--interval <seconds>` | Override poll interval in seconds (watch mode only) |
 | `--route <name>` | Only run a specific route |
-| `--repo-dir <path>` | Repository directory (default: current directory) |
 | `--no-gate` | Bypass the gate_label requirement and process all matching issues immediately |
-
-Equivalent to one iteration of the watch loop. Useful for running forza from a cron job or CI.
-
-### forza watch
-
-Continuous polling loop with auto-fix:
-
-```
-forza watch [--interval <seconds>] [--route <name>] [--repo-dir <path>]
-            [--serve-api] [--api-host <host>] [--api-port <port>]
-            [--no-gate] [--config <path>]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--interval <seconds>` | Override poll interval in seconds (uses per-route intervals by default) |
-| `--route <name>` | Only run a specific route |
+| `--serve-api` | Also start the REST API server alongside the watch loop (watch mode only) |
+| `--api-host <host>` | Host for the API server (default: `127.0.0.1`, watch mode only) |
+| `--api-port <port>` | Port for the API server (default: `8080`, watch mode only) |
 | `--repo-dir <path>` | Repository directory |
-| `--serve-api` | Also start the REST API server alongside the watch loop |
-| `--api-host <host>` | Host address for the REST API server (default: `127.0.0.1`) |
-| `--api-port <port>` | Port for the REST API server (default: `8080`) |
-| `--no-gate` | Bypass the gate_label requirement and process all matching issues immediately |
 
-Runs `forza run` on the configured `poll_interval` for each route, indefinitely. Use `Ctrl+C` to stop.
+Without `--watch`, runs a single discovery and processing cycle. With `--watch`, runs continuously until stopped with `Ctrl+C`. Requires a `forza.toml` with configured routes.
+
+### forza plan
+
+Create, revise, or execute a plan for a set of issues:
+
+```
+forza plan [ISSUES...] [--revise <N>] [--exec <N>] [--dry-run] [--close] [--branch <name>]
+```
+
+| Flag | Description |
+|------|-------------|
+| `[ISSUES...]` | Issue numbers to plan: single (`42`), multiple (`10 20 30`), range (`10..20`). Omit for all open issues |
+| `--label <label>` | Only plan issues with this label |
+| `--revise <N>` | Revise plan issue #N based on human comments |
+| `--exec <N>` | Execute plan issue #N in dependency order |
+| `--dry-run` | Preview execution order without processing (use with `--exec`) |
+| `--close` | Close the plan issue after all items are executed (use with `--exec`) |
+| `--branch <name>` | Target a plan branch for all PRs (e.g. `plan/my-feature`) |
+| `--model <model>` | Override the model |
+| `--limit <N>` | Maximum issues to fetch (default: 50) |
+| `--repo <owner/name>` | Repository (required when multiple repos configured) |
+
+**Three modes:**
+
+- **Create** (default) — Analyzes issues, reads the codebase, and creates a plan issue with a mermaid dependency graph, actionable issues in order, blocked issues with reasons, and skipped issues. Blocked issues get `forza:needs-human` labels and explanatory comments.
+
+- **Revise** (`--revise <N>`) — Reads the plan issue and its comments, then updates the plan based on human feedback. Adjusts ordering, moves issues between sections, and updates labels.
+
+- **Execute** (`--exec <N>`) — Parses the mermaid dependency graph, topologically sorts it, and processes each actionable issue through its workflow pipeline. Issues with unresolved dependencies are skipped. Completed issues (`forza:complete`) are skipped on re-run, enabling resume after interruption.
 
 ### forza status
 
 Show run history and outcomes:
 
 ```
-forza status [--all] [--detailed] [--run-id <id>] [--workflow <name>] [--config <path>]
+forza status [--all] [--detailed] [--run-id <id>] [--workflow <name>]
 ```
 
 | Flag | Description |
@@ -109,16 +127,14 @@ forza status [--all] [--detailed] [--run-id <id>] [--workflow <name>] [--config 
 | `--run-id <id>` | Show a specific run by ID |
 | `--workflow <name>` | Filter dashboard to a single workflow |
 
-Displays recent runs with their route, workflow, outcome, and cost.
+Displays recent runs with their route, workflow, outcome, and cost. Also shows plan execution history when plan issues exist.
 
 ### forza explain
 
 Visualize your config, routes, and workflows:
 
 ```
-forza explain [--repo <owner/name>] [--issues] [--prs] [--conditions]
-              [--route <name>] [--workflows] [--workflow <name>]
-              [-v] [--json] [--config path]
+forza explain [--issues] [--prs] [--conditions] [--route <name>] [--workflows] [--plans] [--json]
 ```
 
 | Flag | Description |
@@ -130,122 +146,67 @@ forza explain [--repo <owner/name>] [--issues] [--prs] [--conditions]
 | `--route <name>` | Show a single route in detail (auto-verbose) |
 | `--workflows` | List all workflow templates |
 | `--workflow <name>` | Show a single workflow's stages |
+| `--plans` | Show open plan issues and their execution status |
 | `-v` / `--verbose` | Verbose output — show per-stage detail |
-| `--json` | Output as JSON instead of human-readable text |
+| `--json` | Output as JSON |
 
-Useful for verifying that routes are configured correctly before running.
-
-### forza fix
-
-Re-run failed stages with error context:
-
-```
-forza fix [--run <id>] [--issue <N>] [--config <path>]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--run <id>` | Run ID to fix (default: latest run) |
-| `--issue <N>` | Issue number to fix (finds latest run for this issue) |
-
-Picks up where a failed run left off, passing the failure reason as additional context to the agent.
+When no `forza.toml` exists, shows builtin defaults (available workflows, labels, agents).
 
 ### forza clean
 
 Remove worktrees and run state:
 
 ```
-forza clean [--repo-dir <path>] [--runs] [--stale] [--days <N>] [--dry-run] [--config <path>]
+forza clean [--runs] [--stale] [--days <N>] [--dry-run]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `--repo-dir <path>` | Repository directory (default: current directory) |
 | `--runs` | Remove run state files instead of worktrees |
-| `--stale` | Remove only worktrees older than the configured threshold (see `--days`) |
-| `--days <N>` | Age threshold in days for `--stale` (overrides the configured default) |
+| `--stale` | Remove only worktrees older than the configured threshold |
+| `--days <N>` | Age threshold in days for `--stale` |
 | `--dry-run` | Print what would be removed without acting |
-
-Removes stale git worktrees created by forza and cleans up local run state.
-
-### forza serve
-
-Start the REST API server:
-
-```
-forza serve [--host <host>] [--port <port>] [--repo-dir <path>] [--config <path>]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--host <host>` | Host address to bind to (default: `127.0.0.1`) |
-| `--port <port>` | Port to listen on (default: `8080`) |
-| `--repo-dir <path>` | Repository directory |
-
-Starts an HTTP server exposing the forza API. See [REST API](../advanced/api.md) for endpoint documentation.
-
-### forza mcp
-
-Start the MCP server:
-
-```
-forza mcp [--http] [--host <host>] [--port <port>] [--config <path>]
-```
-
-| Flag | Description |
-|------|-------------|
-| `--http` | Use HTTP/SSE transport instead of stdio |
-| `--host <host>` | Host address to bind to, HTTP mode only (default: `127.0.0.1`) |
-| `--port <port>` | Port to listen on, HTTP mode only (default: `8080`) |
-
-Starts an MCP server on stdio. See [MCP Server](../advanced/mcp.md) for tool documentation.
 
 ### forza open
 
 Open a new GitHub issue using agent assistance:
 
 ```
-forza open [--repo <owner/name>] [--prompt <text>] [--label <label>] [--ready] [--model <model>] [--config <path>]
+forza open [--repo <owner/name>] [--prompt <text>] [--label <label>] [--ready] [--model <model>]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--repo <owner/name>` | Repository to open an issue in (required when multiple repos are configured) |
+| `--repo <owner/name>` | Repository to open an issue in |
 | `--prompt <text>` | Prompt describing the issue to open |
 | `--label <label>` | Label to apply to the created issue |
-| `--ready` | Also add the `forza:ready` label to the created issue |
-| `--model <model>` | Override the model (e.g. `claude-opus-4-6`) |
+| `--ready` | Also add the `forza:ready` label |
+| `--model <model>` | Override the model |
 
-### forza plan
+### forza serve
 
-Create, revise, or execute a plan for a set of issues:
+Start the REST API server:
 
 ```
-forza plan [ISSUES...] [--label <label>] [--repo <owner/name>] [--revise <N>] [--exec <N>] [--model <model>] [--limit <N>] [--config <path>]
+forza serve [--host <host>] [--port <port>] [--repo-dir <path>]
 ```
 
-| Flag | Description |
-|------|-------------|
-| `[ISSUES...]` | Issue numbers to plan. Supports single (`42`), multiple (`10 20 30`), range (`10..20`). Omit to plan all open issues. |
-| `--label <label>` | Only plan issues with this label |
-| `--repo <owner/name>` | Repository (required when multiple repos are configured) |
-| `--revise <N>` | Revise an existing plan issue based on new comments |
-| `--exec <N>` | Execute a plan issue: process actionable items in dependency order |
-| `--model <model>` | Override the model (e.g. `claude-opus-4-6`) |
-| `--limit <N>` | Maximum issues to fetch when no specific issues are given (default: 50) |
+See [REST API](../advanced/api.md) for endpoint documentation.
 
-**Three modes:**
+### forza mcp
 
-- **Create** (default) — Analyzes the selected issues and creates a plan issue with a mermaid dependency graph, actionable issues in order, blocked issues with reasons, and skipped issues. Blocked issues get `forza:needs-human` labels and explanatory comments.
+Start the MCP server:
 
-- **Revise** (`--revise <N>`) — Reads the plan issue and its comments, then updates the plan based on human feedback. Adjusts ordering, moves issues between sections, and updates `forza:needs-human` labels as needed.
+```
+forza mcp [--http] [--host <host>] [--port <port>]
+```
 
-- **Execute** (`--exec <N>`) — Parses the mermaid dependency graph from the plan issue, topologically sorts it, and processes each actionable issue through its normal workflow pipeline. If an issue fails, dependent issues are skipped.
+See [MCP Server](../advanced/mcp.md) for tool documentation.
 
 ## Global flags
 
 | Flag | Description |
 |------|-------------|
-| `--config <path>` / `-c` | Path to `forza.toml` (default: `./forza.toml`) |
+| `--config <path>` / `-c` | Path to `forza.toml`. Optional for `issue` and `pr` commands when `--workflow` is provided |
 | `--log-file <path>` | Write tracing output to this file instead of stderr |
-| `--dry-run` | Preview actions without executing (supported on `issue`, `pr`) |


### PR DESCRIPTION
## Summary

- README: configless-first quickstart, plan section, remove deprecated watch reference
- CLI reference: complete rewrite matching current `--help` output for all commands
- CLAUDE.md: updated CLI reference section
- Getting started: configless quickstart, config as optional second step
- Introduction: updated use cases

Closes #462

## Not in this PR

- REST API surface alignment (workflow/model/fix params on trigger endpoints)
- MCP server surface alignment (same)

These are code changes, not docs — separate PR.