### PR TITLE
fix(prompts): add {comments} to plan and implement templates + test fixture crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/forza", "crates/forza-core"]
+members = ["crates/forza", "crates/forza-core", "crates/forza-test-fixture"]
 resolver = "3"
 
 [workspace.package]

--- a/crates/forza-core/src/prompts/implement.md
+++ b/crates/forza-core/src/prompts/implement.md
@@ -3,6 +3,7 @@
 Implement the changes for issue #{issue_number}.
 
 {issue_title}
+{comments}
 
 ## Context
 

--- a/crates/forza-core/src/prompts/plan.md
+++ b/crates/forza-core/src/prompts/plan.md
@@ -6,6 +6,7 @@ Read issue #{issue_number} and analyze the codebase to create an implementation 
 
 Issue body:
 {issue_context}
+{comments}
 
 ## Steps
 

--- a/crates/forza-test-fixture/Cargo.toml
+++ b/crates/forza-test-fixture/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "forza-test-fixture"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+description = "Test fixture for forza integration tests — a simple calculator with intentional gaps"

--- a/crates/forza-test-fixture/src/lib.rs
+++ b/crates/forza-test-fixture/src/lib.rs
@@ -1,0 +1,54 @@
+/// A simple calculator for testing forza workflows.
+///
+/// This crate exists as a test fixture — forza integration tests create
+/// issues that add features, fix bugs, or refactor this code. The crate
+/// is intentionally simple so agent-driven changes are easy to verify.
+pub mod calculator {
+    /// Add two numbers.
+    pub fn add(a: i32, b: i32) -> i32 {
+        a + b
+    }
+
+    /// Subtract two numbers.
+    pub fn subtract(a: i32, b: i32) -> i32 {
+        a - b
+    }
+
+    /// Multiply two numbers.
+    pub fn multiply(a: i32, b: i32) -> i32 {
+        a * b
+    }
+
+    /// Divide two numbers. Returns None if divisor is zero.
+    pub fn divide(a: i32, b: i32) -> Option<i32> {
+        if b == 0 { None } else { Some(a / b) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::calculator::*;
+
+    #[test]
+    fn test_add() {
+        assert_eq!(add(2, 3), 5);
+        assert_eq!(add(-1, 1), 0);
+    }
+
+    #[test]
+    fn test_subtract() {
+        assert_eq!(subtract(5, 3), 2);
+    }
+
+    #[test]
+    fn test_multiply() {
+        assert_eq!(multiply(4, 3), 12);
+        assert_eq!(multiply(0, 100), 0);
+    }
+
+    #[test]
+    fn test_divide() {
+        assert_eq!(divide(10, 2), Some(5));
+        assert_eq!(divide(10, 0), None);
+    }
+}

--- a/tests/integration/test-quick-workflow.sh
+++ b/tests/integration/test-quick-workflow.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Integration test: quick workflow end-to-end
+#
+# Creates a real issue on this repo, runs forza to add a function
+# to the test fixture crate, verifies the PR, then cleans up.
+#
+# Usage:
+#   ./tests/integration/test-quick-workflow.sh
+#
+# Requires: forza binary built, gh CLI authenticated, ANTHROPIC_API_KEY set
+
+set -euo pipefail
+
+REPO="joshrotenberg/forza"
+FIXTURE="crates/forza-test-fixture/src/lib.rs"
+FORZA="${FORZA:-cargo run -p forza --}"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== Integration Test: quick workflow ==="
+echo "Repo: $REPO"
+echo "Fixture: $FIXTURE"
+echo ""
+
+# Pick a function that doesn't exist yet
+FUNCS=("factorial" "fibonacci" "gcd" "lcm" "min_val" "max_val" "clamp" "sign" "pow_mod" "sum_range" "abs" "is_even" "is_positive" "square" "cube")
+FUNC=""
+for fn in "${FUNCS[@]}"; do
+    if ! grep -q "pub fn $fn" "$FIXTURE" 2>/dev/null; then
+        FUNC="$fn"
+        break
+    fi
+done
+
+if [ -z "$FUNC" ]; then
+    echo "ERROR: all test functions already exist in $FIXTURE"
+    exit 1
+fi
+
+echo "Test function: $FUNC"
+echo ""
+
+# 1. Create issue
+echo "Step 1: Creating issue..."
+ISSUE_URL=$(gh issue create --repo "$REPO" \
+    --title "[integration-test] add $FUNC to forza-test-fixture calculator" \
+    --body "Add a \`$FUNC\` function to the calculator module in \`$FIXTURE\`. Include at least 2 tests. Handle edge cases (zero, negative numbers where applicable). Run \`cargo test -p forza-test-fixture\` to verify." \
+    )
+ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -o '[0-9]*$')
+echo "  Created issue #$ISSUE_NUMBER"
+
+# Cleanup function
+cleanup() {
+    echo ""
+    echo "Cleaning up..."
+    gh issue close "$ISSUE_NUMBER" --repo "$REPO" \
+        --comment "Integration test complete." 2>/dev/null || true
+    for pr in $(gh pr list --repo "$REPO" --json number,headRefName \
+        --jq ".[] | select(.headRefName | contains(\"$ISSUE_NUMBER\")) | .number" 2>/dev/null); do
+        gh pr close "$pr" --repo "$REPO" --delete-branch 2>/dev/null || true
+    done
+    echo ""
+    echo "=== Results: $PASS passed, $FAIL failed ==="
+    [ "$FAIL" -eq 0 ] && exit 0 || exit 1
+}
+trap cleanup EXIT
+
+# 2. Run forza
+echo ""
+echo "Step 2: Running forza..."
+OUTPUT=$($FORZA issue "$ISSUE_NUMBER" --workflow quick 2>&1) || true
+echo "$OUTPUT" | tail -10
+
+# 3. Verify
+echo ""
+echo "Step 3: Verifying..."
+
+if echo "$OUTPUT" | grep -q "succeeded"; then
+    pass "forza reported success"
+else
+    fail "forza did not report success"
+fi
+
+sleep 3
+PR=$(gh pr list --repo "$REPO" --json number,headRefName \
+    --jq ".[] | select(.headRefName | contains(\"$ISSUE_NUMBER\")) | .number" \
+    | head -1)
+
+if [ -n "$PR" ]; then
+    pass "PR #$PR created"
+else
+    fail "no PR created"
+    exit 0
+fi
+
+ADDITIONS=$(gh pr view "$PR" --repo "$REPO" --json additions --jq '.additions')
+if [ "$ADDITIONS" -gt 0 ] 2>/dev/null; then
+    pass "PR has $ADDITIONS additions"
+else
+    fail "PR has no additions"
+fi
+
+BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName --jq '.headRefName')
+if gh api "repos/$REPO/contents/$FIXTURE?ref=$BRANCH" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | grep -q "pub fn $FUNC"; then
+    pass "function $FUNC exists in PR"
+else
+    fail "function $FUNC not found in PR"
+fi
+
+echo ""
+echo "Done."


### PR DESCRIPTION
## Problem

Issue comments were plumbed through Subject (#469) but no prompt templates included `{comments}`. Agents couldn't see human discussion, clarifications, or suggestions on issues.

Discovered when #495 had a comment suggesting `git rev-parse --show-toplevel` but the agent ignored it — because it literally couldn't see it.

## Fix

Add `{comments}` to `plan.md` and `implement.md` templates.

## Also

- `forza-test-fixture` crate (`publish=false`) — simple calculator for integration tests
- `tests/integration/test-quick-workflow.sh` — local end-to-end test script