### PR TITLE
fix: add version to forza-core path dependency for crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["process", "fs"] }
 tempfile = "3"
 # forza
 
-forza-core = { path = "crates/forza-core" }
+forza-core = { path = "crates/forza-core", version = "0.5.0" }
 
 tower-mcp = { version = "0.9", features = ["http"] }
 schemars = "1"


### PR DESCRIPTION
The workspace path dependency needs an explicit version for `cargo publish` to verify the manifest. Without it, the release CI fails.