### PR TITLE
refactor(pipeline): move breadcrumbs from worktree to state directory

### DIFF
--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -389,8 +389,9 @@ pub async fn execute(
         )
         .await;
 
-        // Load breadcrumb for next stage.
-        pending_breadcrumb = load_breadcrumb(&run_id, stage_name, work_dir).await;
+        // Collect breadcrumbs: move from worktree to state dir, then load.
+        collect_breadcrumbs(&run_id, stage_name, work_dir, state_dir).await;
+        pending_breadcrumb = load_breadcrumb(&run_id, stage_name, state_dir).await;
         if pending_breadcrumb.is_some() {
             info!(
                 number = work.subject.number,
@@ -771,10 +772,50 @@ async fn auto_commit_if_needed(work_dir: &Path, subject: &Subject) {
     }
 }
 
-/// Load a breadcrumb file from a completed stage.
-async fn load_breadcrumb(run_id: &str, stage_name: &str, work_dir: &Path) -> Option<String> {
-    let path = work_dir
+/// Collect breadcrumbs from the worktree into the state directory.
+///
+/// After an agent stage, moves breadcrumb files from the worktree's
+/// `.forza/breadcrumbs/{run_id}/` to `{state_dir}/breadcrumbs/{run_id}/`.
+/// Also collects named breadcrumbs (`.plan_breadcrumb.md`, etc.) using
+/// the stage name as the key.
+async fn collect_breadcrumbs(run_id: &str, stage_name: &str, work_dir: &Path, state_dir: &Path) {
+    let dest_dir = state_dir.join("breadcrumbs").join(run_id);
+    let _ = tokio::fs::create_dir_all(&dest_dir).await;
+
+    // 1. Move stage breadcrumb from worktree .forza/breadcrumbs/{run_id}/{stage}.md
+    let worktree_bc = work_dir
         .join(".forza")
+        .join("breadcrumbs")
+        .join(run_id)
+        .join(format!("{stage_name}.md"));
+    if let Ok(content) = tokio::fs::read_to_string(&worktree_bc).await {
+        let dest = dest_dir.join(format!("{stage_name}.md"));
+        let _ = tokio::fs::write(&dest, &content).await;
+        let _ = tokio::fs::remove_file(&worktree_bc).await;
+    }
+
+    // 2. Collect named breadcrumbs (written to worktree root by agent prompts).
+    let named_files: &[(&str, &str)] = &[
+        (".plan_breadcrumb.md", "plan"),
+        (".review_breadcrumb.md", "review"),
+        (".research_breadcrumb.md", "research"),
+    ];
+    for (filename, key) in named_files {
+        let src = work_dir.join(filename);
+        if let Ok(content) = tokio::fs::read_to_string(&src).await
+            && !content.trim().is_empty()
+        {
+            let dest = dest_dir.join(format!("{key}.md"));
+            let _ = tokio::fs::write(&dest, &content).await;
+            // Don't remove — draft_pr native stage still reads .plan_breadcrumb.md
+            // from the worktree. The .gitignore prevents it from being committed.
+        }
+    }
+}
+
+/// Load a breadcrumb file from the state directory.
+async fn load_breadcrumb(run_id: &str, stage_name: &str, state_dir: &Path) -> Option<String> {
+    let path = state_dir
         .join("breadcrumbs")
         .join(run_id)
         .join(format!("{stage_name}.md"));
@@ -1225,7 +1266,7 @@ mod tests {
     #[tokio::test]
     async fn load_breadcrumb_reads_file() {
         let dir = tempfile::tempdir().unwrap();
-        let bc_dir = dir.path().join(".forza").join("breadcrumbs").join("run-1");
+        let bc_dir = dir.path().join("breadcrumbs").join("run-1");
         std::fs::create_dir_all(&bc_dir).unwrap();
         std::fs::write(bc_dir.join("plan.md"), "# Plan\nDo the thing.").unwrap();
 

--- a/crates/forza-core/src/prompts/implement.md
+++ b/crates/forza-core/src/prompts/implement.md
@@ -5,15 +5,11 @@ Implement the changes for issue #{issue_number}.
 {issue_title}
 {comments}
 
-## Context
-
-If a plan breadcrumb exists at `.plan_breadcrumb.md`, read it for the list of files to modify and the approach. If it does not exist, use the issue title and description above to determine what to implement.
-
 ## Instructions
 
-1. If the breadcrumb exists, only modify the files listed there. Otherwise, determine the minimal set of files to change from the issue description.
+1. If context from a previous planning stage was provided above, follow its file list and approach. Otherwise, determine the minimal set of files to change from the issue description.
 2. Follow the existing code patterns and style.
 3. Follow the project's existing language idioms and conventions.
-{validation_step}{commit_num}. Stage all changed files with `git add` and commit. If the breadcrumb contains a commit message, use it exactly. Otherwise, write a conventional-commit message that references the issue (e.g., `feat(module): short description closes #{issue_number}`).
+{validation_step}{commit_num}. Stage all changed files with `git add` and commit. If a commit message was provided in the context above, use it exactly. Otherwise, write a conventional-commit message that references the issue (e.g., `feat(module): short description closes #{issue_number}`).
 
 Do NOT create a PR in this stage.

--- a/crates/forza-core/src/prompts/open_pr.md
+++ b/crates/forza-core/src/prompts/open_pr.md
@@ -5,21 +5,20 @@ Create or update a pull request for issue #{issue_number}.
 ## Steps
 
 1. Push the branch to origin: `git push origin HEAD`
-2. Read `.plan_breadcrumb.md` for the commit message and files changed.
-3. Read `.review_breadcrumb.md` if it exists for the review verdict.
-4. Check if a draft PR already exists on this branch: `gh pr list --head $(git branch --show-current) --json number,isDraft --jq '.[0]'`
-5. If a draft PR exists, update it and mark it ready for review:
+2. Use the context from previous stages (provided above) for the commit message, files changed, and review verdict.
+3. Check if a draft PR already exists on this branch: `gh pr list --head $(git branch --show-current) --json number,isDraft --jq '.[0]'`
+4. If a draft PR exists, update it and mark it ready for review:
    ```
    gh pr edit <number> --title "<commit message>" --body "<PR body>"
    gh pr ready <number>
    ```
-6. If no PR exists, create one using the template below.
+5. If no PR exists, create one using the template below.
 
 ## PR template
 
 ```
 gh pr create \
---title "<commit message from plan breadcrumb>" \
+--title "<commit message from context above>" \
 --body "$(cat <<'EOF'
 ## Summary
 <2-4 bullet points describing what changed and why>


### PR DESCRIPTION
## Summary

- After each agent stage, breadcrumb files are collected from the worktree to `{state_dir}/breadcrumbs/{run_id}/`
- Pipeline reads breadcrumbs from state_dir when injecting context into prompts
- Prompts no longer tell agents to read `.plan_breadcrumb.md` or `.review_breadcrumb.md` — context is injected by the pipeline via the "Context from previous stage" mechanism
- Named breadcrumbs are still written to the worktree by agents (the prompts tell them to), but collected to state_dir afterward and protected by `.gitignore`

Closes #552

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --all-targets -- -D warnings`
- [x] `cargo test -p forza-core --lib` (137 passed)
- [x] `cargo test -p forza --lib` (134 passed)
- [x] `cargo test -p forza-core --test pipeline_integration` (12 passed)