### PR TITLE
feat(config): per-route agent override

### DIFF
--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -1066,6 +1066,7 @@ mod tests {
                 skills: None,
                 mcp_config: None,
                 validation_commands: None,
+                agent: None,
             },
             workflow_name: "bug".into(),
         }

--- a/crates/forza-core/src/route.rs
+++ b/crates/forza-core/src/route.rs
@@ -84,6 +84,9 @@ pub struct Route {
     /// Override validation commands for this route.
     #[serde(default)]
     pub validation_commands: Option<Vec<String>>,
+    /// Override agent for this route (e.g. `"codex"` or `"claude"`).
+    #[serde(default)]
+    pub agent: Option<String>,
 }
 
 fn default_concurrency() -> usize {
@@ -227,6 +230,7 @@ mod tests {
             skills: None,
             mcp_config: None,
             validation_commands: None,
+            agent: None,
         }
     }
 
@@ -243,6 +247,7 @@ mod tests {
             skills: None,
             mcp_config: None,
             validation_commands: None,
+            agent: None,
         }
     }
 

--- a/crates/forza-core/tests/pipeline_integration.rs
+++ b/crates/forza-core/tests/pipeline_integration.rs
@@ -41,6 +41,7 @@ fn bug_route() -> Route {
         skills: None,
         mcp_config: None,
         validation_commands: None,
+        agent: None,
     }
 }
 
@@ -466,6 +467,7 @@ fn ci_failing_route() -> Route {
         skills: None,
         mcp_config: None,
         validation_commands: None,
+        agent: None,
     }
 }
 
@@ -544,6 +546,7 @@ async fn pipeline_condition_route_has_conflicts_pr_runs_rebase() {
         skills: None,
         mcp_config: None,
         validation_commands: None,
+        agent: None,
     };
 
     let workflow =

--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -351,12 +351,13 @@ pub fn infer_agent_from_model(model: &str) -> Option<&'static str> {
     }
 }
 
-/// Resolve the agent name from explicit `--agent`, `--model`, and config default.
+/// Resolve the agent name from explicit `--agent`, `--model`, route config, and global default.
 ///
-/// Priority: explicit `--agent` > inferred from `--model` > config default.
+/// Priority: explicit `--agent` > inferred from `--model` > route agent > global default.
 pub fn resolve_agent_name<'a>(
     agent_override: Option<&'a str>,
     model_override: Option<&'a str>,
+    route_agent: Option<&'a str>,
     config_default: &'a str,
 ) -> &'a str {
     if let Some(agent) = agent_override {
@@ -367,6 +368,9 @@ pub fn resolve_agent_name<'a>(
     {
         tracing::info!(model, agent = inferred, "inferred agent from model");
         return inferred;
+    }
+    if let Some(agent) = route_agent {
+        return agent;
     }
     config_default
 }

--- a/crates/forza/src/config.rs
+++ b/crates/forza/src/config.rs
@@ -471,6 +471,9 @@ pub struct Route {
 
     /// Override branch_pattern for this route.
     pub branch_pattern: Option<String>,
+
+    /// Override agent for this route (e.g. `"codex"` or `"claude"`).
+    pub agent: Option<String>,
 }
 
 impl Route {
@@ -1512,6 +1515,7 @@ workflow = "bug"
                 max_retries: None,
                 draft_pr: None,
                 branch_pattern: None,
+                agent: None,
             },
         );
 
@@ -1668,6 +1672,7 @@ repo = "owner/repo"
             max_retries: None,
             draft_pr: None,
             branch_pattern: None,
+            agent: None,
         };
         assert!(route.validate("test").is_err()); // no trigger
 

--- a/crates/forza/src/runner.rs
+++ b/crates/forza/src/runner.rs
@@ -315,7 +315,6 @@ pub async fn process_batch(
     // Schedule and execute.
     let gh_adapter = Arc::new(GitHubAdapter::new(gh.clone()));
     let git_adapter = Arc::new(GitAdapter::new(git.clone()));
-    let agent = create_agent(config);
 
     let max_concurrency = config.global.max_concurrency;
     let mut total_active = 0usize;
@@ -342,7 +341,14 @@ pub async fn process_batch(
             let repo_dir_owned = repo_dir.to_path_buf();
             let gh_adapter_clone = gh_adapter.clone();
             let git_adapter_clone = git_adapter.clone();
-            let agent_clone = agent.clone();
+            // Use per-route agent override when set, otherwise fall back to global.
+            let agent_name = work
+                .route
+                .agent
+                .as_deref()
+                .unwrap_or(&config.global.agent)
+                .to_string();
+            let agent_clone = adapters::create_agent(&agent_name);
 
             join_set.spawn(async move {
                 execute_work(
@@ -416,7 +422,6 @@ async fn execute_work(
 
     // Build pipeline config from global + route overrides.
     let mut pipeline_config = build_pipeline_config(config, &work);
-    pipeline_config.agent = config.global.agent.clone();
     let tools_dir = repo_dir.join("tools");
     if tools_dir.exists() {
         pipeline_config.tools_dir = Some(tools_dir);
@@ -432,7 +437,7 @@ async fn execute_work(
         "pending", // run_id isn't known yet; breadcrumb paths use the actual run_id from pipeline
         &pipeline_config.validation,
         &preamble,
-        config.global.agent.as_str(),
+        pipeline_config.agent.as_str(),
         prompts_dir_opt,
         &work.route_name,
         &work.workflow_name,
@@ -555,6 +560,13 @@ fn build_pipeline_config(config: &RunnerConfig, work: &MatchedWork) -> PipelineC
         );
     }
 
+    // Resolve agent: route > global.
+    let agent = work
+        .route
+        .agent
+        .clone()
+        .unwrap_or_else(|| config.global.agent.clone());
+
     PipelineConfig {
         labels,
         model,
@@ -565,7 +577,7 @@ fn build_pipeline_config(config: &RunnerConfig, work: &MatchedWork) -> PipelineC
         append_system_prompt,
         stage_hooks,
         tools_dir: None,
-        agent: String::new(),
+        agent,
     }
 }
 
@@ -599,6 +611,7 @@ fn to_core_route(route: &Route) -> forza_core::Route {
         skills: route.skills.clone(),
         mcp_config: route.mcp_config.clone(),
         validation_commands: route.validation_commands.clone(),
+        agent: route.agent.clone(),
     }
 }
 
@@ -630,11 +643,6 @@ fn to_core_stage_kind(kind: crate::workflow::StageKind) -> forza_core::StageKind
         crate::workflow::StageKind::Research => forza_core::StageKind::Research,
         crate::workflow::StageKind::Comment => forza_core::StageKind::Comment,
     }
-}
-
-/// Delegate to the shared agent factory in `adapters`.
-fn create_agent(config: &RunnerConfig) -> Arc<dyn forza_core::AgentExecutor> {
-    adapters::create_agent(&config.global.agent)
 }
 
 /// The pattern supports four placeholders:
@@ -777,6 +785,7 @@ pub async fn process_issue(
                 },
                 mcp_config: None,
                 validation_commands: None,
+                agent: None,
             },
             workflow_name: wf_name,
         }
@@ -815,6 +824,7 @@ pub async fn process_issue(
     let agent_name = adapters::resolve_agent_name(
         agent_override.as_deref(),
         model_override.as_deref(),
+        matched.route.agent.as_deref(),
         &config.global.agent,
     )
     .to_string();
@@ -897,6 +907,7 @@ pub async fn process_pr(
                 },
                 mcp_config: None,
                 validation_commands: None,
+                agent: None,
             },
             workflow_name: wf_name,
         }
@@ -930,6 +941,7 @@ pub async fn process_pr(
     let agent_name = adapters::resolve_agent_name(
         agent_override.as_deref(),
         model_override.as_deref(),
+        matched.route.agent.as_deref(),
         &config.global.agent,
     )
     .to_string();


### PR DESCRIPTION
## Summary
- Adds `agent: Option<String>` to both `forza_core::Route` and `forza::config::Route`, enabling per-route agent selection (e.g. `agent = "codex"`) that overrides the global default
- Priority order for agent resolution: CLI `--agent` > inferred from `--model` > route agent > global
- Keeps `process_batch` path fully consistent — both executor and `pipeline_config.agent` resolved via route > global

## Files changed
- `crates/forza-core/src/route.rs` — added `agent: Option<String>` field to core `Route`
- `crates/forza/src/config.rs` — added `agent: Option<String>` field to config `Route`; `to_core_route` copies the field
- `crates/forza/src/adapters.rs` — `resolve_agent_name` gains `route_agent` parameter for the new priority slot
- `crates/forza/src/runner.rs` — `process_issue`/`process_pr`/`process_batch` resolve agent using route > global fallback
- `crates/forza-core/tests/pipeline_integration.rs` — mechanical fixture updates (`agent: None`)

## Test plan
- [ ] `cargo test --all` passes
- [ ] Config with `agent = "codex"` on a route selects codex executor for that route while other routes use global default
- [ ] CLI `--agent` still overrides route-level agent
- [ ] Routes without `agent` field continue to use global agent

Closes #520