### PR TITLE
feat(cli): add `forza doctor` to check dependencies and environment

### DIFF
--- a/crates/forza/src/deps.rs
+++ b/crates/forza/src/deps.rs
@@ -95,3 +95,372 @@ fn install_hint(agent: &str) -> &'static str {
         _ => "ensure the agent binary is installed and on your PATH",
     }
 }
+
+// ---------------------------------------------------------------------------
+// Doctor checks — structured results for `forza doctor`
+// ---------------------------------------------------------------------------
+
+/// Result of a single doctor check.
+pub struct CheckResult {
+    /// Display name for the check (left column).
+    pub name: &'static str,
+    /// Detail string shown in the middle column.
+    pub detail: String,
+    /// Whether the check passed.
+    pub ok: bool,
+}
+
+/// Run all doctor checks and return individual results.
+///
+/// Config-dependent checks (repo access, labels) are skipped when `repo` is `None`.
+pub async fn doctor_checks(
+    agent: &str,
+    git: &dyn GitClient,
+    repo: Option<&str>,
+) -> Vec<CheckResult> {
+    let mut results = Vec::new();
+
+    results.push(doctor_agent(agent).await);
+    results.push(doctor_gh_cli().await);
+    results.push(doctor_gh_auth().await);
+    results.push(doctor_git(git).await);
+    results.push(doctor_api_key(agent));
+    results.push(doctor_config());
+
+    if let Some(repo) = repo {
+        results.push(doctor_repo_access(repo).await);
+        results.push(doctor_labels(repo).await);
+    }
+
+    results
+}
+
+async fn doctor_agent(agent: &str) -> CheckResult {
+    let output = Command::new(agent)
+        .arg("--version")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await;
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let version = String::from_utf8_lossy(&o.stdout)
+                .trim()
+                .lines()
+                .next()
+                .unwrap_or("")
+                .to_string();
+            CheckResult {
+                name: "Agent",
+                detail: if version.is_empty() {
+                    agent.to_string()
+                } else {
+                    version
+                },
+                ok: true,
+            }
+        }
+        Ok(_) => CheckResult {
+            name: "Agent",
+            detail: format!("{agent} --version failed"),
+            ok: false,
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => CheckResult {
+            name: "Agent",
+            detail: format!("{agent} not found"),
+            ok: false,
+        },
+        Err(e) => CheckResult {
+            name: "Agent",
+            detail: format!("{agent} error: {e}"),
+            ok: false,
+        },
+    }
+}
+
+async fn doctor_gh_cli() -> CheckResult {
+    let output = Command::new("gh")
+        .arg("--version")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await;
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let version = String::from_utf8_lossy(&o.stdout)
+                .trim()
+                .lines()
+                .next()
+                .unwrap_or("")
+                .to_string();
+            CheckResult {
+                name: "gh CLI",
+                detail: if version.is_empty() {
+                    "gh".to_string()
+                } else {
+                    version
+                },
+                ok: true,
+            }
+        }
+        Ok(_) => CheckResult {
+            name: "gh CLI",
+            detail: "gh --version failed".to_string(),
+            ok: false,
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => CheckResult {
+            name: "gh CLI",
+            detail: "gh not found".to_string(),
+            ok: false,
+        },
+        Err(e) => CheckResult {
+            name: "gh CLI",
+            detail: format!("gh error: {e}"),
+            ok: false,
+        },
+    }
+}
+
+async fn doctor_gh_auth() -> CheckResult {
+    let output = Command::new("gh")
+        .args(["auth", "status"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await;
+
+    match output {
+        Ok(o) if o.status.success() => {
+            // Try to extract the username from gh auth status output.
+            let combined = format!(
+                "{}\n{}",
+                String::from_utf8_lossy(&o.stdout),
+                String::from_utf8_lossy(&o.stderr)
+            );
+            let username = combined
+                .lines()
+                .find_map(|line| {
+                    let line = line.trim();
+                    if line.starts_with("Logged in to") {
+                        line.split("account").nth(1).and_then(|s| {
+                            s.split_whitespace()
+                                .next()
+                                .map(|u| u.trim_end_matches(')').to_string())
+                        })
+                    } else if line.contains("account") && line.contains("github.com") {
+                        // Newer gh format: "account joshrotenberg (github.com/...)"
+                        line.split("account")
+                            .nth(1)
+                            .and_then(|s| s.split_whitespace().next().map(|u| u.to_string()))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| "authenticated".to_string());
+            CheckResult {
+                name: "gh auth",
+                detail: username,
+                ok: true,
+            }
+        }
+        Ok(_) => CheckResult {
+            name: "gh auth",
+            detail: "not authenticated".to_string(),
+            ok: false,
+        },
+        Err(_) => CheckResult {
+            name: "gh auth",
+            detail: "gh not available".to_string(),
+            ok: false,
+        },
+    }
+}
+
+async fn doctor_git(git: &dyn GitClient) -> CheckResult {
+    match git.version().await {
+        Ok(version) => CheckResult {
+            name: "git",
+            detail: version.trim().to_string(),
+            ok: true,
+        },
+        Err(_) => CheckResult {
+            name: "git",
+            detail: "not available".to_string(),
+            ok: false,
+        },
+    }
+}
+
+fn doctor_api_key(agent: &str) -> CheckResult {
+    match agent {
+        "claude" => {
+            if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+                CheckResult {
+                    name: "API key",
+                    detail: "ANTHROPIC_API_KEY set".to_string(),
+                    ok: true,
+                }
+            } else {
+                CheckResult {
+                    name: "API key",
+                    detail: "ANTHROPIC_API_KEY not set".to_string(),
+                    ok: false,
+                }
+            }
+        }
+        "codex" => {
+            if std::env::var("OPENAI_API_KEY").is_ok() {
+                CheckResult {
+                    name: "API key",
+                    detail: "OPENAI_API_KEY set".to_string(),
+                    ok: true,
+                }
+            } else {
+                CheckResult {
+                    name: "API key",
+                    detail: "OPENAI_API_KEY not set".to_string(),
+                    ok: false,
+                }
+            }
+        }
+        _ => CheckResult {
+            name: "API key",
+            detail: "unknown agent; skipped".to_string(),
+            ok: true,
+        },
+    }
+}
+
+fn doctor_config() -> CheckResult {
+    let path = std::path::Path::new("forza.toml");
+    if path.exists() {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => match toml::from_str::<toml::Value>(&contents) {
+                Ok(_) => CheckResult {
+                    name: "Config",
+                    detail: "forza.toml".to_string(),
+                    ok: true,
+                },
+                Err(e) => CheckResult {
+                    name: "Config",
+                    detail: format!("parse error: {e}"),
+                    ok: false,
+                },
+            },
+            Err(e) => CheckResult {
+                name: "Config",
+                detail: format!("read error: {e}"),
+                ok: false,
+            },
+        }
+    } else {
+        CheckResult {
+            name: "Config",
+            detail: "forza.toml not found".to_string(),
+            ok: false,
+        }
+    }
+}
+
+async fn doctor_repo_access(repo: &str) -> CheckResult {
+    let output = Command::new("gh")
+        .args(["api", &format!("repos/{repo}"), "--jq", ".full_name"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await;
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let name = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            CheckResult {
+                name: "Repo",
+                detail: if name.is_empty() {
+                    repo.to_string()
+                } else {
+                    name
+                },
+                ok: true,
+            }
+        }
+        Ok(_) => CheckResult {
+            name: "Repo",
+            detail: format!("{repo} not accessible"),
+            ok: false,
+        },
+        Err(_) => CheckResult {
+            name: "Repo",
+            detail: "gh not available".to_string(),
+            ok: false,
+        },
+    }
+}
+
+async fn doctor_labels(repo: &str) -> CheckResult {
+    let required = [
+        "forza:ready",
+        "forza:in-progress",
+        "forza:complete",
+        "forza:failed",
+        "forza:blocked",
+        "forza:plan",
+    ];
+
+    let output = Command::new("gh")
+        .args([
+            "label", "list", "--repo", repo, "--limit", "100", "--json", "name",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await;
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let body = String::from_utf8_lossy(&o.stdout);
+            let labels: Vec<String> = serde_json::from_str::<Vec<serde_json::Value>>(&body)
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|v| v.get("name")?.as_str().map(String::from))
+                .collect();
+            let present = required
+                .iter()
+                .filter(|r| labels.contains(&(**r).to_string()))
+                .count();
+            let total = required.len();
+            if present == total {
+                CheckResult {
+                    name: "Labels",
+                    detail: format!("{present}/{total} present"),
+                    ok: true,
+                }
+            } else {
+                let missing: Vec<&str> = required
+                    .iter()
+                    .filter(|r| !labels.contains(&(**r).to_string()))
+                    .copied()
+                    .collect();
+                CheckResult {
+                    name: "Labels",
+                    detail: format!(
+                        "{present}/{total} present (missing: {})",
+                        missing.join(", ")
+                    ),
+                    ok: false,
+                }
+            }
+        }
+        Ok(_) => CheckResult {
+            name: "Labels",
+            detail: "could not list labels".to_string(),
+            ok: false,
+        },
+        Err(_) => CheckResult {
+            name: "Labels",
+            detail: "gh not available".to_string(),
+            ok: false,
+        },
+    }
+}

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -62,6 +62,8 @@ enum Command {
     Open(OpenArgs),
     /// Create or execute a plan: analyze issues, build a dependency graph, coordinate work.
     Plan(PlanArgs),
+    /// Check dependencies and environment health.
+    Doctor(DoctorArgs),
 }
 
 #[derive(Debug, Parser)]
@@ -396,6 +398,14 @@ struct PlanArgs {
     branch: Option<String>,
 }
 
+#[derive(Debug, Parser)]
+#[command(after_long_help = "Examples:\n  forza doctor")]
+struct DoctorArgs {
+    /// Repository to check (owner/name). Uses config if omitted.
+    #[arg(long)]
+    repo: Option<String>,
+}
+
 fn state_dir() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
@@ -447,6 +457,7 @@ fn resolve_config(
             | Command::Plan(_)
             | Command::Open(_)
             | Command::Explain(_)
+            | Command::Doctor(_)
     ) {
         return Ok(forza::RunnerConfig::default());
     }
@@ -524,6 +535,7 @@ async fn main() -> ExitCode {
             | Command::Serve(_)
             | Command::Mcp(_)
             | Command::Explain(_)
+            | Command::Doctor(_)
     ) && let Err(e) = forza::deps::validate_dependencies(&config.global.agent, &*git).await
     {
         eprintln!("error: {e}");
@@ -544,6 +556,51 @@ async fn main() -> ExitCode {
         Command::Explain(args) => cmd_explain(args, &config, &gh).await,
         Command::Open(args) => cmd_open(args, &config, &git).await,
         Command::Plan(args) => cmd_plan(args, &config, &gh, &git).await,
+        Command::Doctor(args) => cmd_doctor(args, &config, &git).await,
+    }
+}
+
+async fn cmd_doctor(
+    args: DoctorArgs,
+    config: &forza::RunnerConfig,
+    git: &std::sync::Arc<dyn forza::git::GitClient>,
+) -> ExitCode {
+    // Determine repo from --repo flag or first configured repo.
+    let repo = args
+        .repo
+        .as_deref()
+        .or_else(|| config.repos.keys().next().map(|s| s.as_str()));
+
+    // Check if config was actually loaded (not default empty).
+    let has_config = !config.repos.is_empty();
+    let repo_for_checks = if has_config { repo } else { None };
+
+    let results = forza::deps::doctor_checks(&config.global.agent, &**git, repo_for_checks).await;
+
+    // Calculate column widths for aligned output.
+    let name_width = results.iter().map(|r| r.name.len()).max().unwrap_or(0);
+    let detail_width = results.iter().map(|r| r.detail.len()).max().unwrap_or(0);
+
+    println!();
+    for result in &results {
+        let status = if result.ok { "ok" } else { "FAIL" };
+        println!(
+            "  {:<name_width$}  {:<detail_width$}  {status}",
+            format!("{}:", result.name),
+            result.detail,
+            name_width = name_width + 1,
+            detail_width = detail_width,
+        );
+    }
+    println!();
+
+    let failed = results.iter().filter(|r| !r.ok).count();
+    if failed == 0 {
+        println!("All checks passed.");
+        ExitCode::SUCCESS
+    } else {
+        println!("{failed} check(s) failed.");
+        ExitCode::FAILURE
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `forza doctor` CLI command that checks all environment dependencies and reports their status in an aligned columnar format
- Checks include: agent binary, gh CLI, gh auth, git, GitHub token env var, Anthropic API key env var, config file presence, repo access, and label setup
- Works with or without a valid config — config-dependent checks (repo access, labels) are skipped when no config is loaded
- Exits 0 if all checks pass, 1 if any fail

## Files changed

- `crates/forza/src/main.rs` — add `Doctor` variant to `Command` enum, `DoctorArgs` struct, `cmd_doctor` handler, dispatch in `main()`
- `crates/forza/src/deps.rs` — add structured doctor check functions that return status + detail strings, format aligned columnar output

## Test plan

- [ ] Run `forza doctor` in a fully configured environment — all checks should pass
- [ ] Run `forza doctor` without `forza.toml` — config-dependent checks should be skipped
- [ ] Run `forza doctor` without `gh` installed — should show failure for gh-related checks
- [ ] Verify exit code is 0 when all pass, 1 when any fail
- [ ] Run `cargo test --all` — all existing tests pass
- [ ] Run `cargo clippy --all --all-targets -- -D warnings` — no warnings

Closes #493