### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "forza"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "forza-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/forza", "crates/forza-core", "crates/forza-test-fixture"]
 resolver = "3"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.90.0"
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["process", "fs"] }
 tempfile = "3"
 # forza
 
-forza-core = { path = "crates/forza-core", version = "0.6.0" }
+forza-core = { path = "crates/forza-core", version = "0.7.0" }
 
 tower-mcp = { version = "0.9", features = ["http"] }
 schemars = "1"

--- a/crates/forza-core/CHANGELOG.md
+++ b/crates/forza-core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.6.0...forza-core-v0.7.0) - 2026-04-01
+
+### Added
+
+- *(config)* per-route agent override closes #520 ([#567](https://github.com/joshrotenberg/forza/pull/567))
+
+### Fixed
+
+- *(pipeline)* persist run record at startup and after each stage ([#565](https://github.com/joshrotenberg/forza/pull/565))
+
 ## [0.6.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.5.2...forza-core-v0.6.0) - 2026-03-30
 
 ### Added

--- a/crates/forza/CHANGELOG.md
+++ b/crates/forza/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/joshrotenberg/forza/compare/forza-v0.6.0...forza-v0.7.0) - 2026-04-01
+
+### Added
+
+- *(config)* per-route agent override closes #520 ([#567](https://github.com/joshrotenberg/forza/pull/567))
+- *(mcp)* async execution and agent override for issue_run/pr_run ([#563](https://github.com/joshrotenberg/forza/pull/563))
+- *(api)* auto-start rest api during long-running operations ([#561](https://github.com/joshrotenberg/forza/pull/561))
+
+### Fixed
+
+- *(plan)* detect merged PRs correctly in plan --exec polling ([#559](https://github.com/joshrotenberg/forza/pull/559))
+
+### Other
+
+- remove git hash from version string ([#557](https://github.com/joshrotenberg/forza/pull/557))
+
 ## [0.6.0](https://github.com/joshrotenberg/forza/compare/forza-v0.5.2...forza-v0.6.0) - 2026-03-30
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `forza-core`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `forza`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)

### ⚠ `forza-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Route.agent in /tmp/.tmpHQFeiZ/forza/crates/forza-core/src/route.rs:89
  field Route.agent in /tmp/.tmpHQFeiZ/forza/crates/forza-core/src/route.rs:89
```

### ⚠ `forza` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Route.agent in /tmp/.tmpHQFeiZ/forza/crates/forza/src/config.rs:476

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  forza::adapters::resolve_agent_name now takes 4 parameters instead of 3, in /tmp/.tmpHQFeiZ/forza/crates/forza/src/adapters.rs:357
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `forza-core`

<blockquote>

## [0.7.0](https://github.com/joshrotenberg/forza/compare/forza-core-v0.6.0...forza-core-v0.7.0) - 2026-04-01

### Added

- *(config)* per-route agent override closes #520 ([#567](https://github.com/joshrotenberg/forza/pull/567))

### Fixed

- *(pipeline)* persist run record at startup and after each stage ([#565](https://github.com/joshrotenberg/forza/pull/565))
</blockquote>

## `forza`

<blockquote>

## [0.7.0](https://github.com/joshrotenberg/forza/compare/forza-v0.6.0...forza-v0.7.0) - 2026-04-01

### Added

- *(config)* per-route agent override closes #520 ([#567](https://github.com/joshrotenberg/forza/pull/567))
- *(mcp)* async execution and agent override for issue_run/pr_run ([#563](https://github.com/joshrotenberg/forza/pull/563))
- *(api)* auto-start rest api during long-running operations ([#561](https://github.com/joshrotenberg/forza/pull/561))

### Fixed

- *(plan)* detect merged PRs correctly in plan --exec polling ([#559](https://github.com/joshrotenberg/forza/pull/559))

### Other

- remove git hash from version string ([#557](https://github.com/joshrotenberg/forza/pull/557))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).