### PR TITLE
fix(plan): detect merged PRs correctly in plan --exec polling

### DIFF
--- a/crates/forza/src/github/octocrab_client.rs
+++ b/crates/forza/src/github/octocrab_client.rs
@@ -318,15 +318,18 @@ impl GitHubClient for OctocrabClient {
                 .into_iter()
                 .map(|l| l.name)
                 .collect(),
-            state: pr
-                .state
-                .map(|s| match s {
-                    octocrab::models::IssueState::Open => "open",
-                    octocrab::models::IssueState::Closed => "closed",
-                    _ => "unknown",
-                })
-                .unwrap_or("open")
-                .to_string(),
+            state: if pr.merged_at.is_some() {
+                "merged".to_string()
+            } else {
+                pr.state
+                    .map(|s| match s {
+                        octocrab::models::IssueState::Open => "open",
+                        octocrab::models::IssueState::Closed => "closed",
+                        _ => "unknown",
+                    })
+                    .unwrap_or("open")
+                    .to_string()
+            },
             html_url: pr.html_url.map(|u| u.to_string()).unwrap_or_default(),
             head_branch: pr.head.ref_field,
             base_branch: pr.base.ref_field,

--- a/crates/forza/src/main.rs
+++ b/crates/forza/src/main.rs
@@ -1164,10 +1164,10 @@ async fn wait_for_pr_merge(
     // Check current state first.
     match gh.fetch_pr(repo, pr_number).await {
         Ok(pr) => {
-            if pr.state == "MERGED" {
+            if pr.state == "merged" {
                 return MergeWaitResult::Merged;
             }
-            if pr.state == "CLOSED" {
+            if pr.state == "closed" {
                 return MergeWaitResult::Failed;
             }
         }
@@ -1189,10 +1189,10 @@ async fn wait_for_pr_merge(
 
         match gh.fetch_pr(repo, pr_number).await {
             Ok(pr) => {
-                if pr.state == "MERGED" {
+                if pr.state == "merged" {
                     return MergeWaitResult::Merged;
                 }
-                if pr.state == "CLOSED" {
+                if pr.state == "closed" {
                     return MergeWaitResult::Failed;
                 }
             }


### PR DESCRIPTION
## Summary

- Octocrab returns `IssueState::Closed` for merged PRs (no `Merged` variant)
- The `wait_for_pr_merge` poll loop compared against `"MERGED"` (uppercase) which never matched
- `plan --exec` would hang polling for up to an hour then time out
- Fix: check `pr.merged_at` to distinguish merged from closed, use lowercase state strings

## Test plan

- [x] `cargo clippy --all --all-targets -- -D warnings`
- [x] `cargo test -p forza --lib` (134 passed)
- Reproduced: `plan --exec 49` on redis-server-wrapper hung after PR #53 was merged