### PR TITLE
fix(ci): make release workflow idempotent on re-runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,24 @@ jobs:
           pattern: artifacts-*
           path: target/distrib/
           merge-multiple: true
+      # Clean up stale releases from previous failed runs.
+      # In a workspace, dist creates releases per-package. If one succeeds
+      # and another fails, re-running hits "release already exists". This
+      # step deletes any existing releases for tags in this run.
+      - name: Clean stale releases
+        shell: bash
+        run: |
+          TAG="${{ needs.plan.outputs.tag }}"
+          # Delete the announcement release if it exists
+          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+          # For workspace releases, also clean the other package tag.
+          # Extract version from tag (e.g. forza-v0.5.2 -> 0.5.2)
+          VERSION=$(echo "$TAG" | grep -oP '\d+\.\d+\.\d+')
+          if [ -n "$VERSION" ]; then
+            for pkg in forza forza-core; do
+              gh release delete "${pkg}-v${VERSION}" --yes --cleanup-tag 2>/dev/null || true
+            done
+          fi
       - id: host
         shell: bash
         run: |
@@ -275,6 +293,9 @@ jobs:
         run: |
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+
+          # Delete existing release if present (idempotent re-runs)
+          gh release delete "${{ needs.plan.outputs.tag }}" --yes --cleanup-tag 2>/dev/null || true
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 


### PR DESCRIPTION
## Problem

When the release workflow fails partway through (e.g., cargo publish fails for one crate), tags and partial releases are left behind. Re-running the workflow fails with "a release with the same tag name already exists."

This has been a recurring issue — every release attempt requires manual tag/release cleanup.

## Fix

Add cleanup steps before both release creation points:

1. **Before `dist host`**: delete any existing releases for all workspace package tags
2. **Before `gh release create`**: delete existing announcement release

Both are no-ops on first run. On re-runs, they clean up partial state from the failed attempt. This makes the release workflow fully idempotent.