### PR TITLE
fix(pipeline): warn when open_pr succeeds but no PR found

### DIFF
--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -463,6 +463,12 @@ pub async fn execute(
                     run.pr_number = Some(pr.number);
                     run.outcome = Some(Outcome::PrCreated { number: pr.number });
                 } else {
+                    warn!(
+                        number = work.subject.number,
+                        branch = %work.subject.branch,
+                        "open_pr stage succeeded but no PR found on branch — \
+                         gh pr create may have failed silently"
+                    );
                     run.outcome = Some(Outcome::NothingToDo);
                 }
             } else if merge_succeeded {
@@ -473,6 +479,11 @@ pub async fn execute(
                     run.pr_number = Some(pr.number);
                     run.outcome = Some(Outcome::PrMerged { number: pr.number });
                 } else {
+                    warn!(
+                        number = work.subject.number,
+                        branch = %work.subject.branch,
+                        "merge stage succeeded but no PR found on branch"
+                    );
                     run.outcome = Some(Outcome::NothingToDo);
                 }
             } else if comment_succeeded {


### PR DESCRIPTION
Adds warning logs when `open_pr` or `merge` stage succeeds but no PR is found via `fetch_pr_by_branch`. Previously this was a silent `NothingToDo`.

Root cause addressed in #501 (draft_pr --repo/--head fix). This adds observability.

Closes #491