### PR TITLE
fix: add readme path to crate manifests for crates.io

### DIFF
--- a/crates/forza-core/Cargo.toml
+++ b/crates/forza-core/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 license.workspace = true
 description = "Core abstractions for forza — workflow orchestrator for agent-driven development"
 repository.workspace = true
+readme = "../../README.md"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/forza/Cargo.toml
+++ b/crates/forza/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 description = "Configurable workflow orchestrator for agent driven software development"
 repository.workspace = true
 homepage = "https://github.com/joshrotenberg/forza"
+readme = "../../README.md"
 keywords = ["github", "automation", "issues", "pull-requests", "ci"]
 categories = ["command-line-utilities", "development-tools"]
 


### PR DESCRIPTION
Both crates need `readme = "../../README.md"` since the README is at the workspace root, not in each crate directory.