### PR TITLE
fix(runner): skip closed issues/PRs, auto-prune stale worktrees

### DIFF
--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -742,10 +742,26 @@ async fn load_breadcrumb(run_id: &str, stage_name: &str, work_dir: &Path) -> Opt
 }
 
 /// Create a worktree for isolated execution.
+///
+/// If a previous run left the worktree registered but the directory missing,
+/// prune stale entries before retrying.
 async fn create_worktree(repo_dir: &Path, branch: &str, git: &dyn GitClient) -> Result<PathBuf> {
     let worktree_dir = repo_dir.join(".worktrees").join(branch.replace('/', "-"));
-    git.create_worktree(repo_dir, branch, &worktree_dir).await?;
-    Ok(worktree_dir)
+    match git.create_worktree(repo_dir, branch, &worktree_dir).await {
+        Ok(()) => Ok(worktree_dir),
+        Err(_) if !worktree_dir.exists() => {
+            // Directory missing but registered — prune and retry.
+            info!("pruning stale worktree registration, retrying");
+            let _ = tokio::process::Command::new("git")
+                .args(["worktree", "prune"])
+                .current_dir(repo_dir)
+                .output()
+                .await;
+            git.create_worktree(repo_dir, branch, &worktree_dir).await?;
+            Ok(worktree_dir)
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Save a run record to the state directory.

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -739,6 +739,12 @@ pub async fn process_issue(
         _ => forza_core::Error::GitHub(e.to_string()),
     })?;
 
+    if issue.state == "closed" {
+        return Err(forza_core::Error::GitHub(format!(
+            "issue #{number} is already closed"
+        )));
+    }
+
     let mut matched = if let Some(wf_name) = workflow_override {
         // Workflow override: skip route matching, build a synthetic route.
         let branch = generate_branch(
@@ -854,6 +860,13 @@ pub async fn process_pr(
         crate::error::Error::GitHub(msg) => forza_core::Error::GitHub(msg),
         _ => forza_core::Error::GitHub(e.to_string()),
     })?;
+
+    if pr.state == "closed" || pr.state == "merged" {
+        return Err(forza_core::Error::GitHub(format!(
+            "PR #{number} is already {}",
+            pr.state
+        )));
+    }
 
     let mut matched = if let Some(wf_name) = workflow_override {
         // Workflow override: skip route matching, build a synthetic route.


### PR DESCRIPTION
## Summary

- \`process_issue()\` checks issue state and returns early if closed
- \`process_pr()\` checks PR state and returns early if closed/merged
- \`create_worktree()\` detects "missing but registered" worktrees and auto-prunes before retrying

## Context

Running \`forza issue\` on a closed issue or a stale worktree both produced confusing errors instead of clean failures.

Closes #537, closes #538

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test -p forza-core --lib\` (137 passed)
- [x] \`cargo test -p forza --lib\` (134 passed)