### PR TITLE
debug: loud draft_pr to diagnose Actions failure

### DIFF
--- a/crates/forza-core/src/commands/draft_pr.sh
+++ b/crates/forza-core/src/commands/draft_pr.sh
@@ -1,14 +1,16 @@
 #!/bin/sh
-# Create an early draft PR after the plan stage for visibility.
-# Creates an empty commit so the branch has a diff from main, pushes,
-# and creates a draft PR with the plan breadcrumb as the body.
-# If draft creation fails, exits 0 so the optional stage doesn't block.
+# Create an early draft PR for visibility.
+# Pushes the branch and creates a draft PR.
+set -x
 
 # Create an empty commit to establish a diff from main.
-git commit --allow-empty -m "wip: $FORZA_SUBJECT_TITLE (#$FORZA_SUBJECT_NUMBER) [skip ci]" 2>/dev/null
+git commit --allow-empty -m "wip: $FORZA_SUBJECT_TITLE (#$FORZA_SUBJECT_NUMBER) [skip ci]"
 
 # Push the branch.
-git push origin HEAD 2>/dev/null || true
+git push origin HEAD
+
+# Check gh auth status
+gh auth status
 
 # Read the plan breadcrumb for the PR body.
 if [ -f .plan_breadcrumb.md ]; then
@@ -17,8 +19,7 @@ else
     BODY="Work in progress for $FORZA_SUBJECT_TITLE (#$FORZA_SUBJECT_NUMBER)"
 fi
 
-# Create the draft PR. If it fails (PR already exists, etc.), that's OK.
+# Create the draft PR.
 gh pr create --draft \
     --title "[WIP] $FORZA_SUBJECT_TITLE (#$FORZA_SUBJECT_NUMBER)" \
-    --body "$BODY" \
-    2>/dev/null || true
+    --body "$BODY"

--- a/crates/forza-core/src/stage.rs
+++ b/crates/forza-core/src/stage.rs
@@ -263,7 +263,7 @@ impl Workflow {
                 vec![
                     Stage::agent(StageKind::Implement),
                     Stage::agent(StageKind::Test),
-                    Stage::shell(StageKind::DraftPr, DRAFT_PR_COMMAND).optional(),
+                    Stage::shell(StageKind::DraftPr, DRAFT_PR_COMMAND),
                     Stage::agent(StageKind::OpenPr),
                 ],
             ),


### PR DESCRIPTION
Temporary: set -x, removed || true, added gh auth status check. Will see the actual error.