### PR TITLE
chore: release v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "forza"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "axum",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "forza-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/forza", "crates/forza-core"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["process", "fs"] }
 tempfile = "3"
 # forza
 
-forza-core = { path = "crates/forza-core", version = "0.5.1" }
+forza-core = { path = "crates/forza-core", version = "0.5.2" }
 
 tower-mcp = { version = "0.9", features = ["http"] }
 schemars = "1"

--- a/crates/forza-core/CHANGELOG.md
+++ b/crates/forza-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/joshrotenberg/forza/compare/forza-core-v0.5.1...forza-core-v0.5.2) - 2026-03-29
+
+### Fixed
+
+- add readme path to both crate manifests for crates.io ([#487](https://github.com/joshrotenberg/forza/pull/487))
+
+### Other
+
+- layers of usage guide ([#486](https://github.com/joshrotenberg/forza/pull/486))
+
 ## [0.5.1](https://github.com/joshrotenberg/forza/compare/forza-core-v0.5.0...forza-core-v0.5.1) - 2026-03-29
 
 ### Other

--- a/crates/forza/CHANGELOG.md
+++ b/crates/forza/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/joshrotenberg/forza/compare/forza-v0.5.1...forza-v0.5.2) - 2026-03-29
+
+### Fixed
+
+- add readme path to both crate manifests for crates.io ([#487](https://github.com/joshrotenberg/forza/pull/487))
+
 ## [0.5.1](https://github.com/joshrotenberg/forza/compare/forza-v0.5.0...forza-v0.5.1) - 2026-03-29
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `forza-core`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `forza`: 0.5.1 -> 0.5.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `forza-core`

<blockquote>

## [0.5.2](https://github.com/joshrotenberg/forza/compare/forza-core-v0.5.1...forza-core-v0.5.2) - 2026-03-29

### Fixed

- add readme path to both crate manifests for crates.io ([#487](https://github.com/joshrotenberg/forza/pull/487))

### Other

- layers of usage guide ([#486](https://github.com/joshrotenberg/forza/pull/486))
</blockquote>

## `forza`

<blockquote>

## [0.5.2](https://github.com/joshrotenberg/forza/compare/forza-v0.5.1...forza-v0.5.2) - 2026-03-29

### Fixed

- add readme path to both crate manifests for crates.io ([#487](https://github.com/joshrotenberg/forza/pull/487))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).