### PR TITLE
fix(pipeline): persist run record at startup and after each stage

### DIFF
--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -96,6 +96,11 @@ pub async fn execute(
         &work.subject.branch,
     );
 
+    // 0. Persist initial "running" record so async polling can find it.
+    if let Err(e) = save_run(&run, state_dir) {
+        warn!(error = %e, "failed to save initial run record (non-fatal)");
+    }
+
     // 1. Acquire lease.
     lifecycle::acquire(&work.subject, &config.labels, gh).await;
 
@@ -339,6 +344,9 @@ pub async fn execute(
             StageStatus::Failed
         };
         run.record_stage(stage.kind, stage_status, result);
+
+        // Persist after each stage so async polling sees progress.
+        let _ = save_run(&run, state_dir);
 
         // Post-hooks (only on success).
         if success


### PR DESCRIPTION
## Summary

- Write run record to state_dir immediately when pipeline starts (status "running", no stages yet)
- Update after each stage completes so polling sees incremental progress
- Enables async MCP polling (#563) to work — previously `status_find_issue` returned "no run found" until the entire pipeline finished

Closes #564

## Test plan

- [x] `cargo clippy --all --all-targets -- -D warnings`
- [x] `cargo test -p forza-core --lib` (137 passed)