### PR TITLE
feat(pipeline): auto-commit after agent stages

### DIFF
--- a/crates/forza-core/src/pipeline.rs
+++ b/crates/forza-core/src/pipeline.rs
@@ -326,7 +326,7 @@ pub async fn execute(
         // Auto-commit: if an agent stage left uncommitted changes, commit them.
         // Some agents (e.g. Codex) may not commit even when told to.
         if success && matches!(stage.execution, Execution::Agent) {
-            auto_commit_if_needed(work_dir, &work.subject).await;
+            auto_commit_if_needed(work_dir, stage_name, git).await;
         }
 
         info!(
@@ -726,17 +726,13 @@ async fn ensure_forza_gitignore(work_dir: &Path) {
 /// Some agents (notably Codex) make code changes but don't run `git commit`,
 /// even when instructed. This catches that case so downstream stages
 /// (validation, draft_pr) see the actual changes.
-async fn auto_commit_if_needed(work_dir: &Path, subject: &Subject) {
-    // Check for any uncommitted changes (staged or unstaged, including untracked).
-    let status = tokio::process::Command::new("git")
-        .args(["status", "--porcelain"])
-        .current_dir(work_dir)
-        .output()
-        .await;
-
-    let has_changes = match &status {
-        Ok(output) => output.status.success() && !output.stdout.is_empty(),
-        Err(_) => false,
+async fn auto_commit_if_needed(work_dir: &Path, stage_name: &str, git: &dyn GitClient) {
+    let has_changes = match git.has_changes(work_dir).await {
+        Ok(dirty) => dirty,
+        Err(e) => {
+            warn!("auto-commit: failed to check for changes: {e}");
+            return;
+        }
     };
 
     if !has_changes {
@@ -744,39 +740,19 @@ async fn auto_commit_if_needed(work_dir: &Path, subject: &Subject) {
     }
 
     info!(
-        number = subject.number,
+        stage = stage_name,
         "agent left uncommitted changes, auto-committing"
     );
 
-    // Stage everything.
-    let add = tokio::process::Command::new("git")
-        .args(["add", "-A"])
-        .current_dir(work_dir)
-        .output()
-        .await;
-    if add.is_err() || !add.unwrap().status.success() {
-        warn!(number = subject.number, "auto-commit: git add failed");
+    if let Err(e) = git.stage_all(work_dir).await {
+        warn!(stage = stage_name, "auto-commit: git add failed: {e}");
         return;
     }
 
-    // Commit.
-    let msg = format!(
-        "feat: {} closes #{}",
-        subject.title.to_lowercase(),
-        subject.number
-    );
-    let commit = tokio::process::Command::new("git")
-        .args(["commit", "-m", &msg])
-        .current_dir(work_dir)
-        .output()
-        .await;
-    match commit {
-        Ok(output) if output.status.success() => {
-            info!(number = subject.number, "auto-commit succeeded");
-        }
-        _ => {
-            warn!(number = subject.number, "auto-commit: git commit failed");
-        }
+    let msg = format!("forza: {stage_name}");
+    match git.commit(work_dir, &msg).await {
+        Ok(()) => info!(stage = stage_name, "auto-commit succeeded"),
+        Err(e) => warn!(stage = stage_name, "auto-commit: git commit failed: {e}"),
     }
 }
 
@@ -1013,6 +989,15 @@ mod tests {
         }
         async fn list_worktrees(&self, _repo_dir: &std::path::Path) -> Result<Vec<String>> {
             Ok(vec![])
+        }
+        async fn has_changes(&self, _work_dir: &std::path::Path) -> Result<bool> {
+            Ok(false)
+        }
+        async fn stage_all(&self, _work_dir: &std::path::Path) -> Result<()> {
+            Ok(())
+        }
+        async fn commit(&self, _work_dir: &std::path::Path, _message: &str) -> Result<()> {
+            Ok(())
         }
     }
 

--- a/crates/forza-core/src/testing.rs
+++ b/crates/forza-core/src/testing.rs
@@ -128,6 +128,7 @@ pub enum MockCall {
     AgentExecute(String),   // prompt (truncated)
     CreateWorktree(String), // branch
     RemoveWorktree,
+    GitCommit(String), // message
 }
 
 // ── MockGitHub ──────────────────────────────────────────────────────────
@@ -369,6 +370,7 @@ impl crate::traits::GitHubClient for MockGitHub {
 pub struct MockGit {
     pub calls: Arc<Mutex<Vec<MockCall>>>,
     fail_worktree: bool,
+    dirty: bool,
 }
 
 impl MockGit {
@@ -376,6 +378,7 @@ impl MockGit {
         Self {
             calls: Arc::new(Mutex::new(Vec::new())),
             fail_worktree: false,
+            dirty: false,
         }
     }
 
@@ -383,6 +386,21 @@ impl MockGit {
     pub fn fail_worktree(mut self) -> Self {
         self.fail_worktree = true;
         self
+    }
+
+    /// Make `has_changes` return true (simulates a dirty working tree).
+    pub fn with_dirty(mut self) -> Self {
+        self.dirty = true;
+        self
+    }
+
+    /// Check if a commit was recorded with the given message.
+    pub fn commit_was_made(&self, message: &str) -> bool {
+        self.calls
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|c| matches!(c, MockCall::GitCommit(m) if m == message))
     }
 
     fn record(&self, call: MockCall) {
@@ -441,6 +459,19 @@ impl crate::traits::GitClient for MockGit {
 
     async fn list_worktrees(&self, _repo_dir: &Path) -> Result<Vec<String>> {
         Ok(vec![])
+    }
+
+    async fn has_changes(&self, _work_dir: &Path) -> Result<bool> {
+        Ok(self.dirty)
+    }
+
+    async fn stage_all(&self, _work_dir: &Path) -> Result<()> {
+        Ok(())
+    }
+
+    async fn commit(&self, _work_dir: &Path, message: &str) -> Result<()> {
+        self.record(MockCall::GitCommit(message.to_string()));
+        Ok(())
     }
 }
 

--- a/crates/forza-core/src/traits.rs
+++ b/crates/forza-core/src/traits.rs
@@ -130,6 +130,15 @@ pub trait GitClient: Send + Sync {
 
     /// List existing worktrees.
     async fn list_worktrees(&self, repo_dir: &Path) -> Result<Vec<String>>;
+
+    /// Check whether the working tree has uncommitted changes (staged, unstaged, or untracked).
+    async fn has_changes(&self, work_dir: &Path) -> Result<bool>;
+
+    /// Stage all changes (equivalent to `git add -A`).
+    async fn stage_all(&self, work_dir: &Path) -> Result<()>;
+
+    /// Create a commit with the given message.
+    async fn commit(&self, work_dir: &Path, message: &str) -> Result<()>;
 }
 
 /// Abstraction over agent execution (Claude, or any future LLM).

--- a/crates/forza/src/adapters.rs
+++ b/crates/forza/src/adapters.rs
@@ -325,6 +325,27 @@ impl forza_core::GitClient for GitAdapter {
         // Not directly available in old API. Return empty for now.
         Ok(vec![])
     }
+
+    async fn has_changes(&self, work_dir: &Path) -> CoreResult<bool> {
+        self.inner
+            .has_changes(work_dir)
+            .await
+            .map_err(|e| CoreError::Git(e.to_string()))
+    }
+
+    async fn stage_all(&self, work_dir: &Path) -> CoreResult<()> {
+        self.inner
+            .stage_path(work_dir, ".")
+            .await
+            .map_err(|e| CoreError::Git(e.to_string()))
+    }
+
+    async fn commit(&self, work_dir: &Path, message: &str) -> CoreResult<()> {
+        self.inner
+            .commit(work_dir, message)
+            .await
+            .map_err(|e| CoreError::Git(e.to_string()))
+    }
 }
 
 // ── Agent factory ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `has_changes`, `stage_all`, and `commit` methods to the `GitClient` trait so the pipeline can auto-commit uncommitted changes left by agent stages
- Pipeline calls these after each agent stage, using `forza: {stage_name}` as the commit message
- `MockGit` gains `with_dirty()` and `commit_was_made()` helpers for testing auto-commit behavior
- `GitAdapter` delegates to the inner `forza::git::GitClient` for all three new methods

## Files changed
- `crates/forza-core/src/pipeline.rs` — add auto-commit logic after each agent stage execution
- `crates/forza-core/src/testing.rs` — add `with_dirty()` and `commit_was_made()` to `MockGit`
- `crates/forza-core/src/traits.rs` — extend `GitClient` trait with `has_changes`, `stage_all`, `commit`
- `crates/forza/src/adapters.rs` — implement new `GitClient` methods on `GitAdapter`

## Test plan
- [ ] `cargo test --all` passes
- [ ] `cargo test -p forza-core --test pipeline_integration` covers auto-commit path
- [ ] `MockGit::commit_was_made()` used in tests to assert commit occurred after agent stage
- [ ] No auto-commit when agent stage leaves no changes

Closes #568