### PR TITLE
refactor: extract shared skill-file logic, fix codex init path

### DIFF
--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -11,6 +11,38 @@ use async_trait::async_trait;
 use forza_core::error::{Error as CoreError, Result as CoreResult};
 use forza_core::run::StageResult as CoreStageResult;
 use forza_core::subject::{Subject, SubjectKind};
+use tracing::warn;
+
+// ── Shared helpers ─────────────────────────────────────────────────────
+
+/// Read skill files and prepend their contents to a prompt.
+///
+/// Each skill path is resolved relative to `work_dir` if not absolute.
+/// Unreadable files are skipped with a warning.
+pub fn prepend_skill_files(prompt: &str, skills: &[String], work_dir: &Path) -> String {
+    if skills.is_empty() {
+        return prompt.to_string();
+    }
+    let mut parts = Vec::with_capacity(skills.len() + 1);
+    for skill in skills {
+        let skill_path = {
+            let p = Path::new(skill);
+            if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                work_dir.join(p)
+            }
+        };
+        match std::fs::read_to_string(&skill_path) {
+            Ok(content) => parts.push(content),
+            Err(e) => {
+                warn!(path = %skill_path.display(), error = %e, "skipping unreadable skill file");
+            }
+        }
+    }
+    parts.push(prompt.to_string());
+    parts.join("\n\n")
+}
 
 use crate::github::{IssueCandidate, PrCandidate};
 
@@ -449,28 +481,7 @@ impl forza_core::AgentExecutor for CodexAgentAdapter {
             );
         }
 
-        // Prepend skill file contents to the prompt so Codex gets the same
-        // context that Claude receives via --skill flags.
-        let full_prompt = if skills.is_empty() {
-            prompt.to_string()
-        } else {
-            let mut parts = Vec::new();
-            for skill_path in skills {
-                match std::fs::read_to_string(skill_path) {
-                    Ok(content) => parts.push(content),
-                    Err(e) => {
-                        tracing::warn!(
-                            stage = stage_name,
-                            path = skill_path,
-                            error = %e,
-                            "failed to read skill file, skipping"
-                        );
-                    }
-                }
-            }
-            parts.push(prompt.to_string());
-            parts.join("\n\n")
-        };
+        let full_prompt = prepend_skill_files(prompt, skills, work_dir);
 
         let codex = codex_wrapper::Codex::builder()
             .working_dir(work_dir)

--- a/crates/forza/src/executor.rs
+++ b/crates/forza/src/executor.rs
@@ -6,7 +6,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::error::{Error, Result};
 use crate::planner::PlannedStage;
@@ -109,29 +109,7 @@ impl AgentAdapter for ClaudeAdapter {
         // Read skill files and prepend their content to the prompt instead of
         // using --file, which requires session token persistence in recent Claude
         // Code versions.
-        let prompt = if self.skills.is_empty() {
-            stage.prompt.clone()
-        } else {
-            let mut parts = Vec::with_capacity(self.skills.len() + 1);
-            for skill in &self.skills {
-                let skill_path = {
-                    let p = Path::new(skill);
-                    if p.is_absolute() {
-                        p.to_path_buf()
-                    } else {
-                        work_dir.join(p)
-                    }
-                };
-                match std::fs::read_to_string(&skill_path) {
-                    Ok(content) => parts.push(content),
-                    Err(e) => {
-                        warn!(path = %skill_path.display(), error = %e, "skipping unreadable skill file");
-                    }
-                }
-            }
-            parts.push(stage.prompt.clone());
-            parts.join("\n\n")
-        };
+        let prompt = crate::adapters::prepend_skill_files(&stage.prompt, &self.skills, work_dir);
 
         let mut cmd = QueryCommand::new(&prompt)
             .output_format(OutputFormat::StreamJson)

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -1441,7 +1441,14 @@ async fn cmd_init(args: InitArgs, gh: &dyn forza::github::GitHubClient) -> ExitC
 
         let mut cmd = match agent {
             "codex" => {
-                let mut c = tokio::process::Command::new("codex");
+                let codex = match codex_wrapper::Codex::builder().working_dir(".").build() {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("error creating codex client: {e}");
+                        return ExitCode::FAILURE;
+                    }
+                };
+                let mut c = tokio::process::Command::new(codex.binary());
                 // Codex gets the prompt as a positional arg in exec mode
                 c.arg("exec").arg("--full-auto").arg(&system_prompt);
                 c


### PR DESCRIPTION
## Summary

- Extract duplicated skill-file-reading code from `ClaudeAdapter` (executor.rs) and `CodexAgentAdapter` (adapters.rs) into a shared `prepend_skill_files()` helper function in adapters.rs
- Fix `forza init --guided` codex path to use `codex_wrapper::Codex::builder()` for consistent binary resolution, matching the Claude path's use of `Claude::builder()`

Closes #532

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all --all-targets -- -D warnings` passes
- [x] `cargo test -p forza --lib` passes (134 tests)