### PR TITLE
fix(prompts): make implement/test prompts resilient to missing breadcrumbs

### DIFF
--- a/crates/forza-core/src/prompts/implement.md
+++ b/crates/forza-core/src/prompts/implement.md
@@ -7,13 +7,13 @@ Implement the changes for issue #{issue_number}.
 
 ## Context
 
-Read the plan breadcrumb at `.plan_breadcrumb.md` for the list of files to modify and the approach decided in the plan stage.
+If a plan breadcrumb exists at `.plan_breadcrumb.md`, read it for the list of files to modify and the approach. If it does not exist, use the issue title and description above to determine what to implement.
 
 ## Instructions
 
-1. Only modify the files listed in the breadcrumb. Do NOT touch any other files.
+1. If the breadcrumb exists, only modify the files listed there. Otherwise, determine the minimal set of files to change from the issue description.
 2. Follow the existing code patterns and style.
 3. Follow the project's existing language idioms and conventions.
-{validation_step}{commit_num}. Commit using the exact commit message from the breadcrumb.
+{validation_step}{commit_num}. Stage all changed files with `git add` and commit. If the breadcrumb contains a commit message, use it exactly. Otherwise, write a conventional-commit message that references the issue (e.g., `feat(module): short description closes #{issue_number}`).
 
 Do NOT create a PR in this stage.

--- a/crates/forza-core/src/prompts/test.md
+++ b/crates/forza-core/src/prompts/test.md
@@ -7,3 +7,5 @@ Run each of the following and confirm they pass:
 
 If any command fails, fix the issue and re-run until all pass.
 Do NOT modify implementation logic — only fix formatting, linter warnings, or test failures caused by missing test coverage.
+
+If you made any fixes, stage and commit them: `git add -A && git commit -m "fix: address validation failures for #{issue_number}"`.

--- a/crates/forza/src/github/octocrab_client.rs
+++ b/crates/forza/src/github/octocrab_client.rs
@@ -510,7 +510,7 @@ impl GitHubClient for OctocrabClient {
             .draft(draft)
             .send()
             .await
-            .map_err(|e| Error::GitHub(format!("create PR: {e}")))?;
+            .map_err(|e| Error::GitHub(format!("create PR: {e:#?}")))?;
 
         Ok(PullRequest {
             number: pr.number,


### PR DESCRIPTION
## Summary

- Implement prompt no longer assumes `.plan_breadcrumb.md` exists -- falls back to issue description when there's no plan stage (e.g. `quick` workflow)
- Explicit `git add` + commit instructions so agents that follow instructions literally (Codex) actually produce commits
- Test prompt now commits any fixes it makes during validation
- Octocrab `create_pr` error uses Debug format so API errors are readable instead of just "GitHub"

## Context

Codex runs on the `quick` workflow (implement -> test -> draft_pr -> open_pr) were failing at `draft_pr` because the implement stage produced no commits. The branch tip was identical to master, so `gh pr create` / octocrab failed with no diff. Claude handled the missing breadcrumb gracefully; Codex did not.

## Test plan

- [x] `cargo test -p forza-core --lib` (137 passed)
- [x] `cargo test -p forza --lib` (134 passed)
- [ ] Re-run `forza issue <N> --workflow quick --agent codex` against a test repo