### PR TITLE
fix(action): strip directory prefix when extracting release binary

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -98,7 +98,7 @@ runs:
 
         URL="https://github.com/joshrotenberg/forza/releases/download/forza-v${FORZA_VERSION}/forza-${ARCH}-unknown-${OS}-gnu.tar.xz"
         echo "Installing forza v${FORZA_VERSION} from ${URL}"
-        curl -sL "$URL" | tar xJ -C /usr/local/bin forza
+        curl -sL "$URL" | tar xJ --strip-components=1 -C /usr/local/bin
 
         forza --version
 


### PR DESCRIPTION
Release archives have a directory prefix (`forza-x86_64-unknown-linux-gnu/forza`). Use `--strip-components=1` to extract the binary directly.