### PR TITLE
fix(codex): use full sandbox bypass so Codex can commit in worktrees

### DIFF
--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -384,8 +384,10 @@ impl forza_core::AgentExecutor for ClaudeAgentAdapter {
 
 /// Wraps `codex-wrapper` to satisfy `forza_core::AgentExecutor`.
 ///
-/// Uses `codex exec --full-auto` with the prompt as the command argument.
-/// Codex uses its own default model unless overridden.
+/// Uses `codex exec --dangerously-bypass-approvals-and-sandbox` so Codex has
+/// full git access in the worktree (the default `--full-auto` sandbox makes
+/// `.git` read-only, preventing commits). Codex uses its own default model
+/// unless overridden.
 pub struct CodexAgentAdapter;
 
 #[async_trait]
@@ -429,7 +431,8 @@ impl forza_core::AgentExecutor for CodexAgentAdapter {
             .build()
             .map_err(|e| CoreError::Agent(format!("failed to create codex client: {e}")))?;
 
-        let mut cmd = codex_wrapper::ExecCommand::new(&full_prompt).full_auto();
+        let mut cmd = codex_wrapper::ExecCommand::new(&full_prompt)
+            .dangerously_bypass_approvals_and_sandbox();
 
         if let Some(m) = model {
             cmd = cmd.model(m);


### PR DESCRIPTION
## Summary

- Switch Codex adapter from `--full-auto` to `--dangerously-bypass-approvals-and-sandbox`
- The `--full-auto` sandbox makes `.git` read-only, which prevents `git add`/`git commit` in worktrees
- This was the root cause of Codex runs failing at `draft_pr` -- implement/test stages reported success but produced zero commits

## Context

Codex's `workspace-write` sandbox (what `--full-auto` sets) deliberately protects `.git` as read-only, even in worktrees ([openai/codex#7071](https://github.com/openai/codex/issues/7071)). Since forza already isolates agent work in git worktrees and `forza.toml` is the trust boundary, the sandbox restriction just blocks necessary git operations.

Follow-up issue for configurable agent permissions: #526

## Test plan

- [x] `cargo test -p forza --lib` (134 passed)
- [ ] Re-run `forza issue <N> --workflow quick --agent codex` against a test repo