### PR TITLE
refactor: rationalize builtin workflows — quick/feature/research

### DIFF
--- a/crates/forza-core/src/stage.rs
+++ b/crates/forza-core/src/stage.rs
@@ -219,6 +219,8 @@ fn default_true() -> bool {
 
 /// Shell command for the DraftPr stage.
 /// Loaded from `commands/draft_pr.sh` at compile time.
+/// Available for custom workflows that include a draft_pr stage.
+#[allow(dead_code)]
 const DRAFT_PR_COMMAND: &str = include_str!("commands/draft_pr.sh");
 
 /// Shell command for the Merge stage.
@@ -243,40 +245,35 @@ impl Workflow {
     }
 
     /// Returns the builtin workflow templates.
+    /// Resolve a workflow alias to its canonical name.
+    ///
+    /// Legacy names (`bug`, `chore`) map to their modern equivalents.
+    pub fn resolve_alias(name: &str) -> &str {
+        match name {
+            "bug" | "chore" => "quick",
+            other => other,
+        }
+    }
+
     pub fn builtins() -> Vec<Workflow> {
         vec![
             // ── Issue workflows ──────────────────────────────────────
             Workflow::new(
-                "bug",
+                "quick",
                 vec![
-                    Stage::agent(StageKind::Plan),
-                    Stage::shell(StageKind::DraftPr, DRAFT_PR_COMMAND).optional(),
                     Stage::agent(StageKind::Implement),
                     Stage::agent(StageKind::Test),
-                    Stage::agent(StageKind::Review),
                     Stage::agent(StageKind::OpenPr),
-                    Stage::shell(StageKind::Merge, MERGE_COMMAND).optional(),
                 ],
             ),
             Workflow::new(
                 "feature",
                 vec![
                     Stage::agent(StageKind::Plan),
-                    Stage::shell(StageKind::DraftPr, DRAFT_PR_COMMAND).optional(),
                     Stage::agent(StageKind::Implement),
                     Stage::agent(StageKind::Test),
                     Stage::agent(StageKind::Review),
                     Stage::agent(StageKind::OpenPr),
-                    Stage::shell(StageKind::Merge, MERGE_COMMAND).optional(),
-                ],
-            ),
-            Workflow::new(
-                "chore",
-                vec![
-                    Stage::agent(StageKind::Implement),
-                    Stage::agent(StageKind::Test),
-                    Stage::agent(StageKind::OpenPr),
-                    Stage::shell(StageKind::Merge, MERGE_COMMAND).optional(),
                 ],
             ),
             Workflow::new(
@@ -365,15 +362,23 @@ mod tests {
     fn builtins_cover_expected_names() {
         let builtins = Workflow::builtins();
         let names: Vec<&str> = builtins.iter().map(|w| w.name.as_str()).collect();
-        assert!(names.contains(&"bug"));
+        assert!(names.contains(&"quick"));
         assert!(names.contains(&"feature"));
-        assert!(names.contains(&"chore"));
         assert!(names.contains(&"research"));
         assert!(names.contains(&"pr-fix"));
         assert!(names.contains(&"pr-fix-ci"));
         assert!(names.contains(&"pr-rebase"));
         assert!(names.contains(&"pr-merge"));
         assert!(names.contains(&"pr-review"));
+    }
+
+    #[test]
+    fn aliases_resolve_to_quick() {
+        assert_eq!(Workflow::resolve_alias("bug"), "quick");
+        assert_eq!(Workflow::resolve_alias("chore"), "quick");
+        assert_eq!(Workflow::resolve_alias("feature"), "feature");
+        assert_eq!(Workflow::resolve_alias("research"), "research");
+        assert_eq!(Workflow::resolve_alias("unknown"), "unknown");
     }
 
     #[test]

--- a/crates/forza/src/config.rs
+++ b/crates/forza/src/config.rs
@@ -833,14 +833,21 @@ impl RunnerConfig {
 
     /// Resolve a workflow template by name (custom overrides built-in).
     pub fn resolve_workflow(&self, name: &str) -> Option<crate::workflow::WorkflowTemplate> {
-        // Check custom templates first.
+        // Check custom templates first (before alias resolution so users can override aliases).
         if let Some(template) = self.workflow_templates.iter().find(|t| t.name == name) {
+            return Some(template.clone());
+        }
+        // Resolve aliases (bug -> quick, chore -> quick).
+        let canonical = forza_core::Workflow::resolve_alias(name);
+        if canonical != name
+            && let Some(template) = self.workflow_templates.iter().find(|t| t.name == canonical)
+        {
             return Some(template.clone());
         }
         // Fall back to built-in.
         crate::workflow::builtin_templates()
             .into_iter()
-            .find(|t| t.name == name)
+            .find(|t| t.name == canonical)
     }
 }
 

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -462,7 +462,9 @@ pub fn resolve_workflow_public(config: &RunnerConfig, name: &str) -> Option<Work
 
 /// Resolve a workflow name to a forza-core Workflow.
 fn resolve_workflow(config: &RunnerConfig, name: &str) -> Option<Workflow> {
-    // Prefer forza-core builtins (which include DraftPr stages).
+    // Resolve aliases (bug -> quick, chore -> quick).
+    let name = Workflow::resolve_alias(name);
+    // Prefer forza-core builtins.
     if let Some(builtin) = Workflow::builtins().into_iter().find(|w| w.name == name) {
         // Check if user has a custom override for this workflow name.
         if config.workflow_templates.iter().any(|t| t.name == name) {

--- a/crates/forza/src/workflow.rs
+++ b/crates/forza/src/workflow.rs
@@ -175,15 +175,11 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
     // as normal.
     vec![
         WorkflowTemplate {
-            name: "bug".into(),
+            name: "quick".into(),
             stages: vec![
-                Stage::new(StageKind::Plan),
                 Stage::new(StageKind::Implement),
                 Stage::new(StageKind::Test),
-                Stage::new(StageKind::Review).optional(),
                 Stage::new(StageKind::OpenPr),
-                Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash 2>/dev/null; gh pr view --json autoMergeRequest --jq '.autoMergeRequest != null' | grep -q true || gh pr merge --squash"),
             ],
             ..Default::default()
         },
@@ -193,21 +189,8 @@ pub fn builtin_templates() -> Vec<WorkflowTemplate> {
                 Stage::new(StageKind::Plan),
                 Stage::new(StageKind::Implement),
                 Stage::new(StageKind::Test),
-                Stage::new(StageKind::Review).optional(),
+                Stage::new(StageKind::Review),
                 Stage::new(StageKind::OpenPr),
-                Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash 2>/dev/null; gh pr view --json autoMergeRequest --jq '.autoMergeRequest != null' | grep -q true || gh pr merge --squash"),
-            ],
-            ..Default::default()
-        },
-        WorkflowTemplate {
-            name: "chore".into(),
-            stages: vec![
-                Stage::new(StageKind::Implement),
-                Stage::new(StageKind::Test),
-                Stage::new(StageKind::OpenPr),
-                Stage::new(StageKind::Merge)
-                    .agentless("gh pr merge --auto --squash 2>/dev/null; gh pr view --json autoMergeRequest --jq '.autoMergeRequest != null' | grep -q true || gh pr merge --squash"),
             ],
             ..Default::default()
         },
@@ -309,8 +292,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bug_feature_chore_templates_end_with_merge() {
-        for name in &["bug", "feature", "chore"] {
+    fn quick_and_feature_templates_end_with_open_pr() {
+        for name in &["quick", "feature"] {
             let template = builtin_templates()
                 .into_iter()
                 .find(|t| t.name == *name)
@@ -318,10 +301,9 @@ mod tests {
             let last = template.stages.last().expect("template must have stages");
             assert_eq!(
                 last.kind,
-                StageKind::Merge,
-                "{name} template should end with Merge"
+                StageKind::OpenPr,
+                "{name} template should end with OpenPr"
             );
-            assert!(last.agentless, "{name} Merge stage must be agentless");
         }
     }
 


### PR DESCRIPTION
## Summary

Simplify issue workflows to three with clear purposes:

| Workflow | Stages | Use for |
|----------|--------|---------|
| **quick** | implement → test → open_pr | bugs, chores, small stuff |
| **feature** | plan → implement → test → review → open_pr | big features |
| **research** | research → comment | investigation only |

`bug` and `chore` are aliases for `quick` — existing configs don't break.

**Removed from all issue workflows:**
- `merge` stage — merge is a human decision or condition route
- `draft_pr` stage — PR appears when it's ready
- `review` from quick — human reviews the PR directly

PR workflows unchanged.

Closes #481