### PR TITLE
feat(cli): search parent directories for forza.toml closes #495

### DIFF
--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -433,18 +433,17 @@ fn load_config(path: &std::path::Path) -> Result<forza::RunnerConfig, ExitCode> 
     }
 }
 
-/// Walk parent directories looking for `forza.toml`, stopping at the filesystem
-/// root or when leaving the current git repository (no `.git` in the ancestor).
+/// Walk parent directories looking for `forza.toml`, stopping at the git repo root.
 fn find_config_in_ancestors() -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
     for ancestor in cwd.ancestors().skip(1) {
-        // Stop if we've left the git repository.
-        if !ancestor.join(".git").exists() {
-            return None;
-        }
         let candidate = ancestor.join("forza.toml");
         if candidate.exists() {
             return Some(candidate);
+        }
+        // If this directory is the git repo root, don't search beyond it.
+        if ancestor.join(".git").exists() {
+            return None;
         }
     }
     None


### PR DESCRIPTION
## Summary

- Add `find_config_in_ancestors()` helper that walks parent directories looking for `forza.toml`
- Stops at the git repo root (`.git` boundary) to avoid crossing repository boundaries
- Integrates into `resolve_config()` as a fallback between the cwd check and the default/error paths
- Handles git worktrees correctly (`.git` can be a file, not just a directory)

## Files changed

- `crates/forza/src/main.rs` — added `find_config_in_ancestors()` and integrated it into `resolve_config()`

## Test plan

- [ ] Run `cargo test --all` to verify no regressions
- [ ] Manual: run `forza` from a subdirectory of a repo with `forza.toml` at the root — config should be found
- [ ] Manual: run `forza` from a directory outside any git repo — should fall back to default behavior
- [ ] Manual: verify `--config` flag still takes precedence over ancestor search

Closes #495