### PR TITLE
feat(cli): search parent directories for forza.toml

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -433,18 +433,17 @@ fn load_config(path: &std::path::Path) -> Result<forza::RunnerConfig, ExitCode> 
     }
 }
 
-/// Walk parent directories looking for `forza.toml`, stopping at the filesystem
-/// root or when leaving the current git repository (no `.git` in the ancestor).
+/// Walk parent directories looking for `forza.toml`, stopping at the git repo root.
 fn find_config_in_ancestors() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
     for ancestor in cwd.ancestors().skip(1) {
-        // Stop if we've left the git repository.
-        if !ancestor.join(".git").exists() {
-            return None;
-        }
         let candidate = ancestor.join("forza.toml");
         if candidate.exists() {
             return Some(candidate);
+        }
+        // If this directory is the git repo root, don't search beyond it.
+        if ancestor.join(".git").exists() {
+            return None;
         }
     }
     None


### PR DESCRIPTION
## Summary

- When no `--config` flag is provided and no `forza.toml` exists in the current directory, forza now walks parent directories looking for `forza.toml`.
- The search stops at the git repository root (the directory containing `.git`) to avoid picking up unrelated config files.
- The `--config` flag and all existing fallback behavior remain unchanged.

## Files changed

- `crates/forza/src/main.rs` — added `find_config_in_ancestors()` helper and integrated it into `resolve_config`

## Test plan

- [ ] Run `forza issue` / `forza pr` from a subdirectory of a repo with `forza.toml` at the root and verify config is found
- [ ] Run from a directory outside any git repo and verify the existing error/default behavior
- [ ] Run with `--config path/to/forza.toml` and verify the explicit flag still takes precedence
- [ ] `cargo test --all` passes

Closes #495