### PR TITLE
feat(test-fixture): add factorial to forza-test-fixture calculator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "forza-test-fixture"
+version = "0.0.0"
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/forza", "crates/forza-core"]
+members = ["crates/forza", "crates/forza-core", "crates/forza-test-fixture"]
 resolver = "3"
 
 [workspace.package]

--- a/crates/forza-test-fixture/Cargo.toml
+++ b/crates/forza-test-fixture/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "forza-test-fixture"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+description = "Test fixture for forza integration tests — a simple calculator with intentional gaps"

--- a/crates/forza-test-fixture/src/lib.rs
+++ b/crates/forza-test-fixture/src/lib.rs
@@ -1,0 +1,72 @@
+/// A simple calculator for testing forza workflows.
+///
+/// This crate exists as a test fixture — forza integration tests create
+/// issues that add features, fix bugs, or refactor this code. The crate
+/// is intentionally simple so agent-driven changes are easy to verify.
+pub mod calculator {
+    /// Add two numbers.
+    pub fn add(a: i32, b: i32) -> i32 {
+        a + b
+    }
+
+    /// Subtract two numbers.
+    pub fn subtract(a: i32, b: i32) -> i32 {
+        a - b
+    }
+
+    /// Multiply two numbers.
+    pub fn multiply(a: i32, b: i32) -> i32 {
+        a * b
+    }
+
+    /// Divide two numbers. Returns None if divisor is zero.
+    pub fn divide(a: i32, b: i32) -> Option<i32> {
+        if b == 0 { None } else { Some(a / b) }
+    }
+
+    /// Compute the factorial of n. Returns None if n > 20 (would overflow u64).
+    pub fn factorial(n: u64) -> Option<u64> {
+        if n > 20 {
+            return None;
+        }
+        Some((1..=n).product())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::calculator::*;
+
+    #[test]
+    fn test_add() {
+        assert_eq!(add(2, 3), 5);
+        assert_eq!(add(-1, 1), 0);
+    }
+
+    #[test]
+    fn test_subtract() {
+        assert_eq!(subtract(5, 3), 2);
+    }
+
+    #[test]
+    fn test_multiply() {
+        assert_eq!(multiply(4, 3), 12);
+        assert_eq!(multiply(0, 100), 0);
+    }
+
+    #[test]
+    fn test_divide() {
+        assert_eq!(divide(10, 2), Some(5));
+        assert_eq!(divide(10, 0), None);
+    }
+
+    #[test]
+    fn test_factorial() {
+        assert_eq!(factorial(0), Some(1));
+        assert_eq!(factorial(1), Some(1));
+        assert_eq!(factorial(5), Some(120));
+        assert_eq!(factorial(10), Some(3628800));
+        assert_eq!(factorial(20), Some(2432902008176640000));
+        assert_eq!(factorial(21), None);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `factorial(n: u64) -> Option<u64>` function to the `forza-test-fixture` calculator module
- Returns `None` for inputs greater than 20 to prevent u64 overflow
- Includes unit tests covering base cases, typical values, and the overflow boundary
- Registers the `forza-test-fixture` crate in the workspace `Cargo.toml`

## Files changed
- `Cargo.toml` — added `forza-test-fixture` to the workspace members list
- `Cargo.lock` — updated lockfile with new crate entry
- `crates/forza-test-fixture/Cargo.toml` — new crate manifest for the test fixture
- `crates/forza-test-fixture/src/lib.rs` — calculator module with `factorial` implementation and unit tests

## Test plan
- [ ] `cargo test -p forza-test-fixture` passes all unit tests
- [ ] Tests cover: `factorial(0)` and `factorial(1)` (base cases), `factorial(5)` and `factorial(10)` (typical values), `factorial(20)` (boundary), `factorial(21)` returns `None` (overflow guard)
- [ ] `cargo build --workspace` succeeds with new crate in workspace

Closes #508