### PR TITLE
fix(codex): skip Claude-specific models when invoking Codex

### DIFF
--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -435,7 +435,10 @@ impl forza_core::AgentExecutor for CodexAgentAdapter {
             .dangerously_bypass_approvals_and_sandbox();
 
         if let Some(m) = model {
-            cmd = cmd.model(m);
+            // Skip Claude-specific models — let Codex use its default.
+            if !m.starts_with("claude") {
+                cmd = cmd.model(m);
+            }
         }
 
         let start = std::time::Instant::now();


### PR DESCRIPTION
## Summary

- Filter out `claude`-prefixed models in the Codex adapter so Codex uses its own default
- The `forza.toml` global `model = "claude-sonnet-4-6"` was being passed through to Codex, which rejected it immediately (5s failure)

## Context

Discovered while testing the sandbox fix from #525. The redis-server-wrapper repo has `model = "claude-sonnet-4-6"` in its `forza.toml`, which gets passed to whatever agent is running. Proper per-agent model config is tracked in #531.

## Test plan

- [x] `cargo test -p forza --lib` (134 passed)
- [ ] Re-run `forza issue <N> --workflow quick --agent codex` against redis-server-wrapper