### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "forza"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "forza-core"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/forza", "crates/forza-core", "crates/forza-test-fixture"]
 resolver = "3"
 
 [workspace.package]
-version = "0.5.2"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["process", "fs"] }
 tempfile = "3"
 # forza
 
-forza-core = { path = "crates/forza-core", version = "0.5.2" }
+forza-core = { path = "crates/forza-core", version = "0.6.0" }
 
 tower-mcp = { version = "0.9", features = ["http"] }
 schemars = "1"

--- a/crates/forza-core/CHANGELOG.md
+++ b/crates/forza-core/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.5.2...forza-core-v0.6.0) - 2026-03-30
+
+### Added
+
+- *(pipeline)* native DraftPr stage — no shell, no gh CLI ([#482](https://github.com/joshrotenberg/forza/pull/482)) ([#503](https://github.com/joshrotenberg/forza/pull/503))
+
+### Fixed
+
+- *(pipeline)* prevent agents from committing forza internal files ([#551](https://github.com/joshrotenberg/forza/pull/551))
+- *(runner)* skip closed issues/PRs, auto-prune stale worktrees ([#539](https://github.com/joshrotenberg/forza/pull/539))
+- *(agents)* resolve models per-agent to prevent cross-agent model leaks ([#536](https://github.com/joshrotenberg/forza/pull/536))
+- *(pipeline)* auto-commit uncommitted changes after agent stages ([#534](https://github.com/joshrotenberg/forza/pull/534))
+- *(prompts)* make implement/test prompts resilient to missing breadcrumbs ([#524](https://github.com/joshrotenberg/forza/pull/524))
+- *(prompts)* add {comments} to plan and implement templates ([#510](https://github.com/joshrotenberg/forza/pull/510))
+- *(pipeline)* warn when open_pr succeeds but no PR found ([#491](https://github.com/joshrotenberg/forza/pull/491)) ([#502](https://github.com/joshrotenberg/forza/pull/502))
+- add --repo and --head to draft_pr, remove auth check ([#501](https://github.com/joshrotenberg/forza/pull/501))
+- *(pipeline)* restore draft_pr stage to quick and feature workflows ([#492](https://github.com/joshrotenberg/forza/pull/492))
+
+### Other
+
+- *(pipeline)* move breadcrumbs from worktree to state directory ([#553](https://github.com/joshrotenberg/forza/pull/553))
+- clean debug flags from draft_pr.sh (set -xe -> set -e) ([#512](https://github.com/joshrotenberg/forza/pull/512))
+- loud draft_pr — set -x, no error suppression, gh auth check ([#499](https://github.com/joshrotenberg/forza/pull/499))
+- show draft_pr errors instead of silencing them ([#496](https://github.com/joshrotenberg/forza/pull/496))
+
 ## [0.5.2](https://github.com/joshrotenberg/forza/compare/forza-core-v0.5.1...forza-core-v0.5.2) - 2026-03-29
 
 ### Fixed

--- a/crates/forza/CHANGELOG.md
+++ b/crates/forza/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/joshrotenberg/forza/compare/forza-v0.5.2...forza-v0.6.0) - 2026-03-30
+
+### Added
+
+- *(cli)* output GitHub URLs for PRs in run results ([#554](https://github.com/joshrotenberg/forza/pull/554))
+- *(adapters)* use wrapper RetryPolicy for transient agent CLI failures ([#550](https://github.com/joshrotenberg/forza/pull/550))
+- *(cli)* infer agent from model name when --agent is not specified ([#549](https://github.com/joshrotenberg/forza/pull/549))
+- *(cli)* check agent CLI version at startup closes #530 ([#543](https://github.com/joshrotenberg/forza/pull/543))
+- *(codex)* use ephemeral mode and ReviewCommand for Codex stages ([#541](https://github.com/joshrotenberg/forza/pull/541))
+- *(cli)* guided init supports --agent, auto-detection, and passthrough args ([#521](https://github.com/joshrotenberg/forza/pull/521)) ([#522](https://github.com/joshrotenberg/forza/pull/522))
+- multi-agent support — --agent flag, create_agent helper, codex skills ([#518](https://github.com/joshrotenberg/forza/pull/518)) ([#519](https://github.com/joshrotenberg/forza/pull/519))
+- *(cli)* search parent directories for forza.toml closes #495 ([#511](https://github.com/joshrotenberg/forza/pull/511))
+- *(pipeline)* native DraftPr stage — no shell, no gh CLI ([#482](https://github.com/joshrotenberg/forza/pull/482)) ([#503](https://github.com/joshrotenberg/forza/pull/503))
+- *(cli)* add `forza doctor` to check dependencies and environment closes #493 ([#497](https://github.com/joshrotenberg/forza/pull/497))
+
+### Fixed
+
+- *(plan)* use floor_char_boundary to avoid panic on multi-byte UTF-8 ([#555](https://github.com/joshrotenberg/forza/pull/555))
+- *(codex)* warn when unsupported options are silently dropped ([#540](https://github.com/joshrotenberg/forza/pull/540))
+- *(runner)* skip closed issues/PRs, auto-prune stale worktrees ([#539](https://github.com/joshrotenberg/forza/pull/539))
+- *(agents)* resolve models per-agent to prevent cross-agent model leaks ([#536](https://github.com/joshrotenberg/forza/pull/536))
+- *(codex)* skip Claude-specific models when invoking Codex ([#533](https://github.com/joshrotenberg/forza/pull/533))
+- *(codex)* use full sandbox bypass so Codex can commit in worktrees ([#525](https://github.com/joshrotenberg/forza/pull/525))
+- *(prompts)* make implement/test prompts resilient to missing breadcrumbs ([#524](https://github.com/joshrotenberg/forza/pull/524))
+- *(github)* detect default branch for PR creation ([#523](https://github.com/joshrotenberg/forza/pull/523))
+- *(cli)* add missing --repo-dir to plan/open, --repo to run ([#515](https://github.com/joshrotenberg/forza/pull/515)) ([#516](https://github.com/joshrotenberg/forza/pull/516))
+- *(cli)* forza init infers --repo from git remote ([#513](https://github.com/joshrotenberg/forza/pull/513)) ([#514](https://github.com/joshrotenberg/forza/pull/514))
+
+### Other
+
+- extract shared skill-file logic, fix codex init path ([#532](https://github.com/joshrotenberg/forza/pull/532)) ([#542](https://github.com/joshrotenberg/forza/pull/542))
+
 ## [0.5.2](https://github.com/joshrotenberg/forza/compare/forza-v0.5.1...forza-v0.5.2) - 2026-03-29
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `forza-core`: 0.5.2 -> 0.6.0 (⚠ API breaking changes)
* `forza`: 0.5.2 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `forza-core` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Execution:Native in /tmp/.tmpszPsUJ/forza/crates/forza-core/src/stage.rs:106
  variant Execution:Native in /tmp/.tmpszPsUJ/forza/crates/forza-core/src/stage.rs:106
```

### ⚠ `forza` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  forza::runner::process_pr now takes 13 parameters instead of 12, in /tmp/.tmpszPsUJ/forza/crates/forza/src/runner.rs:850
  forza::runner::process_issue now takes 13 parameters instead of 12, in /tmp/.tmpszPsUJ/forza/crates/forza/src/runner.rs:721
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `forza-core`

<blockquote>

## [0.6.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.5.2...forza-core-v0.6.0) - 2026-03-30

### Added

- *(pipeline)* native DraftPr stage — no shell, no gh CLI ([#482](https://github.com/joshrotenberg/forza/pull/482)) ([#503](https://github.com/joshrotenberg/forza/pull/503))

### Fixed

- *(pipeline)* prevent agents from committing forza internal files ([#551](https://github.com/joshrotenberg/forza/pull/551))
- *(runner)* skip closed issues/PRs, auto-prune stale worktrees ([#539](https://github.com/joshrotenberg/forza/pull/539))
- *(agents)* resolve models per-agent to prevent cross-agent model leaks ([#536](https://github.com/joshrotenberg/forza/pull/536))
- *(pipeline)* auto-commit uncommitted changes after agent stages ([#534](https://github.com/joshrotenberg/forza/pull/534))
- *(prompts)* make implement/test prompts resilient to missing breadcrumbs ([#524](https://github.com/joshrotenberg/forza/pull/524))
- *(prompts)* add {comments} to plan and implement templates ([#510](https://github.com/joshrotenberg/forza/pull/510))
- *(pipeline)* warn when open_pr succeeds but no PR found ([#491](https://github.com/joshrotenberg/forza/pull/491)) ([#502](https://github.com/joshrotenberg/forza/pull/502))
- add --repo and --head to draft_pr, remove auth check ([#501](https://github.com/joshrotenberg/forza/pull/501))
- *(pipeline)* restore draft_pr stage to quick and feature workflows ([#492](https://github.com/joshrotenberg/forza/pull/492))

### Other

- *(pipeline)* move breadcrumbs from worktree to state directory ([#553](https://github.com/joshrotenberg/forza/pull/553))
- clean debug flags from draft_pr.sh (set -xe -> set -e) ([#512](https://github.com/joshrotenberg/forza/pull/512))
- loud draft_pr — set -x, no error suppression, gh auth check ([#499](https://github.com/joshrotenberg/forza/pull/499))
- show draft_pr errors instead of silencing them ([#496](https://github.com/joshrotenberg/forza/pull/496))
</blockquote>

## `forza`

<blockquote>

## [0.6.0](https://github.com/joshrotenberg/forza/compare/forza-v0.5.2...forza-v0.6.0) - 2026-03-30

### Added

- *(cli)* output GitHub URLs for PRs in run results ([#554](https://github.com/joshrotenberg/forza/pull/554))
- *(adapters)* use wrapper RetryPolicy for transient agent CLI failures ([#550](https://github.com/joshrotenberg/forza/pull/550))
- *(cli)* infer agent from model name when --agent is not specified ([#549](https://github.com/joshrotenberg/forza/pull/549))
- *(cli)* check agent CLI version at startup closes #530 ([#543](https://github.com/joshrotenberg/forza/pull/543))
- *(codex)* use ephemeral mode and ReviewCommand for Codex stages ([#541](https://github.com/joshrotenberg/forza/pull/541))
- *(cli)* guided init supports --agent, auto-detection, and passthrough args ([#521](https://github.com/joshrotenberg/forza/pull/521)) ([#522](https://github.com/joshrotenberg/forza/pull/522))
- multi-agent support — --agent flag, create_agent helper, codex skills ([#518](https://github.com/joshrotenberg/forza/pull/518)) ([#519](https://github.com/joshrotenberg/forza/pull/519))
- *(cli)* search parent directories for forza.toml closes #495 ([#511](https://github.com/joshrotenberg/forza/pull/511))
- *(pipeline)* native DraftPr stage — no shell, no gh CLI ([#482](https://github.com/joshrotenberg/forza/pull/482)) ([#503](https://github.com/joshrotenberg/forza/pull/503))
- *(cli)* add `forza doctor` to check dependencies and environment closes #493 ([#497](https://github.com/joshrotenberg/forza/pull/497))

### Fixed

- *(plan)* use floor_char_boundary to avoid panic on multi-byte UTF-8 ([#555](https://github.com/joshrotenberg/forza/pull/555))
- *(codex)* warn when unsupported options are silently dropped ([#540](https://github.com/joshrotenberg/forza/pull/540))
- *(runner)* skip closed issues/PRs, auto-prune stale worktrees ([#539](https://github.com/joshrotenberg/forza/pull/539))
- *(agents)* resolve models per-agent to prevent cross-agent model leaks ([#536](https://github.com/joshrotenberg/forza/pull/536))
- *(codex)* skip Claude-specific models when invoking Codex ([#533](https://github.com/joshrotenberg/forza/pull/533))
- *(codex)* use full sandbox bypass so Codex can commit in worktrees ([#525](https://github.com/joshrotenberg/forza/pull/525))
- *(prompts)* make implement/test prompts resilient to missing breadcrumbs ([#524](https://github.com/joshrotenberg/forza/pull/524))
- *(github)* detect default branch for PR creation ([#523](https://github.com/joshrotenberg/forza/pull/523))
- *(cli)* add missing --repo-dir to plan/open, --repo to run ([#515](https://github.com/joshrotenberg/forza/pull/515)) ([#516](https://github.com/joshrotenberg/forza/pull/516))
- *(cli)* forza init infers --repo from git remote ([#513](https://github.com/joshrotenberg/forza/pull/513)) ([#514](https://github.com/joshrotenberg/forza/pull/514))

### Other

- extract shared skill-file logic, fix codex init path ([#532](https://github.com/joshrotenberg/forza/pull/532)) ([#542](https://github.com/joshrotenberg/forza/pull/542))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).