### PR TITLE
fix(pipeline): restore draft_pr stage to quick and feature workflows

### DIFF
--- a/crates/forza-core/src/stage.rs
+++ b/crates/forza-core/src/stage.rs
@@ -219,8 +219,8 @@ fn default_true() -> bool {
 
 /// Shell command for the DraftPr stage.
 /// Loaded from `commands/draft_pr.sh` at compile time.
-/// Available for custom workflows that include a draft_pr stage.
-#[allow(dead_code)]
+/// Shell command for the DraftPr stage.
+/// Loaded from `commands/draft_pr.sh` at compile time.
 const DRAFT_PR_COMMAND: &str = include_str!("commands/draft_pr.sh");
 
 /// Shell command for the Merge stage.
@@ -263,6 +263,7 @@ impl Workflow {
                 vec![
                     Stage::agent(StageKind::Implement),
                     Stage::agent(StageKind::Test),
+                    Stage::shell(StageKind::DraftPr, DRAFT_PR_COMMAND).optional(),
                     Stage::agent(StageKind::OpenPr),
                 ],
             ),
@@ -270,6 +271,7 @@ impl Workflow {
                 "feature",
                 vec![
                     Stage::agent(StageKind::Plan),
+                    Stage::shell(StageKind::DraftPr, DRAFT_PR_COMMAND).optional(),
                     Stage::agent(StageKind::Implement),
                     Stage::agent(StageKind::Test),
                     Stage::agent(StageKind::Review),


### PR DESCRIPTION
## Problem

On GitHub Actions, the `open_pr` agent stage runs `gh pr create` inside Claude Code, which may not have GitHub auth. The agent reports success but no PR is created (#491).

## Fix

Restore `draft_pr` (optional shell stage) to both `quick` and `feature` workflows. This stage runs `gh pr create --draft` directly with full environment access, ensuring the branch is pushed and a draft PR exists before the agent handles `open_pr`.

```
quick:   implement -> test -> draft_pr -> open_pr
feature: plan -> draft_pr -> implement -> test -> review -> open_pr
```