### PR TITLE
feat(cli): infer agent from model name when --agent is not specified

### DIFF
--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -329,6 +329,48 @@ impl forza_core::GitClient for GitAdapter {
 
 // ── Agent factory ──────────────────────────────────────────────────────
 
+/// Infer the agent name from a model string.
+///
+/// Returns `Some("codex")` for OpenAI models, `Some("claude")` for Anthropic
+/// models, or `None` if the model doesn't clearly identify an agent.
+pub fn infer_agent_from_model(model: &str) -> Option<&'static str> {
+    if model.starts_with("o1")
+        || model.starts_with("o3")
+        || model.starts_with("gpt")
+        || model.starts_with("codex")
+    {
+        Some("codex")
+    } else if model.starts_with("claude")
+        || model.starts_with("sonnet")
+        || model.starts_with("opus")
+        || model.starts_with("haiku")
+    {
+        Some("claude")
+    } else {
+        None
+    }
+}
+
+/// Resolve the agent name from explicit `--agent`, `--model`, and config default.
+///
+/// Priority: explicit `--agent` > inferred from `--model` > config default.
+pub fn resolve_agent_name<'a>(
+    agent_override: Option<&'a str>,
+    model_override: Option<&'a str>,
+    config_default: &'a str,
+) -> &'a str {
+    if let Some(agent) = agent_override {
+        return agent;
+    }
+    if let Some(model) = model_override
+        && let Some(inferred) = infer_agent_from_model(model)
+    {
+        tracing::info!(model, agent = inferred, "inferred agent from model");
+        return inferred;
+    }
+    config_default
+}
+
 /// Create the appropriate agent executor based on the agent name.
 ///
 /// Supported values: `"claude"` (default), `"codex"`.

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -811,6 +811,14 @@ pub async fn process_issue(
         }
     };
 
+    // Resolve agent before model_override is consumed.
+    let agent_name = adapters::resolve_agent_name(
+        agent_override.as_deref(),
+        model_override.as_deref(),
+        &config.global.agent,
+    )
+    .to_string();
+
     // Apply CLI overrides (for the route-matched path; workflow override path sets these above).
     if matched.route_name != "direct" {
         if let Some(m) = model_override {
@@ -823,8 +831,7 @@ pub async fn process_issue(
 
     let gh_adapter = Arc::new(GitHubAdapter::new(gh));
     let git_adapter = Arc::new(GitAdapter::new(git));
-    let agent_name = agent_override.as_deref().unwrap_or(&config.global.agent);
-    let agent = adapters::create_agent(agent_name);
+    let agent = adapters::create_agent(&agent_name);
 
     Ok(execute_work(
         matched,
@@ -919,6 +926,14 @@ pub async fn process_pr(
         }
     };
 
+    // Resolve agent before model_override is consumed.
+    let agent_name = adapters::resolve_agent_name(
+        agent_override.as_deref(),
+        model_override.as_deref(),
+        &config.global.agent,
+    )
+    .to_string();
+
     // Apply CLI overrides (for the route-matched path; workflow override path sets these above).
     if matched.route_name != "direct" {
         if let Some(m) = model_override {
@@ -931,8 +946,7 @@ pub async fn process_pr(
 
     let gh_adapter = Arc::new(GitHubAdapter::new(gh));
     let git_adapter = Arc::new(GitAdapter::new(git));
-    let agent_name = agent_override.as_deref().unwrap_or(&config.global.agent);
-    let agent = adapters::create_agent(agent_name);
+    let agent = adapters::create_agent(&agent_name);
 
     Ok(execute_work(
         matched,


### PR DESCRIPTION
## Summary

- `forza issue 5 --model o3` now automatically uses Codex without needing `--agent codex`
- Adds `infer_agent_from_model()` and `resolve_agent_name()` helpers
- Priority: explicit `--agent` > inferred from `--model` > config default
- OpenAI models (o1/o3/gpt) -> codex, Anthropic models (claude/sonnet/opus/haiku) -> claude

Closes #545

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --all-targets -- -D warnings`
- [x] `cargo test -p forza --lib` (134 passed)