### PR TITLE
fix(codex): warn when unsupported options are silently dropped

### DIFF
--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -425,10 +425,30 @@ impl forza_core::AgentExecutor for CodexAgentAdapter {
         work_dir: &Path,
         model: Option<&str>,
         skills: &[String],
-        _mcp_config: Option<&str>,
-        _append_system_prompt: Option<&str>,
-        _allowed_tools: &[String],
+        mcp_config: Option<&str>,
+        append_system_prompt: Option<&str>,
+        allowed_tools: &[String],
     ) -> CoreResult<CoreStageResult> {
+        if mcp_config.is_some() {
+            tracing::warn!(
+                stage = stage_name,
+                "Codex does not support MCP config; mcp_config will be ignored"
+            );
+        }
+        if append_system_prompt.is_some() {
+            tracing::warn!(
+                stage = stage_name,
+                "Codex does not support append_system_prompt; value will be ignored"
+            );
+        }
+        if !allowed_tools.is_empty() {
+            tracing::warn!(
+                stage = stage_name,
+                "Codex does not support allowed_tools; {} tool(s) will be ignored",
+                allowed_tools.len()
+            );
+        }
+
         // Prepend skill file contents to the prompt so Codex gets the same
         // context that Claude receives via --skill flags.
         let full_prompt = if skills.is_empty() {


### PR DESCRIPTION
## Summary

- Rename `_mcp_config`, `_append_system_prompt`, and `_allowed_tools` params in `CodexAgentAdapter::execute()` and add `tracing::warn!` calls when they are provided (non-empty/non-None), so users know their config is being ignored by the Codex backend.

Closes #529

## Test plan

- `cargo clippy --all --all-targets -- -D warnings` passes
- `cargo test -p forza --lib` passes (134 tests)
- Manually verify warnings appear when running Codex with mcp_config, append_system_prompt, or allowed_tools set