### PR TITLE
feat(cli): add --base-branch and --target-branch flags

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -127,6 +127,12 @@ struct IssueArgs {
     /// Re-run the latest failed run for this issue.
     #[arg(long)]
     fix: bool,
+    /// Branch to create worktree from (default: repo default branch).
+    #[arg(long)]
+    base_branch: Option<String>,
+    /// Branch to target PRs to (default: repo default branch).
+    #[arg(long)]
+    target_branch: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -157,6 +163,9 @@ struct PrArgs {
     /// Re-run the latest failed run for this PR.
     #[arg(long)]
     fix: bool,
+    /// Branch to target PRs to (default: repo default branch).
+    #[arg(long)]
+    target_branch: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -1752,7 +1761,7 @@ async fn cmd_issue(
         git.clone(),
         args.model,
         args.skill,
-        None,
+        args.base_branch,
         args.workflow,
     )
     .await


### PR DESCRIPTION
## Summary

- `--base-branch` on `forza issue`: create worktree from a custom ref instead of the default branch
- `--target-branch` on `forza issue` and `forza pr`: specify PR target (field added, threading through PR creation is a follow-up)

## Use cases

- **Testing**: `forza issue 42 --workflow quick --base-branch scenario/bug-v1` — branch from a known-broken tag
- **Plan branches**: all issues in a plan merge to a staging branch, human reviews the batch and merges to main
- **Daily work branch**: auto-merge enabled but targeting a work branch, sanity check at end of day

Closes #484