### PR TITLE
feat: multi-agent support — --agent flag, dedup, codex skills

### DIFF
--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -295,6 +295,27 @@ impl forza_core::GitClient for GitAdapter {
     }
 }
 
+// ── Agent factory ──────────────────────────────────────────────────────
+
+/// Create the appropriate agent executor based on the agent name.
+///
+/// Supported values: `"claude"` (default), `"codex"`.
+pub fn create_agent(agent_name: &str) -> Arc<dyn forza_core::AgentExecutor> {
+    match agent_name {
+        "codex" => {
+            tracing::info!(agent = "codex", "using Codex agent backend");
+            Arc::new(CodexAgentAdapter)
+        }
+        other => {
+            if other != "claude" {
+                tracing::warn!(agent = other, "unknown agent, falling back to Claude");
+            }
+            tracing::info!(agent = "claude", "using Claude agent backend");
+            Arc::new(ClaudeAgentAdapter)
+        }
+    }
+}
+
 // ── Agent adapter ───────────────────────────────────────────────────────
 
 /// Wraps `claude-wrapper` to satisfy `forza_core::AgentExecutor`.
@@ -371,21 +392,44 @@ pub struct CodexAgentAdapter;
 impl forza_core::AgentExecutor for CodexAgentAdapter {
     async fn execute(
         &self,
-        _stage_name: &str,
+        stage_name: &str,
         prompt: &str,
         work_dir: &Path,
         model: Option<&str>,
-        _skills: &[String],
+        skills: &[String],
         _mcp_config: Option<&str>,
         _append_system_prompt: Option<&str>,
         _allowed_tools: &[String],
     ) -> CoreResult<CoreStageResult> {
+        // Prepend skill file contents to the prompt so Codex gets the same
+        // context that Claude receives via --skill flags.
+        let full_prompt = if skills.is_empty() {
+            prompt.to_string()
+        } else {
+            let mut parts = Vec::new();
+            for skill_path in skills {
+                match std::fs::read_to_string(skill_path) {
+                    Ok(content) => parts.push(content),
+                    Err(e) => {
+                        tracing::warn!(
+                            stage = stage_name,
+                            path = skill_path,
+                            error = %e,
+                            "failed to read skill file, skipping"
+                        );
+                    }
+                }
+            }
+            parts.push(prompt.to_string());
+            parts.join("\n\n")
+        };
+
         let codex = codex_wrapper::Codex::builder()
             .working_dir(work_dir)
             .build()
             .map_err(|e| CoreError::Agent(format!("failed to create codex client: {e}")))?;
 
-        let mut cmd = codex_wrapper::ExecCommand::new(prompt).full_auto();
+        let mut cmd = codex_wrapper::ExecCommand::new(&full_prompt).full_auto();
 
         if let Some(m) = model {
             cmd = cmd.model(m);

--- a/crates/forza/src/api.rs
+++ b/crates/forza/src/api.rs
@@ -304,6 +304,7 @@ async fn trigger_issue(
             vec![],
             None,
             workflow_override,
+            None,
         )
         .await
         {
@@ -392,6 +393,7 @@ async fn trigger_pr(
             vec![],
             None,
             workflow_override,
+            None,
         )
         .await
         {
@@ -858,6 +860,7 @@ async fn exec_plan(
                 git.clone(),
                 None,
                 vec![],
+                None,
                 None,
                 None,
             )

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -135,6 +135,9 @@ struct IssueArgs {
     /// Branch to target PRs to (default: repo default branch).
     #[arg(long)]
     target_branch: Option<String>,
+    /// Override the agent backend (claude or codex).
+    #[arg(long)]
+    agent: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -168,6 +171,9 @@ struct PrArgs {
     /// Branch to target PRs to (default: repo default branch).
     #[arg(long)]
     target_branch: Option<String>,
+    /// Override the agent backend (claude or codex).
+    #[arg(long)]
+    agent: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -363,6 +369,9 @@ struct OpenArgs {
     /// Override the model (e.g. claude-opus-4-6).
     #[arg(long)]
     model: Option<String>,
+    /// Override the agent backend (claude or codex).
+    #[arg(long)]
+    agent: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -405,6 +414,9 @@ struct PlanArgs {
     /// The branch is created from `origin/main` before execution begins.
     #[arg(long, value_name = "BRANCH")]
     branch: Option<String>,
+    /// Override the agent backend (claude or codex).
+    #[arg(long)]
+    agent: Option<String>,
 }
 
 #[derive(Debug, Parser)]
@@ -661,10 +673,8 @@ async fn cmd_open(
         .replace("{preamble}", &preamble)
         .replace("{repo}", &repo);
 
-    let agent: std::sync::Arc<dyn forza_core::AgentExecutor> = match config.global.agent.as_str() {
-        "codex" => std::sync::Arc::new(forza::adapters::CodexAgentAdapter),
-        _ => std::sync::Arc::new(forza::adapters::ClaudeAgentAdapter),
-    };
+    let agent_name = args.agent.as_deref().unwrap_or(&config.global.agent);
+    let agent = forza::adapters::create_agent(agent_name);
 
     let model = args.model.as_deref().or(config.global.model.as_deref());
 
@@ -719,7 +729,7 @@ async fn cmd_plan(
 
     // Revise mode: update an existing plan issue.
     if let Some(plan_number) = args.revise {
-        return cmd_plan_revise(plan_number, &repo, &rd, config, gh).await;
+        return cmd_plan_revise(plan_number, &repo, &rd, config, gh, args.agent.as_deref()).await;
     }
 
     // Fetch issues based on selection.
@@ -759,10 +769,8 @@ async fn cmd_plan(
         "Bash(gh *)".into(),
     ];
 
-    let agent: std::sync::Arc<dyn forza_core::AgentExecutor> = match config.global.agent.as_str() {
-        "codex" => std::sync::Arc::new(forza::adapters::CodexAgentAdapter),
-        _ => std::sync::Arc::new(forza::adapters::ClaudeAgentAdapter),
-    };
+    let agent_name = args.agent.as_deref().unwrap_or(&config.global.agent);
+    let agent = forza::adapters::create_agent(agent_name);
 
     let model = args.model.as_deref().or(config.global.model.as_deref());
 
@@ -1021,6 +1029,7 @@ async fn cmd_plan_exec(
                         vec![],
                         branch_override_clone,
                         None,
+                        None,
                     )
                     .await;
                     (issue_number, result)
@@ -1200,6 +1209,7 @@ async fn cmd_plan_revise(
     rd: &std::path::Path,
     config: &forza::RunnerConfig,
     gh: &std::sync::Arc<dyn forza::github::GitHubClient>,
+    agent_override: Option<&str>,
 ) -> ExitCode {
     let plan_issue = match gh.fetch_issue(repo, plan_number).await {
         Ok(i) => i,
@@ -1238,10 +1248,8 @@ async fn cmd_plan_revise(
         "Bash(gh *)".into(),
     ];
 
-    let agent: std::sync::Arc<dyn forza_core::AgentExecutor> = match config.global.agent.as_str() {
-        "codex" => std::sync::Arc::new(forza::adapters::CodexAgentAdapter),
-        _ => std::sync::Arc::new(forza::adapters::ClaudeAgentAdapter),
-    };
+    let agent_name = agent_override.unwrap_or(&config.global.agent);
+    let agent = forza::adapters::create_agent(agent_name);
 
     let model = config.global.model.as_deref();
 
@@ -1858,6 +1866,7 @@ async fn cmd_issue(
             args.skill,
             None,
             args.workflow,
+            args.agent,
         )
         .await
         {
@@ -1882,6 +1891,7 @@ async fn cmd_issue(
         args.skill,
         args.base_branch,
         args.workflow,
+        args.agent,
     )
     .await
     {
@@ -1991,6 +2001,7 @@ async fn cmd_pr(
             args.skill,
             None,
             args.workflow,
+            args.agent,
         )
         .await
         {
@@ -2015,6 +2026,7 @@ async fn cmd_pr(
         args.skill,
         None,
         args.workflow,
+        args.agent,
     )
     .await
     {
@@ -3070,6 +3082,7 @@ async fn cmd_fix(
         git.clone(),
         None,
         vec![],
+        None,
         None,
         None,
     )

--- a/crates/forza/src/mcp.rs
+++ b/crates/forza/src/mcp.rs
@@ -226,6 +226,7 @@ pub fn build_router(state: AppState) -> McpRouter {
                     vec![],
                     None,
                     input.workflow,
+                    None,
                 )
                 .await
                 {
@@ -268,6 +269,7 @@ pub fn build_router(state: AppState) -> McpRouter {
                     vec![],
                     None,
                     input.workflow,
+                    None,
                 )
                 .await
                 {
@@ -831,6 +833,7 @@ pub fn build_router(state: AppState) -> McpRouter {
                         app.git.clone(),
                         None,
                         vec![],
+                        None,
                         None,
                         None,
                     )

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -27,7 +27,7 @@ use forza_core::run::Run;
 use forza_core::stage::Workflow;
 use forza_core::subject::SubjectKind;
 
-use crate::adapters::{self, ClaudeAgentAdapter, CodexAgentAdapter, GitAdapter, GitHubAdapter};
+use crate::adapters::{self, GitAdapter, GitHubAdapter};
 use crate::config::{self, IssueOrder, Route, RunnerConfig};
 use crate::state;
 
@@ -632,25 +632,9 @@ fn to_core_stage_kind(kind: crate::workflow::StageKind) -> forza_core::StageKind
     }
 }
 
-/// Generate a branch name from a pattern by substituting issue metadata.
-///
-/// Create the appropriate agent executor based on the config's `agent` field.
-///
-/// Supported values: `"claude"` (default), `"codex"`.
+/// Delegate to the shared agent factory in `adapters`.
 fn create_agent(config: &RunnerConfig) -> Arc<dyn forza_core::AgentExecutor> {
-    match config.global.agent.as_str() {
-        "codex" => {
-            info!(agent = "codex", "using Codex agent backend");
-            Arc::new(CodexAgentAdapter)
-        }
-        other => {
-            if other != "claude" {
-                warn!(agent = other, "unknown agent, falling back to Claude");
-            }
-            info!(agent = "claude", "using Claude agent backend");
-            Arc::new(ClaudeAgentAdapter)
-        }
-    }
+    adapters::create_agent(&config.global.agent)
 }
 
 /// The pattern supports four placeholders:
@@ -747,6 +731,7 @@ pub async fn process_issue(
     skill_overrides: Vec<String>,
     base_branch_override: Option<String>,
     workflow_override: Option<String>,
+    agent_override: Option<String>,
 ) -> forza_core::Result<Run> {
     tracing::info!(number, repo, "processing issue");
     let issue = gh.fetch_issue(repo, number).await.map_err(|e| match e {
@@ -832,7 +817,8 @@ pub async fn process_issue(
 
     let gh_adapter = Arc::new(GitHubAdapter::new(gh));
     let git_adapter = Arc::new(GitAdapter::new(git));
-    let agent = create_agent(config);
+    let agent_name = agent_override.as_deref().unwrap_or(&config.global.agent);
+    let agent = adapters::create_agent(agent_name);
 
     Ok(execute_work(
         matched,
@@ -861,6 +847,7 @@ pub async fn process_pr(
     skill_overrides: Vec<String>,
     route_override: Option<String>,
     workflow_override: Option<String>,
+    agent_override: Option<String>,
 ) -> forza_core::Result<Run> {
     tracing::info!(number, repo, "processing PR");
     let pr = gh.fetch_pr(repo, number).await.map_err(|e| match e {
@@ -931,7 +918,8 @@ pub async fn process_pr(
 
     let gh_adapter = Arc::new(GitHubAdapter::new(gh));
     let git_adapter = Arc::new(GitAdapter::new(git));
-    let agent = create_agent(config);
+    let agent_name = agent_override.as_deref().unwrap_or(&config.global.agent);
+    let agent = adapters::create_agent(agent_name);
 
     Ok(execute_work(
         matched,

--- a/crates/forza/tests/orchestrator.rs
+++ b/crates/forza/tests/orchestrator.rs
@@ -157,6 +157,7 @@ async fn issue_workflow_creates_run_record() {
         vec![],
         None,
         None,
+        None,
     )
     .await;
 
@@ -211,6 +212,7 @@ async fn worktree_cleaned_up_after_run() {
         git,
         None,
         vec![],
+        None,
         None,
         None,
     )


### PR DESCRIPTION
## Summary

Three improvements for multi-agent support:

1. **`create_agent()` helper** — single function for agent selection, replaces 4+ duplicated match blocks
2. **`--agent` flag** on issue, pr, plan, open — override the config agent per-command
3. **Codex skill support** — reads skill files and prepends to prompt (was silently ignored)

```bash
forza issue 42 --workflow quick --agent codex
forza pr 84 --workflow pr-fix --agent claude
```

Partially closes #518 (items 1-3 done, per-route agent override is future)