### PR TITLE
feat(pipeline): native DraftPr stage — direct API calls, no gh CLI

### DIFF
--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -250,6 +250,14 @@ pub async fn execute(
                     files_modified: None,
                 }
             }
+            Execution::Native => {
+                info!(
+                    number = work.subject.number,
+                    stage = stage_name,
+                    "running native stage"
+                );
+                execute_native_stage(stage.kind, &work.subject, work_dir, gh, git).await
+            }
             Execution::Agent => {
                 let model = stage.model.as_deref().or(config.model.as_deref());
                 let base_skills = stage.skills.as_ref().unwrap_or(&config.skills);
@@ -542,6 +550,90 @@ pub async fn execute(
     );
 
     run
+}
+
+/// Execute a native stage via direct trait method calls.
+///
+/// Currently supports `DraftPr` — pushes the branch and creates a draft PR
+/// using the `GitClient` and `GitHubClient` traits directly, replacing the
+/// previous shell-based implementation.
+async fn execute_native_stage(
+    kind: StageKind,
+    subject: &Subject,
+    work_dir: &Path,
+    gh: &dyn GitHubClient,
+    git: &dyn GitClient,
+) -> StageResult {
+    let start = std::time::Instant::now();
+    match kind {
+        StageKind::DraftPr => {
+            // 1. Push the branch.
+            if let Err(e) = git.push(work_dir, &subject.branch, false).await {
+                return StageResult {
+                    stage: "draft_pr".into(),
+                    success: false,
+                    duration_secs: start.elapsed().as_secs_f64(),
+                    cost_usd: None,
+                    output: format!("failed to push branch: {e}"),
+                    files_modified: None,
+                };
+            }
+
+            // 2. Build PR title and body.
+            let title = format!("[WIP] {} (#{})", subject.title, subject.number);
+            let body = match tokio::fs::read_to_string(work_dir.join(".plan_breadcrumb.md")).await {
+                Ok(content) if !content.trim().is_empty() => content,
+                _ => format!(
+                    "Work in progress for {} (#{})",
+                    subject.title, subject.number
+                ),
+            };
+
+            // 3. Create the draft PR.
+            match gh
+                .create_pr(
+                    &subject.repo,
+                    &subject.branch,
+                    &title,
+                    &body,
+                    true,
+                    work_dir,
+                )
+                .await
+            {
+                Ok(pr_number) => StageResult {
+                    stage: "draft_pr".into(),
+                    success: true,
+                    duration_secs: start.elapsed().as_secs_f64(),
+                    cost_usd: None,
+                    output: format!("created draft PR #{pr_number}"),
+                    files_modified: None,
+                },
+                Err(e) => StageResult {
+                    stage: "draft_pr".into(),
+                    success: false,
+                    duration_secs: start.elapsed().as_secs_f64(),
+                    cost_usd: None,
+                    output: format!("failed to create draft PR: {e}"),
+                    files_modified: None,
+                },
+            }
+        }
+        other => {
+            warn!(stage = other.name(), "unsupported native stage kind");
+            StageResult {
+                stage: other.name().into(),
+                success: false,
+                duration_secs: start.elapsed().as_secs_f64(),
+                cost_usd: None,
+                output: format!(
+                    "native execution not implemented for stage: {}",
+                    other.name()
+                ),
+                files_modified: None,
+            }
+        }
+    }
 }
 
 /// Run finally hooks for a stage (always runs, regardless of outcome).

--- a/crates/forza-core/src/planner.rs
+++ b/crates/forza-core/src/planner.rs
@@ -72,8 +72,8 @@ pub fn generate_prompts(
         .iter()
         .enumerate()
         .map(|(i, stage)| {
-            // Shell stages don't need prompts — the command is in the stage.
-            if matches!(stage.execution, Execution::Shell { .. }) {
+            // Shell and native stages don't need prompts.
+            if matches!(stage.execution, Execution::Shell { .. } | Execution::Native) {
                 return String::new();
             }
 

--- a/crates/forza-core/src/stage.rs
+++ b/crates/forza-core/src/stage.rs
@@ -102,6 +102,8 @@ pub enum Execution {
         /// The shell command to execute via `sh -c`.
         command: String,
     },
+    /// Executed directly by the pipeline via trait methods — no agent or shell.
+    Native,
 }
 
 impl std::fmt::Display for Execution {
@@ -109,6 +111,7 @@ impl std::fmt::Display for Execution {
         match self {
             Execution::Agent => f.write_str("agent"),
             Execution::Shell { .. } => f.write_str("shell"),
+            Execution::Native => f.write_str("native"),
         }
     }
 }
@@ -170,6 +173,19 @@ impl Stage {
         }
     }
 
+    /// Create a new native-executed stage (direct API calls, no agent or shell).
+    pub fn native(kind: StageKind) -> Self {
+        Self {
+            kind,
+            execution: Execution::Native,
+            optional: false,
+            condition: None,
+            model: None,
+            skills: None,
+            mcp_config: None,
+        }
+    }
+
     /// Mark this stage as optional (failure won't stop the workflow).
     pub fn optional(mut self) -> Self {
         self.optional = true;
@@ -182,16 +198,16 @@ impl Stage {
         self
     }
 
-    /// Whether this stage runs a shell command directly.
+    /// Whether this stage runs without an agent (shell command or native API call).
     pub fn is_agentless(&self) -> bool {
-        matches!(self.execution, Execution::Shell { .. })
+        matches!(self.execution, Execution::Shell { .. } | Execution::Native)
     }
 
-    /// Returns the shell command if this is an agentless stage.
+    /// Returns the shell command if this is a shell-executed stage.
     pub fn shell_command(&self) -> Option<&str> {
         match &self.execution {
             Execution::Shell { command } => Some(command),
-            Execution::Agent => None,
+            Execution::Agent | Execution::Native => None,
         }
     }
 }
@@ -219,8 +235,8 @@ fn default_true() -> bool {
 
 /// Shell command for the DraftPr stage.
 /// Loaded from `commands/draft_pr.sh` at compile time.
-/// Shell command for the DraftPr stage.
-/// Loaded from `commands/draft_pr.sh` at compile time.
+/// Retained for custom shell-based DraftPr workflows.
+#[allow(dead_code)]
 const DRAFT_PR_COMMAND: &str = include_str!("commands/draft_pr.sh");
 
 /// Shell command for the Merge stage.
@@ -263,7 +279,7 @@ impl Workflow {
                 vec![
                     Stage::agent(StageKind::Implement),
                     Stage::agent(StageKind::Test),
-                    Stage::shell(StageKind::DraftPr, DRAFT_PR_COMMAND),
+                    Stage::native(StageKind::DraftPr),
                     Stage::agent(StageKind::OpenPr),
                 ],
             ),
@@ -271,7 +287,7 @@ impl Workflow {
                 "feature",
                 vec![
                     Stage::agent(StageKind::Plan),
-                    Stage::shell(StageKind::DraftPr, DRAFT_PR_COMMAND).optional(),
+                    Stage::native(StageKind::DraftPr).optional(),
                     Stage::agent(StageKind::Implement),
                     Stage::agent(StageKind::Test),
                     Stage::agent(StageKind::Review),
@@ -429,6 +445,15 @@ mod tests {
             .to_string(),
             "shell"
         );
+        assert_eq!(Execution::Native.to_string(), "native");
+    }
+
+    #[test]
+    fn stage_native_is_agentless() {
+        let s = Stage::native(StageKind::DraftPr);
+        assert!(s.is_agentless());
+        assert!(s.shell_command().is_none());
+        assert!(!s.optional);
     }
 
     #[test]

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -2598,11 +2598,7 @@ fn explain_route_verbose(name: &str, route: &forza::config::Route, config: &forz
         println!("  Workflow:    {wf_name}");
         println!("  Stages:");
         for (i, stage) in wf.stages.iter().enumerate() {
-            let exec = if stage.is_agentless() {
-                "shell"
-            } else {
-                "agent"
-            };
+            let exec = &stage.execution;
             let opt = if stage.optional { " (optional)" } else { "" };
             let cond = stage
                 .condition
@@ -2669,11 +2665,7 @@ fn explain_workflow(name: &str, config: &forza::RunnerConfig) -> ExitCode {
     println!("Workflow: {} ({wt})", wf.name);
     println!("{}", "-".repeat(60));
     for (i, stage) in wf.stages.iter().enumerate() {
-        let exec = if stage.is_agentless() {
-            "shell"
-        } else {
-            "agent"
-        };
+        let exec = &stage.execution;
         let opt = if stage.optional { " (optional)" } else { "" };
         let cond = stage
             .condition


### PR DESCRIPTION
## Summary

Add `Execution::Native` variant for stages that call Rust trait methods directly instead of shelling out to `gh` CLI.

**DraftPr** is the first native stage:
- Pushes branch via `GitClient::push()`
- Creates draft PR via `GitHubClient::create_pr()`
- No `gh` CLI dependency for PR creation
- Works reliably in CI/Actions (no worktree auth issues)

## Why

Root cause of #491 — `gh pr create` failed silently in worktrees on Actions because the CLI couldn't detect the repo. Native calls use the same `GITHUB_TOKEN` that forza already authenticates with.

## Changes

- `Execution::Native` enum variant
- `Stage::native()` constructor
- `execute_native_stage()` in pipeline for DraftPr dispatch
- `quick` and `feature` workflows use native DraftPr
- Merge stays Shell (complex auto-merge logic)

Closes #482 (partially — DraftPr native, Merge later)