### PR TITLE
feat(api,mcp): add workflow and model overrides to trigger endpoints

### DIFF
--- a/crates/forza/src/api.rs
+++ b/crates/forza/src/api.rs
@@ -121,6 +121,10 @@ impl From<crate::state::WorkflowSummary> for WorkflowSummaryResponse {
 struct TriggerQuery {
     repo: Option<String>,
     dry_run: Option<bool>,
+    /// Override the workflow template, skipping route matching.
+    workflow: Option<String>,
+    /// Override the model for every stage.
+    model: Option<String>,
 }
 
 // --- Repo resolution ---
@@ -280,6 +284,8 @@ async fn trigger_issue(
         .into_response());
     }
 
+    let model_override = query.model.clone();
+    let workflow_override = query.workflow.clone();
     let config = state.config.clone();
     let state_dir = state.state_dir.clone();
     let gh = state.gh.clone();
@@ -294,10 +300,10 @@ async fn trigger_issue(
             &rd,
             gh,
             git,
-            None,
+            model_override,
             vec![],
             None,
-            None,
+            workflow_override,
         )
         .await
         {
@@ -366,6 +372,8 @@ async fn trigger_pr(
         .into_response());
     }
 
+    let model_override = query.model.clone();
+    let workflow_override = query.workflow.clone();
     let config = state.config.clone();
     let state_dir = state.state_dir.clone();
     let gh = state.gh.clone();
@@ -380,10 +388,10 @@ async fn trigger_pr(
             &rd,
             gh,
             git,
-            None,
+            model_override,
             vec![],
             None,
-            None,
+            workflow_override,
         )
         .await
         {

--- a/crates/forza/src/mcp.rs
+++ b/crates/forza/src/mcp.rs
@@ -63,6 +63,10 @@ struct IssueRunInput {
     number: u64,
     /// Repository (owner/name). Required when multiple repos are configured.
     repo: Option<String>,
+    /// Override the workflow template, skipping route matching (e.g. "feature", "bug").
+    workflow: Option<String>,
+    /// Override the model for every stage (e.g. "claude-opus-4-6").
+    model: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -71,6 +75,10 @@ struct PrRunInput {
     number: u64,
     /// Repository (owner/name). Required when multiple repos are configured.
     repo: Option<String>,
+    /// Override the workflow template, skipping route matching (e.g. "pr-fix", "pr-rebase").
+    workflow: Option<String>,
+    /// Override the model for every stage (e.g. "claude-opus-4-6").
+    model: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -214,10 +222,10 @@ pub fn build_router(state: AppState) -> McpRouter {
                     &rd,
                     app.gh.clone(),
                     app.git.clone(),
-                    None,
+                    input.model,
                     vec![],
                     None,
-                    None,
+                    input.workflow,
                 )
                 .await
                 {
@@ -256,10 +264,10 @@ pub fn build_router(state: AppState) -> McpRouter {
                     &rd,
                     app.gh.clone(),
                     app.git.clone(),
-                    None,
+                    input.model,
                     vec![],
                     None,
-                    None,
+                    input.workflow,
                 )
                 .await
                 {


### PR DESCRIPTION
## Summary

- REST API: add `workflow` and `model` query params to `POST /runs/issue/{n}` and `POST /runs/pr/{n}`
- MCP server: add `workflow` and `model` fields to `IssueRunInput` and `PrRunInput`

Matches CLI parity from #439 — API/MCP users can now bypass route matching with an explicit workflow.

Closes #464